### PR TITLE
Lookup of previous on-chain points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 
 - [📌 #17](https://github.com/CardanoSolutions/kupo/issues/20) - The `slot_no` and `header_hash` fields are no longer accessible on top-level match result objects. Instead, they're now nested under a `created_at` field, analogous to how `spent_at` has been introduced. 
 
+- [📌 #24](https://github.com/CardanoSolutions/kupo/issues/24) - Fixed a bug where listing checkpoints may sometimes return duplicate entries. 
+
 #### Removed
 
 - N/A

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,20 @@
 
   Consequently, there's also a new (possibly `null`) field `spent_at` returned for each match result. When set, it indicates the slot in which the input was found being spent. 
 
-  - `GET v1/matches` → [🕮  API Reference](https://cardanosolutions.github.io/kupo/#operation/getAllMatches)
-  - `GET v1/matches/{pattern-fragment}` → [📖 API Reference](https://cardanosolutions.github.io/kupo/#operation/getMatches1Ary)
-  - `GET v1/matches/{pattern-fragment}/{pattern-fragment}` → [📖 API Reference](https://cardanosolutions.github.io/kupo/#operation/getMatches2Ary)
+  - `GET v1/matches[?(spent|unspent)]` → [🕮  API Reference](https://cardanosolutions.github.io/kupo/#operation/getAllMatches)
+  - `GET v1/matches/{pattern-fragment}[?(spent|unspent)]` → [📖 API Reference](https://cardanosolutions.github.io/kupo/#operation/getMatches1Ary)
+  - `GET v1/matches/{pattern-fragment}/{pattern-fragment}[?(spent|unspent)]` → [📖 API Reference](https://cardanosolutions.github.io/kupo/#operation/getMatches2Ary)
+
+[📌 #24](https://github.com/CardanoSolutions/kupo/issues/24) - New HTTP endpoint to retrieve a point on-chain from a given slot. The endpoint is flexible and allows for retrieving the ancestor 
+  of a known point very easily. This is handy in combination with other protocols that leverage on-chain points and intersections (like [Ogmios' chain-sync](https://ogmios.dev/mini-protocols/local-chain-sync/)). 
+
+  - `GET v1/checkpoints/{slot-no}[?strict]` → [🕮  API Reference](https://cardanosolutions.github.io/kupo/#operation/getCheckpointBySlot)
 
 #### Changed
 
 - [📌 #17](https://github.com/CardanoSolutions/kupo/issues/20) - The `slot_no` and `header_hash` fields are no longer accessible on top-level match result objects. Instead, they're now nested under a `created_at` field, analogous to how `spent_at` has been introduced. 
 
-- [📌 #24](https://github.com/CardanoSolutions/kupo/issues/24) - Fixed a bug where listing checkpoints may sometimes return duplicate entries. 
+- [📌 #24](https://github.com/CardanoSolutions/kupo/issues/24) - Fixed a bug where listing checkpoints would sometimes return duplicate entries. 
 
 #### Removed
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -450,13 +450,21 @@ components:
           - { "$ref": "#/components/schemas/AddressParameter" }
           - { "$ref": "#/components/schemas/Credential" }
 
+    slot-no:
+      name: slot-no
+      in: path
+      required: true
+      schema:
+        type: integer
+        minimum: 0
+
     spent:
       name: spent
       in: query
       required: false
       allowEmptyValue: true
       description: |
-        Query flag (i.e. `?spent`) to filter matches by status, to get only 'spent' matches.
+        A query flag (i.e. `?spent`) to filter matches by status, to get only 'spent' matches.
 
     unspent:
       name: unspent
@@ -464,7 +472,24 @@ components:
       required: false
       allowEmptyValue: true
       description: |
-        Query flag (i.e. `?unspent`) filter matches by status, to get only 'unspent' matches.
+        A query flag (i.e. `?unspent`) filter matches by status, to get only 'unspent' matches.
+
+    strict:
+      name: strict
+      in: query
+      required: false
+      allowEmptyValue: true
+      description: |
+        A query flag (i.e. `?strict`) to only look for checkpoints that strictly match the provided slot. The behavior otherwise is to look for the largest nearest slot smaller or equal to the one provided.
+
+tags:
+  - name: Matches
+  - name: Checkpoints
+    description: |
+      An API for inspecting checkpoints known of the database. A checkpoint really is a point on-chain that directly references a block. They are comprised of an absolute slot
+      number and a block header hash. Kupo records all such points as it processes blocks. In particular, they are also used to resume synchronization upon restart.
+  - name: Patterns
+  - name: Health
 
 paths:
   /v1/matches:
@@ -617,13 +642,13 @@ paths:
 
   /v1/checkpoints:
     get:
-      operationId: getCheckpoints
+      operationId: sampleCheckpoints
       tags: ["Checkpoints"]
-      summary: Get Checkpoints
+      summary: Sample Checkpoints
       description: |
-        Retrieve all checkpoints currently in the database, in descending `slot_no` order. This is useful to know where
-        the synchronization is at. On restart, the synchronization will continue from the most recent checkpoints that
-        is also known of the network.
+        Retrieve a **sample of** all checkpoints currently in the database, in descending `slot_no` order.
+        This is useful to know where the synchronization is at. On restart, the synchronization will continue from the most recent
+        checkpoints that is also valid on the network.
       responses:
         200:
           description: OK
@@ -632,6 +657,28 @@ paths:
               schema:
                 type: array
                 items: { "$ref": "#/components/schemas/Point" }
+
+  /v1/checkpoints/{slot-no}:
+    get:
+      operationId: getCheckpointBySlot
+      tags: ["Checkpoints"]
+      summary: Get Checkpoint By Slot
+      description: |
+        Retrieve a checkpoint by its (absolute) slot number. The query is flexible by default. Meaning that, if there's no checkpoint at the given slot, the server
+        will for for the closest (i.e. most recent) slot that is **before** the provided slot number. This is particularly useful to find ancestors to known slots
+        in order to use them for references on-chain.
+      parameters:
+        - { "$ref": "#/components/parameters/slot-no" }
+        - { "$ref": "#/components/parameters/strict" }
+      responses:
+        200:
+          description: OK
+          content:
+            "application/json;charset=utf-8":
+              schema:
+                oneOf:
+                  - { "$ref": "#/components/schemas/Point" }
+                  - type: "null"
 
   /v1/health:
     get:

--- a/kupo.cabal
+++ b/kupo.cabal
@@ -46,6 +46,7 @@ library
       Kupo.App.ChainSync.Ogmios
       Kupo.App.Health
       Kupo.App.Http
+      Kupo.App.Http.HealthCheck
       Kupo.App.Mailbox
       Kupo.Configuration
       Kupo.Control.MonadAsync
@@ -61,6 +62,11 @@ library
       Kupo.Data.ChainSync
       Kupo.Data.Database
       Kupo.Data.Health
+      Kupo.Data.Http.Default
+      Kupo.Data.Http.Error
+      Kupo.Data.Http.GetCheckpointMode
+      Kupo.Data.Http.Response
+      Kupo.Data.Http.Status
       Kupo.Data.Ogmios
       Kupo.Data.Pattern
       Kupo.Options

--- a/src/Kupo/App/Http.hs
+++ b/src/Kupo/App/Http.hs
@@ -2,7 +2,6 @@
 --  License, v. 2.0. If a copy of the MPL was not distributed with this
 --  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-{-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE RecordWildCards #-}
 
 module Kupo.App.Http
@@ -10,7 +9,7 @@ module Kupo.App.Http
       httpServer
     , app
 
-      -- * Client
+      -- * HealthCheck
     , healthCheck
 
       -- * Tracer
@@ -21,8 +20,8 @@ import Kupo.Prelude
 
 import Data.List
     ( nub, (\\) )
-import Kupo.Control.MonadCatch
-    ( handle )
+import Kupo.App.Http.HealthCheck
+    ( healthCheck )
 import Kupo.Control.MonadDatabase
     ( Database (..) )
 import Kupo.Control.MonadLog
@@ -34,21 +33,21 @@ import Kupo.Data.Cardano
 import Kupo.Data.Database
     ( patternToRow, patternToSql, pointFromRow, resultFromRow, statusToSql )
 import Kupo.Data.Health
-    ( ConnectionStatus (..), Health )
+    ( Health )
+import Kupo.Data.Http.Response
+    ( responseJson, responseStreamJson )
+import Kupo.Data.Http.Status
+    ( Status (..), mkStatus )
 import Kupo.Data.Pattern
     ( Pattern (..)
     , overlaps
+    , patternFromPath
     , patternFromText
     , patternToText
     , resultToJson
-    , wildcard
     )
-import Network.HTTP.Client
-    ( defaultManagerSettings, httpLbs, newManager, parseRequest, responseBody )
-import Network.HTTP.Types.Header
-    ( Header, hContentLength, hContentType )
 import Network.HTTP.Types.Status
-    ( status200, status400, status404, status406 )
+    ( status200 )
 import Network.Wai
     ( Application
     , Middleware
@@ -58,19 +57,14 @@ import Network.Wai
     , requestMethod
     , responseLBS
     , responseStatus
-    , responseStream
     )
-import Relude.Extra
-    ( lookup )
-import System.Exit
-    ( ExitCode (..) )
 
 import qualified Data.Aeson as Json
 import qualified Data.Aeson.Encoding as Json
 import qualified Data.Binary.Builder as B
-import qualified Data.ByteString.Lazy as BL
 import qualified Data.Text as T
-import qualified Network.HTTP.Types.Status as Http
+import qualified Kupo.Data.Http.Default as Default
+import qualified Kupo.Data.Http.Error as Errors
 import qualified Network.HTTP.Types.URI as Http
 import qualified Network.Wai.Handler.Warp as Warp
 
@@ -87,7 +81,9 @@ httpServer
     -> Int
     -> IO ()
 httpServer tr withDatabase patternsVar readHealth host port =
-    Warp.runSettings settings $ tracerMiddleware tr (app withDatabase patternsVar readHealth)
+    Warp.runSettings settings
+        $ tracerMiddleware tr
+        $ app withDatabase patternsVar readHealth
   where
     settings = Warp.defaultSettings
         & Warp.setPort port
@@ -119,53 +115,67 @@ app withDatabase patternsVar readHealth req send =
             routePatterns (requestMethod req, args)
 
         _ ->
-            send handleNotFound
+            send Errors.notFound
   where
     routeHealth = \case
         ("GET", []) ->
             send . handleGetHealth =<< readHealth
         ("GET", _) ->
-            send handleNotFound
+            send Errors.notFound
         (_, _) ->
-            send handleMethodNotAllowed
+            send Errors.methodNotAllowed
 
     routeCheckpoints = \case
         ("GET", []) ->
-            withDatabase (send . handleGetCheckpoints)
+            withDatabase (send .
+                handleGetCheckpoints
+            )
         ("GET", _) ->
-            send handleNotFound
+            send Errors.notFound
         (_, _) ->
-            send handleMethodNotAllowed
+            send Errors.methodNotAllowed
 
     routeMatches = \case
         ("GET", args) ->
-            withDatabase (send . handleGetMatches (patternFromQuery args) (queryString req))
+            withDatabase (send .
+                handleGetMatches (patternFromPath args) (queryString req)
+            )
         ("DELETE", args) ->
-            withDatabase (send <=< handleDeleteMatches patternsVar (patternFromQuery args))
+            withDatabase (send <=<
+                handleDeleteMatches patternsVar (patternFromPath args)
+            )
         (_, _) ->
-            send handleMethodNotAllowed
+            send Errors.methodNotAllowed
 
     routePatterns = \case
         ("GET", []) ->
             readTVarIO patternsVar >>= send . handleGetPatterns
         ("GET", _) ->
-            send handleNotFound
+            send Errors.notFound
         ("PUT", args) ->
-            withDatabase (send <=< handlePutPattern patternsVar (patternFromQuery args))
+            withDatabase (send <=<
+                handlePutPattern patternsVar (patternFromPath args)
+            )
         ("DELETE", args) ->
-            withDatabase (send <=< handleDeletePattern patternsVar (patternFromQuery args))
+            withDatabase (send <=<
+                handleDeletePattern patternsVar (patternFromPath args)
+            )
         (_, _) ->
-            send handleMethodNotAllowed
+            send Errors.methodNotAllowed
 
 --
--- Handlers
+-- /v1/health
 --
 
 handleGetHealth
     :: Health
     -> Response
 handleGetHealth =
-    responseJson status200 defaultHeaders
+    responseJson status200 Default.headers
+
+--
+-- /v1/checkpoints
+--
 
 handleGetCheckpoints
     :: Database IO
@@ -176,6 +186,10 @@ handleGetCheckpoints Database{..} = do
         mapM_ yield points
         done
 
+--
+-- /v1/matches
+--
+
 handleGetMatches
     :: Maybe Text
     -> Http.Query
@@ -184,9 +198,9 @@ handleGetMatches
 handleGetMatches patternQuery filterQuery Database{..} = do
     case (patternQuery >>= patternFromText, statusToSql filterQuery) of
         (Nothing, _) ->
-            handleInvalidPattern
+            Errors.invalidPattern
         (_, Nothing) ->
-            handleInvalidFilterQuery
+            Errors.invalidFilterQuery
         (Just p, Just q) -> do
             let query = patternToSql p <> if T.null q then "" else (" AND " <> q)
             responseStreamJson resultToJson $ \yield done -> do
@@ -202,15 +216,19 @@ handleDeleteMatches patternsVar query Database{..} = do
     patterns <- readTVarIO patternsVar
     case query >>= patternFromText of
         Nothing -> do
-            pure handleInvalidPattern
+            pure Errors.invalidPattern
         Just p | p `overlaps` patterns -> do
-            pure handleStillActivePattern
+            pure Errors.stillActivePattern
         Just p -> do
             n <- runImmediateTransaction $ deleteInputsByAddress (patternToSql p)
-            pure $ responseLBS status200 defaultHeaders $
+            pure $ responseLBS status200 Default.headers $
                 B.toLazyByteString $ Json.fromEncoding $ Json.pairs $ mconcat
                     [ Json.pair "deleted" (Json.int n)
                     ]
+
+--
+-- /v1/patterns
+--
 
 handleGetPatterns
     :: [Pattern]
@@ -228,11 +246,11 @@ handleDeletePattern
 handleDeletePattern patternsVar query Database{..} = do
     case query >>= patternFromText of
         Nothing ->
-            pure handleInvalidPattern
+            pure Errors.invalidPattern
         Just p -> do
             n <- runImmediateTransaction $ deletePattern (patternToRow p)
             atomically $ modifyTVar' patternsVar (\\ [p])
-            pure $ responseLBS status200 defaultHeaders $
+            pure $ responseLBS status200 Default.headers $
                 B.toLazyByteString $ Json.fromEncoding $ Json.pairs $ mconcat
                     [ Json.pair "deleted" (Json.int n)
                     ]
@@ -245,143 +263,16 @@ handlePutPattern
 handlePutPattern patternsVar query Database{..} = do
     case query >>= patternFromText of
         Nothing ->
-            pure handleInvalidPattern
+            pure Errors.invalidPattern
         Just p  -> do
             runImmediateTransaction $ insertPatterns [patternToRow p]
             patterns <- atomically $ do
                 modifyTVar' patternsVar (nub . (p :))
                 readTVar patternsVar
-            pure $ responseLBS status200 defaultHeaders $
+            pure $ responseLBS status200 Default.headers $
                 B.toLazyByteString $ Json.fromEncoding $ Json.list
                     (Json.text . patternToText)
                     patterns
-
-handleInvalidPattern :: Response
-handleInvalidPattern = do
-    responseJson status400 defaultHeaders $ HttpError
-        { hint = "Invalid pattern! To fetch matches, you may provide any valid \
-                 \pattern, including wildcards ('*') or full addresses. Make \
-                 \sure to double-check the documentation at: \
-                 \<https://cardanosolutions.github.io/kupo>!"
-        }
-
-handleInvalidFilterQuery :: Response
-handleInvalidFilterQuery = do
-    responseJson status400 defaultHeaders $ HttpError
-        { hint = "Invalid filter query! Matches can be filtered by status using \
-                 \HTTP query flags. Provide either '?spent' or '?unspent' to \
-                 \filter accordingly. Anything else is an error. In case of \
-                 \doubts, check the documentation at: <https://cardanosolutions.github.io/kupo>!"
-        }
-
-handleStillActivePattern :: Response
-handleStillActivePattern = do
-    responseJson status400 defaultHeaders $ HttpError
-        { hint = "Beware! You've just attempted to remove matches using a pattern \
-                 \that overlaps with another still active pattern! This is not \
-                 \allowed as it could lead to very confusing index states. \
-                 \Make sure to remove conflicting patterns first AND THEN, \
-                 \clean-up obsolete matches if necessary."
-        }
-
-
-handleNotFound :: Response
-handleNotFound =
-    responseJson status404 defaultHeaders $ HttpError
-        { hint = "Endpoint not found. Make sure to double-check the \
-                 \documentation at: <https://cardanosolutions.github.io/kupo>!"
-        }
-
-handleMethodNotAllowed :: Response
-handleMethodNotAllowed =
-    responseJson status406 defaultHeaders $ HttpError
-        { hint = "Unsupported method called on known endpoint. Make sure to \
-                 \double-check the documentation at: \
-                 \<https://cardanosolutions.github.io/kupo>!"
-        }
-
---
--- Clients
---
-
--- | Performs a health check against a running server, this is a standalone
--- program which exits immediately, either with a success or an error code.
-healthCheck :: String -> Int -> IO ()
-healthCheck host port = do
-    response <- handle onAnyException $ join $ httpLbs
-        <$> parseRequest ("http://" <> host <> ":" <> show port <> "/v1/health")
-        <*> newManager defaultManagerSettings
-    case Json.decode (responseBody response) >>= getConnectionStatus of
-        Just st | Json.value st == Json.toEncoding Connected ->
-            return ()
-        _ -> do
-            exitWith (ExitFailure 1)
-  where
-    onAnyException (_ :: SomeException) =
-        exitWith (ExitFailure 1)
-    getConnectionStatus =
-        lookup @(Map String Json.Value) "connection_status"
-
---
--- Helpers
---
-
-data HttpError = HttpError
-    { hint :: Text }
-    deriving stock (Generic)
-    deriving anyclass (ToJSON)
-
-defaultHeaders :: [Header]
-defaultHeaders =
-    [ ( hContentType, "application/json;charset=utf-8" )
-    ]
-
-patternFromQuery :: [Text] -> Maybe Text
-patternFromQuery = \case
-    [] ->
-        Just wildcard
-    [arg0] ->
-        Just arg0
-    [arg0, arg1] ->
-        Just (arg0 <> "/" <> arg1)
-    _ ->
-        Nothing
-
-responseJson
-    :: ToJSON a
-    => Http.Status
-    -> [Header]
-    -> a
-    -> Response
-responseJson status headers a =
-    let
-        bytes = B.toLazyByteString $ Json.fromEncoding (Json.toEncoding a)
-        len = BL.length bytes
-        contentLength = ( hContentLength, encodeUtf8 (show @Text len) )
-     in
-        responseLBS status (contentLength : headers) bytes
-
-responseStreamJson
-    :: (a -> Json.Encoding)
-    -> ((a -> IO ()) -> IO () -> IO ())
-    -> Response
-responseStreamJson encode callback = do
-    responseStream status200 defaultHeaders $ \write flush -> do
-        ref <- newIORef True
-        write openBracket
-        callback
-            (\a -> do
-                isFirstResult <- readIORef ref
-                write (separator isFirstResult <> Json.fromEncoding (encode a))
-                writeIORef ref False
-            )
-            (write closeBracket >> flush)
-  where
-    openBracket = B.putCharUtf8 '['
-    closeBracket = B.putCharUtf8 ']'
-    separator isFirstResult
-        | isFirstResult = mempty
-        | otherwise     = B.putCharUtf8 ','
 
 --
 -- Tracer
@@ -415,18 +306,3 @@ instance ToJSON TraceHttpServer where
     toEncoding =
         defaultGenericToEncoding
 
---
--- Status
---
-
-data Status = Status
-    { statusCode :: Int
-    , statusMessage :: Text
-    } deriving stock (Generic)
-      deriving anyclass (ToJSON)
-
-mkStatus :: Http.Status -> Status
-mkStatus status = Status
-    { statusCode = Http.statusCode status
-    , statusMessage = decodeUtf8 (Http.statusMessage status)
-    }

--- a/src/Kupo/App/Http/HealthCheck.hs
+++ b/src/Kupo/App/Http/HealthCheck.hs
@@ -1,0 +1,41 @@
+--  This Source Code Form is subject to the terms of the Mozilla Public
+--  License, v. 2.0. If a copy of the MPL was not distributed with this
+--  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+module Kupo.App.Http.HealthCheck
+    ( healthCheck
+    ) where
+
+import Kupo.Prelude
+
+import Kupo.Control.MonadCatch
+    ( handle )
+import Kupo.Data.Health
+    ( ConnectionStatus (..) )
+import Network.HTTP.Client
+    ( defaultManagerSettings, httpLbs, newManager, parseRequest, responseBody )
+import Relude.Extra
+    ( lookup )
+import System.Exit
+    ( ExitCode (..) )
+
+import qualified Data.Aeson as Json
+import qualified Data.Aeson.Encoding as Json
+
+-- | Performs a health check against a running server, this is a standalone
+-- program which exits immediately, either with a success or an error code.
+healthCheck :: String -> Int -> IO ()
+healthCheck host port = do
+    response <- handle onAnyException $ join $ httpLbs
+        <$> parseRequest ("http://" <> host <> ":" <> show port <> "/v1/health")
+        <*> newManager defaultManagerSettings
+    case Json.decode (responseBody response) >>= getConnectionStatus of
+        Just st | Json.value st == Json.toEncoding Connected ->
+            return ()
+        _ -> do
+            exitWith (ExitFailure 1)
+  where
+    onAnyException (_ :: SomeException) =
+        exitWith (ExitFailure 1)
+    getConnectionStatus =
+        lookup @(Map String Json.Value) "connection_status"

--- a/src/Kupo/Data/Http/Default.hs
+++ b/src/Kupo/Data/Http/Default.hs
@@ -6,12 +6,9 @@ module Kupo.Data.Http.Default
     ( headers
     ) where
 
-import Kupo.Prelude
 
 import Network.HTTP.Types.Header
-    ( Header, hContentLength, hContentType )
-
-
+    ( Header, hContentType )
 
 headers :: [Header]
 headers =

--- a/src/Kupo/Data/Http/Default.hs
+++ b/src/Kupo/Data/Http/Default.hs
@@ -1,0 +1,19 @@
+--  This Source Code Form is subject to the terms of the Mozilla Public
+--  License, v. 2.0. If a copy of the MPL was not distributed with this
+--  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+module Kupo.Data.Http.Default
+    ( headers
+    ) where
+
+import Kupo.Prelude
+
+import Network.HTTP.Types.Header
+    ( Header, hContentLength, hContentType )
+
+
+
+headers :: [Header]
+headers =
+    [ ( hContentType, "application/json;charset=utf-8" )
+    ]

--- a/src/Kupo/Data/Http/Error.hs
+++ b/src/Kupo/Data/Http/Error.hs
@@ -1,0 +1,66 @@
+--  This Source Code Form is subject to the terms of the Mozilla Public
+--  License, v. 2.0. If a copy of the MPL was not distributed with this
+--  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+{-# LANGUAGE DeriveAnyClass #-}
+
+module Kupo.Data.Http.Error where
+
+import Kupo.Prelude
+
+import Kupo.Data.Http.Response
+    ( responseJson )
+import Network.HTTP.Types.Status
+    ( status400, status404, status406 )
+import Network.Wai
+    ( Response )
+
+import qualified Kupo.Data.Http.Default as Default
+
+data HttpError = HttpError
+    { hint :: Text }
+    deriving stock (Generic)
+    deriving anyclass (ToJSON)
+
+invalidPattern :: Response
+invalidPattern =
+    responseJson status400 Default.headers $ HttpError
+        { hint = "Invalid pattern! To fetch matches, you may provide any valid \
+                 \pattern, including wildcards ('*') or full addresses. Make \
+                 \sure to double-check the documentation at: \
+                 \<https://cardanosolutions.github.io/kupo>!"
+        }
+
+invalidFilterQuery :: Response
+invalidFilterQuery =
+    responseJson status400 Default.headers $ HttpError
+        { hint = "Invalid filter query! Matches can be filtered by status using \
+                 \HTTP query flags. Provide either '?spent' or '?unspent' to \
+                 \filter accordingly. Anything else is an error. In case of \
+                 \doubts, check the documentation at: <https://cardanosolutions.github.io/kupo>!"
+        }
+
+stillActivePattern :: Response
+stillActivePattern =
+    responseJson status400 Default.headers $ HttpError
+        { hint = "Beware! You've just attempted to remove matches using a pattern \
+                 \that overlaps with another still active pattern! This is not \
+                 \allowed as it could lead to very confusing index states. \
+                 \Make sure to remove conflicting patterns first AND THEN, \
+                 \clean-up obsolete matches if necessary."
+        }
+
+notFound :: Response
+notFound =
+    responseJson status404 Default.headers $ HttpError
+        { hint = "Endpoint not found. Make sure to double-check the \
+                 \documentation at: <https://cardanosolutions.github.io/kupo>!"
+        }
+
+methodNotAllowed :: Response
+methodNotAllowed =
+    responseJson status406 Default.headers $ HttpError
+        { hint = "Unsupported method called on known endpoint. Make sure to \
+                 \double-check the documentation at: \
+                 \<https://cardanosolutions.github.io/kupo>!"
+        }

--- a/src/Kupo/Data/Http/Error.hs
+++ b/src/Kupo/Data/Http/Error.hs
@@ -50,6 +50,22 @@ stillActivePattern =
                  \clean-up obsolete matches if necessary."
         }
 
+invalidStrictMode :: Response
+invalidStrictMode =
+    responseJson status400 Default.headers $ HttpError
+        { hint = "Invalid strict-mode query flag! This endpoint only accepts a \
+                 \single query flag '?strict' which semantics is defined in the \
+                 \documentation: <https://cardanosolutions.github.io/kupo>. \
+                 \Any other query parameter is treated as an error."
+        }
+
+invalidSlotNo :: Response
+invalidSlotNo =
+    responseJson status400 Default.headers $ HttpError
+        { hint = "The path parameter for the endpoint must be an absolute slot \
+                 \number. That is, an non-negative integer."
+        }
+
 notFound :: Response
 notFound =
     responseJson status404 Default.headers $ HttpError

--- a/src/Kupo/Data/Http/GetCheckpointMode.hs
+++ b/src/Kupo/Data/Http/GetCheckpointMode.hs
@@ -1,0 +1,24 @@
+--  This Source Code Form is subject to the terms of the Mozilla Public
+--  License, v. 2.0. If a copy of the MPL was not distributed with this
+--  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+module Kupo.Data.Http.GetCheckpointMode
+    ( GetCheckpointMode (..)
+    , getCheckpointModeFromQuery
+    ) where
+
+import Kupo.Prelude
+
+import qualified Network.HTTP.Types as Http
+
+data GetCheckpointMode
+    = GetCheckpointStrict
+    | GetCheckpointClosestAncestor
+
+getCheckpointModeFromQuery
+    :: Http.Query
+    -> Maybe GetCheckpointMode
+getCheckpointModeFromQuery = \case
+    [("strict", Nothing)] -> Just GetCheckpointStrict
+    [] -> Just GetCheckpointClosestAncestor
+    _ -> Nothing

--- a/src/Kupo/Data/Http/Response.hs
+++ b/src/Kupo/Data/Http/Response.hs
@@ -1,0 +1,72 @@
+--  This Source Code Form is subject to the terms of the Mozilla Public
+--  License, v. 2.0. If a copy of the MPL was not distributed with this
+--  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+module Kupo.Data.Http.Response
+    ( responseJson
+    , responseJsonEncoding
+    , responseStreamJson
+    ) where
+
+import Kupo.Prelude
+
+import Network.HTTP.Types.Header
+    ( Header, hContentLength )
+import Network.HTTP.Types.Status
+    ( status200 )
+import Network.Wai
+    ( Response, responseLBS, responseStream )
+
+import qualified Kupo.Data.Http.Default as Default
+
+import qualified Data.Aeson as Json
+import qualified Data.Binary.Builder as B
+import qualified Data.ByteString.Lazy as BL
+import qualified Network.HTTP.Types.Status as Http
+
+responseJsonEncoding
+    :: Http.Status
+    -> [Header]
+    -> Json.Encoding
+    -> Response
+responseJsonEncoding status headers a =
+    let
+        bytes = B.toLazyByteString $ Json.fromEncoding a
+        len = BL.length bytes
+        contentLength = ( hContentLength, encodeUtf8 (show @Text len) )
+     in
+        responseLBS status (contentLength : headers) bytes
+{-# INLINEABLE responseJsonEncoding #-}
+
+responseJson
+    :: ToJSON a
+    => Http.Status
+    -> [Header]
+    -> a
+    -> Response
+responseJson status headers a =
+    responseJsonEncoding status headers (Json.toEncoding a)
+{-# INLINEABLE responseJson #-}
+
+responseStreamJson
+    :: (a -> Json.Encoding)
+    -> ((a -> IO ()) -> IO () -> IO ())
+    -> Response
+responseStreamJson encode callback = do
+    responseStream status200 Default.headers $ \write flush -> do
+        ref <- newIORef True
+        write openBracket
+        callback
+            (\a -> do
+                isFirstResult <- readIORef ref
+                write (separator isFirstResult <> Json.fromEncoding (encode a))
+                writeIORef ref False
+            )
+            (write closeBracket >> flush)
+  where
+    openBracket = B.putCharUtf8 '['
+    closeBracket = B.putCharUtf8 ']'
+    separator isFirstResult
+        | isFirstResult = mempty
+        | otherwise     = B.putCharUtf8 ','
+

--- a/src/Kupo/Data/Http/Status.hs
+++ b/src/Kupo/Data/Http/Status.hs
@@ -1,0 +1,26 @@
+--  This Source Code Form is subject to the terms of the Mozilla Public
+--  License, v. 2.0. If a copy of the MPL was not distributed with this
+--  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+{-# LANGUAGE DeriveAnyClass #-}
+
+module Kupo.Data.Http.Status
+    ( Status (statusCode, statusMessage)
+    , mkStatus
+    ) where
+
+import Kupo.Prelude
+
+import qualified Network.HTTP.Types.Status as Http
+
+data Status = Status
+    { statusCode :: Int
+    , statusMessage :: Text
+    } deriving stock (Generic)
+      deriving anyclass (ToJSON)
+
+mkStatus :: Http.Status -> Status
+mkStatus status = Status
+    { statusCode = Http.statusCode status
+    , statusMessage = decodeUtf8 (Http.statusMessage status)
+    }

--- a/src/Kupo/Data/Pattern.hs
+++ b/src/Kupo/Data/Pattern.hs
@@ -14,6 +14,7 @@ module Kupo.Data.Pattern
     , overlaps
     , patternFromText
     , patternToText
+    , patternFromPath
     , wildcard
 
       -- * Matching
@@ -111,6 +112,17 @@ overlaps p = \case
 wildcard :: Text
 wildcard = "*"
 {-# INLINEABLE wildcard #-}
+
+patternFromPath :: [Text] -> Maybe Text
+patternFromPath = \case
+    [] ->
+        Just wildcard
+    [arg0] ->
+        Just arg0
+    [arg0, arg1] ->
+        Just (arg0 <> "/" <> arg1)
+    _ ->
+        Nothing
 
 patternToText :: Pattern -> Text
 patternToText = \case

--- a/src/Kupo/Prelude.hs
+++ b/src/Kupo/Prelude.hs
@@ -37,6 +37,9 @@ module Kupo.Prelude
       -- * System
     , hijackSigTerm
     , ConnectionStatusToggle (..)
+
+      -- * Utils
+    , nubOn
     ) where
 
 import Cardano.Binary
@@ -51,6 +54,8 @@ import Data.ByteString.Base64
     ( decodeBase64, encodeBase64 )
 import Data.Generics.Internal.VL.Lens
     ( view, (^.) )
+import Data.List
+    ( nubBy )
 import GHC.Generics
     ( Rep )
 import Relude hiding
@@ -148,3 +153,8 @@ byteStringToJson =
 defaultGenericToEncoding :: (Generic a, GToJSON' Encoding Zero (Rep a)) => a -> Json.Encoding
 defaultGenericToEncoding =
     genericToEncoding Json.defaultOptions
+
+-- | Remove duplicates from a list based on information extracted from the
+-- elements.
+nubOn :: Eq b => (a -> b) -> [a] -> [a]
+nubOn b = nubBy (on (==) b)

--- a/test/Test/Kupo/App/HttpSpec.hs
+++ b/test/Test/Kupo/App/HttpSpec.hs
@@ -225,6 +225,8 @@ databaseStub = Database
         \_ -> return ()
     , listCheckpointsDesc = \mk -> lift $ do
         fmap (mk . pointToRow) <$> generate (listOf1 genNonGenesisPoint)
+    , listAncestorsDesc = \_ _ mk -> lift $ do
+        fmap (mk . pointToRow) <$> generate (listOf1 genNonGenesisPoint)
     , insertPatterns =
         \_ -> return ()
     , deletePattern =

--- a/test/Test/Kupo/Data/Generators.hs
+++ b/test/Test/Kupo/Data/Generators.hs
@@ -87,6 +87,18 @@ genNonGenesisPoint :: Gen (Point Block)
 genNonGenesisPoint = do
     BlockPoint <$> genSlotNo <*> genHeaderHash
 
+genPointsBetween :: (SlotNo, SlotNo) -> Gen [Point Block]
+genPointsBetween (inf, sup)
+    | inf >= sup = pure []
+    | otherwise = do
+        slotNo <- SlotNo <$> frequency
+            [ (3, pure (unSlotNo inf + 1))
+            , (2, choose (unSlotNo inf + 1, min (unSlotNo inf + 5) (unSlotNo sup)))
+            , (1, choose (unSlotNo inf + 1, unSlotNo sup))
+            ]
+        pt <- BlockPoint slotNo <$> genHeaderHash
+        (pt :) <$> genPointsBetween (slotNo, sup)
+
 genOutputIndex :: Gen OutputIndex
 genOutputIndex =
     fromIntegral <$> choose (0 :: Int, 255)

--- a/test/Test/Kupo/Fixture.hs
+++ b/test/Test/Kupo/Fixture.hs
@@ -29,6 +29,22 @@ somePoint = pointFromRow $ Checkpoint
         "2e7ee124eccbc648789008f8669695486f5727cada41b2d86d1c36355c76b771"
     }
 
+somePointAncestor :: Point Block
+somePointAncestor = pointFromRow $ Checkpoint
+    { checkpointSlotNo =
+        51292617
+    , checkpointHeaderHash = unsafeDecodeBase16
+        "e63797c3982e9af8ab1f9ea1a60bfa47df9ead2e745adcca95ad30c6f49982a0"
+    }
+
+somePointSuccessor :: Point Block
+somePointSuccessor = pointFromRow $ Checkpoint
+    { checkpointSlotNo =
+        51292686
+    , checkpointHeaderHash = unsafeDecodeBase16
+        "0cdb5efde9aba0bbd2f0606d4ab64e4762cf13fe4ee78e0c5d956666fe6c95d3"
+    }
+
 someOtherPoint :: Point Block
 someOtherPoint = pointFromRow $ Checkpoint
     { checkpointSlotNo =


### PR DESCRIPTION
Fixes #24 

---

- :round_pushpin: **Provide a new database accessor to retrieve checkpoints' ancestors.**
    This is built as a simple query on the checkpoints table. The commit
  also add two property test focused on the checkpoints table. It also
  test the insertion and listing of checkpoints (and found a bug). The
  interface is a bit flexible and allows for returning many a list of
  ancestors, even though the main motivating use-case is only about
  single ancestors. It makes for a nicer interface (lists for the win
  o/).

- :round_pushpin: **Re-organize App.Http, split pure code out and tidy up.**
    The module was starting to get big with many level of abstractions
  intertwined. For the sake of keeping the separation good (and
  possibly, indidually improve test coverage of the sub-parts), I've
  move all the pure helpers into separate modules under the 'Data'
  section. Remains in 'App.Http' only the actual route handlers. This is
  a bit cleaner and allow to extend even more the http endpoints while
  keeping things clean and tidy.

- :round_pushpin: **Add new endpoint to retrive checkpoints by slot number.**
    The API is purposely flexible to also make it easy to retrieve
  ancestors from a given point. It suffices to remove 1 from any given
  slot number to get the nearest slot that is smaller or equal to the
  provided slot number. Because this behavior can also be somewhat odd,
  it is possible to make the request completely strict using a query
  flag '?strict', in which case, the server will only retrun results if
  strictly matching the request.
