### PR TITLE
Provide an API endpoint that returns all patterns covering a given address

### DIFF
--- a/src/Kupo/App/Http.hs
+++ b/src/Kupo/App/Http.hs
@@ -37,7 +37,7 @@ import Kupo.Data.Cardano
     , slotNoFromText
     )
 import Kupo.Data.Database
-    ( patternToRow, patternFromRow, patternToSql, pointFromRow, resultFromRow, statusToSql )
+    ( patternToRow, patternFromRow, patternToSql, patternContainsSql, pointFromRow, resultFromRow, statusToSql )
 import Kupo.Data.Health
     ( Health )
 import Kupo.Data.Http.FilterMatchesBy
@@ -313,7 +313,7 @@ handleGetMatchingPatterns patternQuery Database{..} = do
         Nothing ->
             Errors.invalidPattern
         Just p -> do
-            let query = patternToSql p
+            let query = patternContainsSql p
             responseStreamJson Json.text $ \yield done -> do
                 runTransaction $ selectPatterns patternFromRow query (yield . patternToText)
                 done

--- a/src/Kupo/App/Http.hs
+++ b/src/Kupo/App/Http.hs
@@ -164,8 +164,10 @@ app withDatabase patternsVar readHealth req send =
     routePatterns = \case
         ("GET", []) ->
             readTVarIO patternsVar >>= send . handleGetPatterns
