### PR TITLE
20/distinguish between spent and unspent matched inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,31 @@
+### [2.0.0] - UNRELEASED
+
+#### Added
+
+- [📌 #17](https://github.com/CardanoSolutions/kupo/issues/20) - New command-line flag: `--prune-utxo`. When set, inputs that are spent on-chain will be removed from the index. Once-synced, 
+  the index therefore only contain the current ledger UTxO set. When not set, spent inputs are kept in the index but are now marked accordingly to record if and when they've spent.
+
+  HTTP endpoints for `/matches` (& the like) can also now accept either optional query-flag `?spent` or `?unspent` to filter matches depending on whether they've been spent. 
+
+  Consequently, there's also a new (possibly `null`) field `spent_at` returned for each match result. When set, it indicates the slot in which the input was found being spent. 
+
+  - `GET v1/matches` → [🕮  API Reference](https://cardanosolutions.github.io/kupo/#operation/getAllMatches)
+  - `GET v1/matches/{pattern-fragment}` → [📖 API Reference](https://cardanosolutions.github.io/kupo/#operation/getMatches1Ary)
+  - `GET v1/matches/{pattern-fragment}/{pattern-fragment}` → [📖 API Reference](https://cardanosolutions.github.io/kupo/#operation/getMatches2Ary)
+
+#### Changed
+
+- [📌 #17](https://github.com/CardanoSolutions/kupo/issues/20) - The `slot_no` and `header_hash` fields are no longer accessible on top-level match result objects. Instead, they're now nested under a `created_at` field, analogous to how `spent_at` has been introduced. 
+
+#### Removed
+
+- N/A
+
 ### [1.0.1] - 2022-05-04
 
 #### Added
 
-- N/A
+N/A
 
 #### Changed
 

--- a/cabal.project
+++ b/cabal.project
@@ -186,6 +186,12 @@ source-repository-package
     server/modules/contra-tracers
     server/modules/fast-bech32
 
+source-repository-package
+  type: git
+  location: https://github.com/IreneKnapp/direct-sqlite
+  tag: ab62e1e0e85ca9b92a55265744821ccfb75b0633
+  --sha256: 1r8w5dybyg2d274xlzjdy1p0v4zarhvsi20j9c7370bmp588y6n6
+
 constraints:
     hedgehog >= 1.0
   , bimap >= 0.4.0
@@ -194,6 +200,7 @@ constraints:
   , network >= 3.1.1.0
   , relude == 0.7.0.0
   , graphviz >= 2999.20.1.0
+  , direct-sqlite >= 2.3.27
 
 allow-newer:
   monoidal-containers:aeson,

--- a/db/005.sql
+++ b/db/005.sql
@@ -1,0 +1,16 @@
+DROP TABLE inputs;
+
+CREATE TABLE IF NOT EXISTS inputs (
+  output_reference BLOB NOT NULL,
+  address TEXT NOT NULL,
+  value BLOB NOT NULL,
+  datum_hash BLOB,
+  header_hash BLOB NOT NULL,
+  slot_no INTEGER NOT NULL,
+  status TEXT NOT NULL,
+  PRIMARY KEY (output_reference)
+);
+
+CREATE INDEX IF NOT EXISTS inputsByAddressAndStatus  ON inputs(address, status);
+
+DELETE FROM checkpoints;

--- a/db/005.sql
+++ b/db/005.sql
@@ -5,12 +5,13 @@ CREATE TABLE IF NOT EXISTS inputs (
   address TEXT NOT NULL,
   value BLOB NOT NULL,
   datum_hash BLOB,
-  header_hash BLOB NOT NULL,
-  slot_no INTEGER NOT NULL,
-  status TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  spent_at INTEGER,
   PRIMARY KEY (output_reference)
 );
 
-CREATE INDEX IF NOT EXISTS inputsByAddressAndStatus  ON inputs(address, status);
+CREATE INDEX IF NOT EXISTS inputsByAddress ON inputs(address, spent_at);
 
 DELETE FROM checkpoints;
+
+CREATE INDEX IF NOT EXISTS checkpointsBySlotNo ON checkpoints(slot_no);

--- a/db/006.sql
+++ b/db/006.sql
@@ -1,0 +1,1 @@
+PRAGMA synchronous = normal;

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -335,6 +335,7 @@ components:
         - datum_hash
         - slot_no
         - header_hash
+        - status
       properties:
         transaction_id: { "$ref": "#/components/schemas/TransactionId" }
         output_index: { "$ref": "#/components/schemas/OutputIndex" }
@@ -343,6 +344,14 @@ components:
         datum_hash: { "$ref": "#/components/schemas/DatumHash" }
         slot_no: { "$ref": "#/components/schemas/SlotNo" }
         header_hash: { "$ref": "#/components/schemas/HeaderHash" }
+        status: { "$ref": "#/components/schemas/InputStatus" }
+
+    InputStatus:
+      type: string
+      description: Indicate the status of this particular input.
+      enum:
+        - spent
+        - unspent
 
     OutputIndex:
       type: integer
@@ -441,6 +450,22 @@ components:
           - { "$ref": "#/components/schemas/AddressParameter" }
           - { "$ref": "#/components/schemas/Credential" }
 
+    spent:
+      name: spent
+      in: query
+      required: false
+      allowEmptyValue: true
+      description: |
+        Query flag (i.e. `?spent`) to filter matches by status, to get only 'spent' matches.
+
+    unspent:
+      name: unspent
+      in: query
+      required: false
+      allowEmptyValue: true
+      description: |
+        Query flag (i.e. `?unspent`) filter matches by status, to get only 'unspent' matches.
+
 paths:
   /v1/matches:
     get:
@@ -450,6 +475,9 @@ paths:
       description: |
         Retrieve all matches from the database, in descending `slot_no` order. Results are streamed to the client for more efficiency.
         Note that this is generally a bad idea for indexes built off permissive patterns (e.g. `*`) for the server will yield a large response.
+      parameters:
+        - { "$ref": "#/components/parameters/spent" }
+        - { "$ref": "#/components/parameters/unspent" }
       responses:
         200:
           description: OK
@@ -469,6 +497,8 @@ paths:
         See [Pattern](#section/Pattern) for more information about constructing patterns.
       parameters:
         - { "$ref": "#/components/parameters/pattern-fragment" }
+        - { "$ref": "#/components/parameters/spent" }
+        - { "$ref": "#/components/parameters/unspent" }
       responses:
         200:
           description: OK

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -255,14 +255,7 @@ components:
           description: Some hint about what went wrong.
 
     Checkpoint:
-      type: object
-      additionalProperties: false
-      required:
-        - slot_no
-        - header_hash
-      properties:
-        slot_no: { "$ref": "#/components/schemas/SlotNo" }
-        header_hash: { "$ref": "#/components/schemas/HeaderHash" }
+      $ref: "#/components/schemas/Point"
 
     Credential:
       anyOf:
@@ -333,25 +326,19 @@ components:
         - address
         - value
         - datum_hash
-        - slot_no
-        - header_hash
-        - status
+        - created_at
+        - spent_at
       properties:
         transaction_id: { "$ref": "#/components/schemas/TransactionId" }
         output_index: { "$ref": "#/components/schemas/OutputIndex" }
         address: { "$ref": "#/components/schemas/Address" }
         value: { "$ref": "#/components/schemas/Value" }
         datum_hash: { "$ref": "#/components/schemas/DatumHash" }
-        slot_no: { "$ref": "#/components/schemas/SlotNo" }
-        header_hash: { "$ref": "#/components/schemas/HeaderHash" }
-        status: { "$ref": "#/components/schemas/InputStatus" }
-
-    InputStatus:
-      type: string
-      description: Indicate the status of this particular input.
-      enum:
-        - spent
-        - unspent
+        created_at: { "$ref": "#/components/schemas/Point" }
+        spent_at:
+          oneOf:
+            - { "$ref": "#/components/schemas/Point" }
+            - type: "null"
 
     OutputIndex:
       type: integer
@@ -366,6 +353,16 @@ components:
         - { "$ref": "#/components/schemas/Wildcard" }
         - { "$ref": "#/components/schemas/AddressParameter" }
         - { "$ref": "#/components/schemas/Credential" }
+
+    Point:
+      type: object
+      additionalProperties: false
+      required:
+        - slot_no
+        - header_hash
+      properties:
+        slot_no: { "$ref": "#/components/schemas/SlotNo" }
+        header_hash: { "$ref": "#/components/schemas/HeaderHash" }
 
     SlotNo: &slotNo
       type: integer

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -58,7 +58,7 @@ info:
       --in-memory
     ```
 
-    #### --in-memory / --workdir
+    #### --in-memory / --workdir \<dir>
 
     This will build an index from the beginning of the blockchain (i.e. `origin`) of all transaction outputs where that stake key has been involved in. The `--in-memory` option tells kupo to not persist the index on-disk but to build it fully
     in-memory. When building such a large index (from origin!), this is not recommended as it may cause the program memory usage to grow unbounded.
@@ -76,7 +76,7 @@ info:
 
     Perfect, now kupo will store all the information in a database on-disk at the location pointed by `--workdir`. Incidentally, this also allows kupo to resume its work from where it lefts it in case the server is interrupted. Neat!
 
-    #### --since
+    #### --since \<slot-no.header_hash>
 
     What if we only need to synchronize from a given point in time? For example, we may want to skip the entire Byron and Shelley eras because we know that this stake key may only have been used starting from the Allegra era onwards.
     Fortunately, we can use the `--since` to provide a different starting point!
@@ -100,12 +100,18 @@ info:
     | Last Mary Block    | 39916796 | e72579ff89dc9ed325b723a33624b596c08141c7bd573ecfff56a1f7229e4d09 |
     | Last Alonzo Block  | N/A      | N/A                                                              |
 
-    #### --match
+    #### --match \<pattern>
 
     Kupo can accept one or more matching patterns using the `--match` option. In case multiple patterns are provided, they'll ALL be used when looking for addresses. This allows for example to build an index for a list of payment keys known of a wallet. The syntax for patterns
     is explained in greater details in the [Pattern](#section/Pattern) section below.
 
-    #### --ogmios-host / --ogmios-port
+    #### --prune-utxo
+
+    Sometimes, it isn't necessary to keep old data around. Fear not, Kupo has got you covered! Using the `--prune-utxo` command-line flag, you can instrument Kupo to automatically remove inputs that are spent on-chain. This makes sure to keep only what's truly available on-chain and
+    has a positive effect on both the final size of the index and the synchronization time. If you don't set that flag, then all data are kept in the database and spent inputs are instead marked to know if and when they were spent. You can then using query-flag in the API to filter
+    results based on whether or not they've been spent.
+
+    #### --ogmios-host \<hostname> / --ogmios-port \<port-number>
 
     So far, we've connected Kupo to a local cardano-node, using a unix domain socket as a communication channel. However, Kupo can also connect through [Ogmios](https://github.com/CardanoSolutions/ogmios#readme); and this works for either a local or remote instance of Ogmios! To do so,
     simply swap the `--node-socket` and `--node-config` options for `--ogmios-host` and `--ogmios-port`. For instance:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -254,9 +254,6 @@ components:
           type: string
           description: Some hint about what went wrong.
 
-    Checkpoint:
-      $ref: "#/components/schemas/Point"
-
     Credential:
       anyOf:
         - title: Bech32
@@ -628,7 +625,7 @@ paths:
             "application/json;charset=utf-8":
               schema:
                 type: array
-                items: { "$ref": "#/components/schemas/Checkpoint" }
+                items: { "$ref": "#/components/schemas/Point" }
 
   /v1/health:
     get:

--- a/kupo.cabal
+++ b/kupo.cabal
@@ -23,6 +23,7 @@ extra-source-files:
     db/002.sql
     db/003.sql
     db/004.sql
+    db/005.sql
 data-files:
     docs/openapi.yaml
 

--- a/kupo.cabal
+++ b/kupo.cabal
@@ -24,6 +24,7 @@ extra-source-files:
     db/003.sql
     db/004.sql
     db/005.sql
+    db/006.sql
 data-files:
     docs/openapi.yaml
 

--- a/kupo.cabal
+++ b/kupo.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           kupo
-version:        1.0.1
+version:        2.0.0
 synopsis:       A daemon for building lookup indexes from entities of the Cardano blockchain
 description:    Please see the README on GitHub at <https://github.com/cardanosolutions/kupo/tree/master/README.md>
 category:       Web

--- a/kupo.cabal
+++ b/kupo.cabal
@@ -213,7 +213,7 @@ executable kupo
       base >=4.7 && <5
     , kupo
   if flag(production)
-    ghc-options: -O2 -Werror "-with-rtsopts=-T -N2"
+    ghc-options: -O2 -Werror "-with-rtsopts=-T -N2 -I0 -A16m"
   default-language: Haskell2010
 
 test-suite unit

--- a/kupo.cabal
+++ b/kupo.cabal
@@ -294,6 +294,7 @@ test-suite unit
     , relude
     , sqlite-simple
     , temporary
+    , text
     , wai
     , wai-extra
     , yaml

--- a/package.yaml
+++ b/package.yaml
@@ -130,6 +130,6 @@ executables:
       ghc-options:
       - -O2
       - -Werror
-      - '"-with-rtsopts=-T -N2"'
+      - '"-with-rtsopts=-T -N2 -I0 -A16m"'
     dependencies:
     - kupo

--- a/package.yaml
+++ b/package.yaml
@@ -1,7 +1,7 @@
 _config: !include ".hpack.config.yaml"
 
 name:                kupo
-version:             1.0.1
+version:             2.0.0
 stability:           experimental
 github:              "cardanosolutions/kupo"
 license:             MPL-2.0

--- a/package.yaml
+++ b/package.yaml
@@ -114,6 +114,7 @@ tests:
     - relude
     - sqlite-simple
     - temporary
+    - text
     - wai
     - wai-extra
     - yaml

--- a/resolver.yaml
+++ b/resolver.yaml
@@ -14,6 +14,7 @@ packages:
 - composition-prelude-3.0.0.2
 - constraints-extras-0.3.1.0
 - contra-tracers-1.0.0
+- direct-sqlite-2.3.27
 - dom-lt-0.2.3
 - fast-bech32-1.0.0
 - gray-code-0.3.1

--- a/src/Kupo.hs
+++ b/src/Kupo.hs
@@ -87,6 +87,7 @@ kupo tr@Tracers{tracerChainSync, tracerConfiguration, tracerHttp, tracerDatabase
             , serverPort
             , chainProducer
             , workDir
+            , inputManagement
             }
         } <- ask
 
@@ -136,6 +137,7 @@ kupo tr@Tracers{tracerChainSync, tracerConfiguration, tracerHttp, tracerDatabase
                 -- Block consumer fueling the database
                 ( consumer
                     tracerChainSync
+                    inputManagement
                     notifyTip
                     mailbox
                     patterns

--- a/src/Kupo/App.hs
+++ b/src/Kupo/App.hs
@@ -253,7 +253,6 @@ consumer
     :: forall m block.
         ( MonadSTM m
         , MonadLog m
-        , MonadFail m
         , Monad (DBTransaction m)
         , IsBlock block
         )
@@ -269,7 +268,6 @@ consumer tr inputManagement notifyTip mailbox patternsVar Database{..} = forever
     let (lastKnownTip, lastKnownBlk) = last blks
     let lastKnownPoint = getPoint lastKnownBlk
     let lastKnownSlot = getPointSlotNo lastKnownPoint
-    when (lastKnownSlot >= 58836325) $ fail "done" -- TODO: TMP
     let (spentInputs, newInputs) = foldMap (matchBlock resultToRow serialize' patterns . snd) blks
     logWith tr (ChainSyncRollForward lastKnownSlot (length newInputs))
     notifyTip lastKnownTip (Just lastKnownSlot)

--- a/src/Kupo/App/Http.hs
+++ b/src/Kupo/App/Http.hs
@@ -32,7 +32,7 @@ import Kupo.Control.MonadSTM
 import Kupo.Data.Cardano
     ( pointToJson )
 import Kupo.Data.Database
-    ( patternToQueryLike, patternToRow, pointFromRow, resultFromRow )
+    ( patternToRow, patternToSql, pointFromRow, resultFromRow, statusToSql )
 import Kupo.Data.Health
     ( ConnectionStatus (..), Health )
 import Kupo.Data.Pattern
@@ -54,6 +54,7 @@ import Network.Wai
     , Middleware
     , Response
     , pathInfo
+    , queryString
     , requestMethod
     , responseLBS
     , responseStatus
@@ -68,7 +69,9 @@ import qualified Data.Aeson as Json
 import qualified Data.Aeson.Encoding as Json
 import qualified Data.Binary.Builder as B
 import qualified Data.ByteString.Lazy as BL
+import qualified Data.Text as T
 import qualified Network.HTTP.Types.Status as Http
+import qualified Network.HTTP.Types.URI as Http
 import qualified Network.Wai.Handler.Warp as Warp
 
 --
@@ -136,7 +139,7 @@ app withDatabase patternsVar readHealth req send =
 
     routeMatches = \case
         ("GET", args) ->
-            withDatabase (send . handleGetMatches (patternFromQuery args))
+            withDatabase (send . handleGetMatches (patternFromQuery args) (queryString req))
         ("DELETE", args) ->
             withDatabase (send <=< handleDeleteMatches patternsVar (patternFromQuery args))
         (_, _) ->
@@ -175,17 +178,19 @@ handleGetCheckpoints Database{..} = do
 
 handleGetMatches
     :: Maybe Text
+    -> Http.Query
     -> Database IO
     -> Response
-handleGetMatches query Database{..} = do
-    case query >>= patternFromText of
-        Nothing ->
+handleGetMatches patternQuery filterQuery Database{..} = do
+    case (patternQuery >>= patternFromText, statusToSql filterQuery) of
+        (Nothing, _) ->
             handleInvalidPattern
-        Just p -> do
+        (_, Nothing) ->
+            handleInvalidFilterQuery
+        (Just p, Just q) -> do
+            let query = patternToSql p <> if T.null q then "" else (" AND " <> q)
             responseStreamJson resultToJson $ \yield done -> do
-                runTransaction $ foldInputs
-                    (patternToQueryLike p)
-                    (yield . resultFromRow)
+                runTransaction $ foldInputs query (yield . resultFromRow)
                 done
 
 handleDeleteMatches
@@ -258,6 +263,15 @@ handleInvalidPattern = do
                  \pattern, including wildcards ('*') or full addresses. Make \
                  \sure to double-check the documentation at: \
                  \<https://cardanosolutions.github.io/kupo>!"
+        }
+
+handleInvalidFilterQuery :: Response
+handleInvalidFilterQuery = do
+    responseJson status400 defaultHeaders $ HttpError
+        { hint = "Invalid filter query! Matches can be filtered by status using \
+                 \HTTP query flags. Provide either '?spent' or '?unspent' to \
+                 \filter accordingly. Anything else is an error. In case of \
+                 \doubts, check the documentation at: <https://cardanosolutions.github.io/kupo>!"
         }
 
 handleStillActivePattern :: Response

--- a/src/Kupo/App/Http.hs
+++ b/src/Kupo/App/Http.hs
@@ -201,7 +201,7 @@ handleDeleteMatches patternsVar query Database{..} = do
         Just p | p `overlaps` patterns -> do
             pure handleStillActivePattern
         Just p -> do
-            n <- runImmediateTransaction $ deleteInputs (patternToQueryLike p)
+            n <- runImmediateTransaction $ deleteInputsByAddress (patternToSql p)
             pure $ responseLBS status200 defaultHeaders $
                 B.toLazyByteString $ Json.fromEncoding $ Json.pairs $ mconcat
                     [ Json.pair "deleted" (Json.int n)

--- a/src/Kupo/Configuration.hs
+++ b/src/Kupo/Configuration.hs
@@ -13,6 +13,7 @@ module Kupo.Configuration
     -- * Configuration
       Configuration (..)
     , WorkDir (..)
+    , InputManagement (..)
     , ChainProducer (..)
 
     -- * NetworkParameters
@@ -64,6 +65,7 @@ data Configuration = Configuration
     , serverPort :: !Int
     , since :: !(Maybe (Point Block))
     , patterns :: ![Pattern]
+    , inputManagement :: !InputManagement
     } deriving (Generic, Eq, Show)
 
 data ChainProducer
@@ -80,6 +82,21 @@ data ChainProducer
 data WorkDir
     = Dir FilePath
     | InMemory
+    deriving (Generic, Eq, Show)
+
+-- | What to do with inputs that are spent. There are two options:
+--
+-- - 'Mark': keeps all spent inputs in the index, but marks them as spent or
+-- unspent. Clients may then query filtered results based on their status.
+--
+-- - 'Remove': which deletes any spent inputs from the index, keeping it
+-- concise.
+--
+-- There are use-cases for both behavior, hence why is is a user-configured
+-- behavior. The default should be the less destructive one, which is 'Mark'.
+data InputManagement
+    = MarkSpentInputs
+    | RemoveSpentInputs
     deriving (Generic, Eq, Show)
 
 data NetworkParameters = NetworkParameters

--- a/src/Kupo/Data/Cardano.hs
+++ b/src/Kupo/Data/Cardano.hs
@@ -38,12 +38,6 @@ module Kupo.Data.Cardano
     , mkOutputReference
     , withReferences
 
-      -- * InputStatus
-    , InputStatus (..)
-    , inputStatusToJson
-    , inputStatusToText
-    , unsafeInputStatusFromText
-
       -- * Output
     , Output
     , mkOutput
@@ -447,33 +441,6 @@ type Input =
 
 type Input' crypto =
     Ledger.TxIn crypto
-
--- InputStatus
---
-data InputStatus = Spent | Unspent
-    deriving (Show, Eq)
-
-inputStatusToJson
-    :: InputStatus
-    -> Json.Encoding
-inputStatusToJson =
-    Json.text . inputStatusToText
-
-inputStatusToText
-    :: InputStatus
-    -> Text
-inputStatusToText = \case
-    Spent -> "spent"
-    Unspent -> "unspent"
-
-unsafeInputStatusFromText
-    :: HasCallStack
-    => Text
-    -> InputStatus
-unsafeInputStatusFromText = \case
-    "spent" -> Spent
-    "unspent" -> Unspent
-    _ -> error "neither 'spent' or 'unspent'."
 
 -- OutputReference
 

--- a/src/Kupo/Data/Cardano.hs
+++ b/src/Kupo/Data/Cardano.hs
@@ -34,12 +34,15 @@ module Kupo.Data.Cardano
 
       -- * Input
     , Input
-    , InputStatus (..)
-    , inputStatusToText
-    , unsafeInputStatusFromText
     , OutputReference
     , mkOutputReference
     , withReferences
+
+      -- * InputStatus
+    , InputStatus (..)
+    , inputStatusToJson
+    , inputStatusToText
+    , unsafeInputStatusFromText
 
       -- * Output
     , Output
@@ -450,12 +453,23 @@ type Input' crypto =
 data InputStatus = Spent | Unspent
     deriving (Show, Eq)
 
-inputStatusToText :: InputStatus -> Text
+inputStatusToJson
+    :: InputStatus
+    -> Json.Encoding
+inputStatusToJson =
+    Json.text . inputStatusToText
+
+inputStatusToText
+    :: InputStatus
+    -> Text
 inputStatusToText = \case
     Spent -> "spent"
     Unspent -> "unspent"
 
-unsafeInputStatusFromText :: HasCallStack => Text -> InputStatus
+unsafeInputStatusFromText
+    :: HasCallStack
+    => Text
+    -> InputStatus
 unsafeInputStatusFromText = \case
     "spent" -> Spent
     "unspent" -> Unspent

--- a/src/Kupo/Data/Ogmios.hs
+++ b/src/Kupo/Data/Ogmios.hs
@@ -162,6 +162,7 @@ decodeRequestNextResponse json =
             , decodeAllegraBlock block
             , decodeMaryBlock block
             , decodeAlonzoBlock block
+            , decodeBabbageBlock block
             ]
 
     decodeRollBackward = Json.withObject "RequestNextResponse" $ \o -> do
@@ -226,6 +227,16 @@ decodeAlonzoBlock = Json.withObject "AlonzoBlock" $ \o -> do
     point <- decodeBlockPoint alonzo
     PartialBlock point <$> traverse decodePartialTransaction txs
 
+decodeBabbageBlock
+    :: Json.Value
+    -> Json.Parser PartialBlock
+decodeBabbageBlock = Json.withObject "babbageBlock" $ \o -> do
+    babbage <- o .: "babbage"
+    txs <- babbage .: "body"
+    point <- decodeBlockPoint babbage
+    PartialBlock point <$> traverse decodePartialTransaction txs
+
+
 decodeAddress
     :: Text
     -> Json.Parser Address
@@ -263,7 +274,7 @@ decodeOutput
 decodeOutput = Json.withObject "Output" $ \o -> do
     address <- o .: "address" >>= decodeAddress
     value <- o .: "value" >>= decodeValue
-    datumHash <- o .:? "datum" >>= traverse (fmap unsafeMakeSafeHash . decodeHash @Blake2b_256)
+    datumHash <- o .:? "datumHash" >>= traverse (fmap unsafeMakeSafeHash . decodeHash @Blake2b_256)
     pure (mkOutput address value datumHash)
 
 decodePartialTransaction

--- a/src/Kupo/Data/Pattern.hs
+++ b/src/Kupo/Data/Pattern.hs
@@ -57,6 +57,7 @@ import Kupo.Data.Cardano
     , getTransactionId
     , getValue
     , headerHashToJson
+    , inputStatusToJson
     , isBootstrap
     , outputIndexToJson
     , slotNoToJson
@@ -275,6 +276,8 @@ resultToJson Result{..} = Json.pairs $ mconcat
         (slotNoToJson (getPointSlotNo point))
     , Json.pair "header_hash"
         (headerHashToJson (unsafeGetPointHeaderHash point))
+    , Json.pair "status"
+        (inputStatusToJson status)
     ]
 
 -- | Match all outputs in transactions from a block that match any of the given

--- a/src/Kupo/Options.hs
+++ b/src/Kupo/Options.hs
@@ -29,7 +29,11 @@ import Data.Char
 import Kupo.App
     ( Tracers' (..) )
 import Kupo.Configuration
-    ( ChainProducer (..), Configuration (..), WorkDir (..) )
+    ( ChainProducer (..)
+    , Configuration (..)
+    , InputManagement (..)
+    , WorkDir (..)
+    )
 import Kupo.Control.MonadLog
     ( Severity (..), TracerDefinition (..), defaultTracers )
 import Kupo.Data.Cardano
@@ -76,6 +80,7 @@ parserInfo = info (helper <*> parser) $ mempty
                     <*> serverPortOption
                     <*> optional sinceOption
                     <*> many patternOption
+                    <*> inputManagementOption
                 )
             <*> (tracersOption <|> Tracers
                     <$> fmap Const (logLevelOption "http-server")
@@ -237,6 +242,15 @@ patternOption = option (maybeReader (patternFromText . toText)) $ mempty
     <> long "match"
     <> metavar "PATTERN"
     <> help "A pattern to match on. Can be provided multiple times (as a logical disjunction, i.e. 'or')"
+
+-- | [--prune-utxo]
+inputManagementOption :: Parser InputManagement
+inputManagementOption = flag MarkSpentInputs RemoveSpentInputs $ mempty
+    <> long "prune-utxo"
+    <> helpDoc (Just doc)
+  where
+    doc =
+        string "Remove inputs from the index when spent, instead of marking them as 'spent'."
 
 -- | [--log-level-{COMPONENT}=SEVERITY], default: Info
 logLevelOption :: Text -> Parser (Maybe Severity)

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -40,6 +40,13 @@ packages:
   original:
     hackage: contra-tracers-1.0.0
 - completed:
+    hackage: direct-sqlite-2.3.27@sha256:94207d3018da3bda84bc6ce00d2c0236ced7edb37afbd726ed2a0bfa236e149b,3771
+    pantry-tree:
+      size: 770
+      sha256: c7f5afe70db567e2cf9f3119b49f4b402705e6bd08ed8ba98747a64a8a0bef41
+  original:
+    hackage: direct-sqlite-2.3.27
+- completed:
     hackage: dom-lt-0.2.3@sha256:89f17bbeb0d23f5a46fe7099b81cc9b4b5df32aadb5080fc171c874aafc802c0,1850
     pantry-tree:
       size: 442

--- a/test/Test/Kupo/App/HttpSpec.hs
+++ b/test/Test/Kupo/App/HttpSpec.hs
@@ -219,6 +219,8 @@ databaseStub = Database
         \_ -> return ()
     , markInputsByReference =
         \_ _ -> return ()
+    , countSpentInputs = lift $ do
+        generate arbitrary
     , insertCheckpoints =
         \_ -> return ()
     , listCheckpointsDesc = \mk -> lift $ do

--- a/test/Test/Kupo/App/HttpSpec.hs
+++ b/test/Test/Kupo/App/HttpSpec.hs
@@ -199,7 +199,7 @@ databaseStub = Database
     , foldInputs = \_ callback -> lift $ do
         rows <- fmap resultToRow <$> generate (listOf1 genResult)
         mapM_ callback rows
-    , deleteInputs =
+    , deleteInputsByAddress =
         \_ -> liftIO (abs <$> generate arbitrary)
     , insertCheckpoint =
         \_ -> return ()

--- a/test/Test/Kupo/Data/DatabaseSpec.hs
+++ b/test/Test/Kupo/Data/DatabaseSpec.hs
@@ -133,7 +133,7 @@ shortLivedWorker dir lock = do
                 , (1, do
                     p <- genPattern
                     let q = patternToQueryLike p
-                    pure $ void $ runImmediateTransaction $ deleteInputs q
+                    pure $ void $ runImmediateTransaction $ deleteInputsByAddress q
                   )
                 , (1, do
                     p <- genPattern

--- a/test/Test/Kupo/Data/DatabaseSpec.hs
+++ b/test/Test/Kupo/Data/DatabaseSpec.hs
@@ -39,8 +39,8 @@ import Kupo.Data.Cardano
     ( Address, addressFromBytes, addressToBytes )
 import Kupo.Data.Database
     ( patternFromRow
-    , patternToQueryLike
     , patternToRow
+    , patternToSql
     , pointFromRow
     , pointToRow
     , resultFromRow
@@ -71,9 +71,9 @@ spec = parallel $ do
         prop "Pattern" $
             roundtripFromToRow genPattern patternToRow patternFromRow
 
-    context "patternToQueryLike" $ around withFixtureDatabase $ do
+    context "patternToSql" $ around withFixtureDatabase $ do
         forM_ patterns $ \(_, p, results) -> do
-            let like = patternToQueryLike p
+            let like = patternToSql p
             specify (toString like) $ \conn -> do
                 rows <- query_ conn $ "SELECT address, LENGTH(address) as len \
                                       \FROM addresses \
@@ -127,12 +127,12 @@ shortLivedWorker dir lock = do
                   )
                 , (2, do
                     p <- genPattern
-                    let q = patternToQueryLike p
+                    let q = patternToSql p
                     pure $ runTransaction $ foldInputs q (\_ -> pure ())
                   )
                 , (1, do
                     p <- genPattern
-                    let q = patternToQueryLike p
+                    let q = patternToSql p
                     pure $ void $ runImmediateTransaction $ deleteInputsByAddress q
                   )
                 , (1, do

--- a/test/Test/Kupo/Data/Generators.hs
+++ b/test/Test/Kupo/Data/Generators.hs
@@ -112,6 +112,7 @@ genResult = Result
     <*> genValue
     <*> frequency [(1, pure Nothing), (5, Just <$> genDatumHash)]
     <*> genNonGenesisPoint
+    <*> frequency [(1, pure Nothing), (5, Just <$> genNonGenesisPoint)]
 
 genSlotNo :: Gen SlotNo
 genSlotNo = do

--- a/test/Test/Kupo/OptionsSpec.hs
+++ b/test/Test/Kupo/OptionsSpec.hs
@@ -17,7 +17,11 @@ import Data.List
 import Kupo.App
     ( Tracers' (..) )
 import Kupo.Configuration
-    ( ChainProducer (..), Configuration (..), WorkDir (..) )
+    ( ChainProducer (..)
+    , Configuration (..)
+    , InputManagement (..)
+    , WorkDir (..)
+    )
 import Kupo.Control.MonadLog
     ( Severity (..), TracerDefinition (..), defaultTracers )
 import Kupo.Data.Pattern
@@ -105,6 +109,11 @@ spec = parallel $ do
           )
         , ( defaultArgs ++ [ "--port", "#" ]
           , shouldFail
+          )
+        , ( defaultArgs ++ [ "--prune-utxo" ]
+          , shouldParseAppConfiguration $ defaultConfiguration
+            { inputManagement = RemoveSpentInputs
+            }
           )
         , ( defaultArgs ++ [ "--since", "51292637.2e7ee124eccbc648789008f8669695486f5727cada41b2d86d1c36355c76b771" ]
           , shouldParseAppConfiguration $ defaultConfiguration

--- a/test/Test/KupoSpec.hs
+++ b/test/Test/KupoSpec.hs
@@ -149,6 +149,16 @@ spec = skippableContext "End-to-end" $ \manager -> do
             shouldThrowTimeout @ConflictingOptionsException 1 (kupo tr `runWith` env)
           )
 
+        ( do -- Can't restart with different utxo management behavior
+            env <- newEnvironment $ cfg
+                { workDir = Dir tmp
+                , since = Just somePoint
+                , patterns = [MatchAny OnlyShelley]
+                , inputManagement = RemoveSpentInputs
+                }
+            shouldThrowTimeout @ConflictingOptionsException 1 (kupo tr `runWith` env)
+          )
+
     specify "Can't start the server on a fresh new db without explicit point" $ \(tmp, tr, cfg) -> do
         env <- newEnvironment $ cfg
             { workDir = Dir tmp


### PR DESCRIPTION
Fixes #20 

---

- :round_pushpin: **Add 'status' to inputs, tracking whether it's been spent.**
    This translate to multiple levels of the application. The database
  requires a new column, which I opted for a 'TEXT' (instead of a
  boolean or an int) to keep the database also somewhat human friendly.
  There's a little overhead in using 'TEXT' here but it makes debugging
  and inspecting the database a lot easier / less error-prone.

  The rest is mostly just glue to extract inputs from transactions of
  all eras. As usual, Byron is the weird kid.

- :round_pushpin: **Add option --prune-utxo to drive behavior regarding consumed inputs.**
    This comes as a flag. The default, when the flag isn't present is to
  keep everything and mark outputs as 'spent'. When set however,
  consumed inputs are discarded to keep the database tidy.

  The effect of pruning the database is double: it reduces its overall
  size (by about 5x on testnet for instance), but also makes the whole
  synchronization a bit faster since the database is less bloated.

  Why the flag also? Well, there are use-cases for both scenarios. Some
  users may be interested in keeping historical data around, while
  others are only interested about what's currently available on the
  chain. Thus, we need a user input for this.

- :round_pushpin: **Allow filtering by input's status on /matches HTTP endpoints**
    Doing this via a flag set as query parameter. Or more exactly, two
  flags. Arguably, this could also be a single parameter 'status = X/Y'
  but I somehow do not like the 'status' terminology as its too vague
  and generic. Thus, providing two mutually exclusive flags feels more
  right.

- :round_pushpin: **Rework migration logic to enable changing safety settings.**
    This is because I need / want to change the 'synchronous' setting to
  'normal' (which makes more sense in the case of WAL journal mode, as
  per: https://sqlite.org/pragma.html#pragma_synchronous.

  Yet, this can't be done inside a transaction apparently. So, I am
  introducing a proper sum-type for migrations to allow defining two
  distinct types. Of course, this works in combination with what is
  written in the external migration file.

- :round_pushpin: **Record point on chain when inputs are spent, instead of a mere label.**
    This completely redefine how we represent spent and unspent inputs in
  the database, as well as how we store checkpoints. This is also made
  in anticipation of another feature (lookup of checkpoint ancestors in
  the database).

  Now, the `inputs` table record slots (and only slots) at which some
  events happened and we're mainly only interested in two events:

  - When was is created
  - When was it spent

  Obviously, the second one can be null if the input has never been
  spent. And that's actually how we can distinguish unspent outputs from
  the rest.

  Now, in theory, we would have to record both slots and header hashes,
  in the two cases. It starts feeling like a lot of redundancy and
  wasted data in the db schema. So, this commits bundle another change
  which make sure that kupo records not only some points as checkpoints,
  but actually all checkpoints (as in, points on-chain that have a
  block). This allows to lookup header hashes for inputs based by doing
  a table union.

- :round_pushpin: **Slightly tweak RTS options.**
  
- :round_pushpin: **Bump direct-sqlite-2.3.27**
    This version includes a more recent version of sqlite, which is in
  particular > 3.33. This matters because 3.33 changes, among other
  things, the default SQLITE_MAX_VARIABLE_NUMBER well beyond 999.
  Without this, we need to make sure that queries uses less than 999
  variables and, given the simple approach we've taken for marking or
  pruning inputs AND, the batch processing of blocks happening in the
  consumer sub-process, this is necessary.

  Plus, it doesn't hurt to use a more recent version of Sqlite and
  benefits from improvements, fixes as well security and feature
  updates.

- :round_pushpin: **Repair and augment test-suite to cover --prune-utxo**
    As well as new query parameters in the HTTP API. Most tests were already indirectly testing that newly introduced features, but it's still worth adding a few more to cover scenarios that are specific to the new utxo management behavior.

- :round_pushpin: **Prevent conflicting scenarios with --prune-utxo**
    See note in the added log message / warning.

- :round_pushpin: **Bump version to 2.0.0 and prepare CHANGELOG skeleton**
    The API changes _could_ have been introduced in a backward compatible
  manner, but since Kupo is in its infancy and users aren't yet legion,
  it's still okay-ish to break the API slightly and not accumulate
  technical debts from the start. Plus, the change is relatively minor
  -- though still breaking. Plus, this will be the opportunity to also
  bundle in Babbage features and additions to make the indexer ready.