-        ("GET", _) ->
-            send Errors.notFound
+        ("GET", args) ->
+            withDatabase (send .
+                handleGetMatchingPatterns (patternFromPath args) (queryString req)
+            )
         ("PUT", args) ->
             withDatabase (send <=<
                 handlePutPattern patternsVar (patternFromPath args)
@@ -301,6 +303,21 @@ handleGetPatterns patterns = do
     responseStreamJson Json.text $ \yield done -> do
         mapM_ (yield . patternToText) patterns
         done
+
+handleGetMatchingPatterns
+    :: Maybe Text
+    -> Http.Query
+    -> Database IO
+    -> Response
+handleGetMatchingPatterns patternQuery queryParams Database{..} = do
+    case patternQuery >>= patternFromText of
+        Nothing ->
+            Errors.invalidPattern
+        Just p -> do
+            let query = patternToSql p
+            responseStreamJson resultToJson $ \yield done -> do
+                runTransaction $ selectPatterns patternFromRow query (yield . patternToText)
+                done
 
 handleDeletePattern
     :: TVar IO [Pattern]

--- a/src/Kupo/Control/MonadDatabase.hs
+++ b/src/Kupo/Control/MonadDatabase.hs
@@ -367,7 +367,7 @@ mkDatabase (fromIntegral -> longestRollback) bracketConnection = Database
             $ \xs (Only x) -> pure (mk x:xs)
 
     , selectPatterns = \mk addressLike yield -> ReaderT $ \conn -> do
-        let qry = "SELECT * \
+        let qry = "SELECT pattern, LENGTH(pattern) as len \
                   \FROM patterns \
                   \WHERE pattern " <> addressLike
 

--- a/src/Kupo/Control/MonadDatabase.hs
+++ b/src/Kupo/Control/MonadDatabase.hs
@@ -359,6 +359,14 @@ mkDatabase (fromIntegral -> longestRollback) bracketConnection = Database
         fold_ conn "SELECT * FROM patterns" []
             $ \xs (Only x) -> pure (mk x:xs)
 
+    , selectPatterns = \mk -> \addressLike yield -> ReaderT $ \conn -> do
+        let qry = "SELECT * \
+                  \FROM patterns \
+                  \WHERE pattern " <> addressLike
+
+        fold_ conn qry []
+            $ \xs (Only x) -> pure (mk x:xs)
+
     , rollbackTo = \slotNo -> ReaderT $ \conn -> do
         execute conn "DELETE FROM inputs WHERE created_at > ?"
             [ SQLInteger (fromIntegral slotNo)

--- a/src/Kupo/Control/MonadDatabase.hs
+++ b/src/Kupo/Control/MonadDatabase.hs
@@ -367,7 +367,7 @@ mkDatabase (fromIntegral -> longestRollback) bracketConnection = Database
             $ \xs (Only x) -> pure (mk x:xs)
 
     , selectPatterns = \mk addressLike yield -> ReaderT $ \conn -> do
-        let qry = "SELECT pattern, LENGTH(pattern) as len \
+        let qry = "SELECT pattern \
                   \FROM patterns \
                   \WHERE pattern " <> addressLike
 

--- a/src/Kupo/Data/Database.hs
+++ b/src/Kupo/Data/Database.hs
@@ -22,6 +22,7 @@ module Kupo.Data.Database
     , patternToRow
     , patternFromRow
     , patternToSql
+    , patternContainsSql
 
       -- * Filtering
     , statusToSql
@@ -30,7 +31,7 @@ module Kupo.Data.Database
 import Kupo.Prelude
 
 import Kupo.Data.Cardano
-    ( Block, SlotNo (..), StandardCrypto )
+    ( Block, SlotNo (..), StandardCrypto, getDelegationPartBytes, getPaymentPartBytes )
 import Kupo.Data.Pattern
     ( MatchBootstrap (..)
     , Pattern (..)
@@ -145,6 +146,40 @@ patternToSql = \case
         "LIKE '%" <> encodeBase16 delegation <> "' AND len > 58"
     MatchPaymentAndDelegation payment delegation ->
         "LIKE '__" <> encodeBase16 payment <> encodeBase16 delegation <> "'"
+
+
+-- querying whether the given pattern is covered entirely by a pattern stored in the DB
+patternContainsSql
+    :: Pattern
+    -> Text
+patternContainsSql = \case
+    MatchAny IncludingBootstrap ->
+        "= '*'"
+    MatchAny OnlyShelley ->
+        "= '*/*'"
+        <> " OR " <> patternContainsSql (MatchAny IncludingBootstrap)
+    MatchPayment payment ->
+        "= '" <> encodeBase16 payment <> "/*'"
+        <> " OR " <> patternContainsSql (MatchAny OnlyShelley)
+    MatchDelegation delegation ->
+        "= '*/" <> encodeBase16 delegation <> "'"
+        <> " OR " <> patternContainsSql (MatchAny OnlyShelley)
+    MatchPaymentAndDelegation payment delegation ->
+        "= '" <> encodeBase16 payment <> "/" <> encodeBase16 delegation <> "'"
+        <> " OR " <> patternContainsSql (MatchDelegation delegation)
+        <> " OR " <> patternContainsSql (MatchPayment payment)
+    MatchExact addr ->
+        "= '" <> encodeBase16 (Ledger.serialiseAddr addr) <> "'" <>
+        case (getPaymentPartBytes addr) of
+        Nothing ->
+            " OR " <> patternContainsSql (MatchAny IncludingBootstrap)
+        Just payment -> 
+             case (getDelegationPartBytes addr) of
+                Nothing ->
+                    " OR " <> patternContainsSql (MatchPayment payment)
+                Just delegation -> 
+                    " OR " <> patternContainsSql (MatchPaymentAndDelegation payment delegation)
+            
 
 --
 -- Filters

--- a/src/Kupo/Data/Database.hs
+++ b/src/Kupo/Data/Database.hs
@@ -49,6 +49,7 @@ import Ouroboros.Network.Block
 import qualified Cardano.Ledger.Address as Ledger
 import qualified Kupo.Control.MonadDatabase as DB
 import qualified Network.HTTP.Types.URI as Http
+import qualified Data.Text as Text
 
 --
 -- Checkpoint
@@ -149,37 +150,40 @@ patternToSql = \case
 
 
 -- querying whether the given pattern is covered entirely by a pattern stored in the DB
-patternContainsSql
+patternContainsPatterns
     :: Pattern
-    -> Text
-patternContainsSql = \case
+    -> [Text]
+patternContainsPatterns = \case
     MatchAny IncludingBootstrap ->
-        "= '*'"
+        ["*"]
     MatchAny OnlyShelley ->
-        "= '*/*'"
-        <> " OR " <> patternContainsSql (MatchAny IncludingBootstrap)
+        "*/*" : (patternContainsPatterns (MatchAny IncludingBootstrap))
     MatchPayment payment ->
-        "= '" <> encodeBase16 payment <> "/*'"
-        <> " OR " <> patternContainsSql (MatchAny OnlyShelley)
+        encodeBase16 payment <> "/*" : (patternContainsPatterns (MatchAny OnlyShelley))
     MatchDelegation delegation ->
-        "= '*/" <> encodeBase16 delegation <> "'"
-        <> " OR " <> patternContainsSql (MatchAny OnlyShelley)
+        "*/" <> encodeBase16 delegation : (patternContainsPatterns (MatchAny OnlyShelley))
     MatchPaymentAndDelegation payment delegation ->
-        "= '" <> encodeBase16 payment <> "/" <> encodeBase16 delegation <> "'"
-        <> " OR " <> patternContainsSql (MatchDelegation delegation)
-        <> " OR " <> patternContainsSql (MatchPayment payment)
+        encodeBase16 payment <> "/" <> encodeBase16 delegation : (
+            patternContainsPatterns (MatchPayment payment) <>
+            patternContainsPatterns (MatchDelegation delegation)
+        )
     MatchExact addr ->
-        "= '" <> encodeBase16 (Ledger.serialiseAddr addr) <> "'" <>
+        encodeBase16 (Ledger.serialiseAddr addr) :
         case (getPaymentPartBytes addr) of
         Nothing ->
-            " OR " <> patternContainsSql (MatchAny IncludingBootstrap)
+            patternContainsPatterns (MatchAny IncludingBootstrap)
         Just payment -> 
              case (getDelegationPartBytes addr) of
                 Nothing ->
-                    " OR " <> patternContainsSql (MatchPayment payment)
+                    patternContainsPatterns (MatchPayment payment)
                 Just delegation -> 
-                    " OR " <> patternContainsSql (MatchPaymentAndDelegation payment delegation)
-            
+                    patternContainsPatterns (MatchPaymentAndDelegation payment delegation)
+
+
+patternContainsSql
+    :: Pattern
+    -> Text
+patternContainsSql p = "IN ('" <> Text.intercalate "','" (patternContainsPatterns p) <> "')"
 
 --
 -- Filters


### PR DESCRIPTION
This adds the endpoint /v1/patterns/{pattern-frac}
It returns all patterns that completely cover {pattern-frac} (i.e. if the result is non-empty, the user can be sure that {pattern-frac} UTxOs are correctly represented in the DB - this excludes the possibility of dynamically added patterns)

TODO:
- [x] add endpoint
- [ ] add documentation