### PR TITLE
 Give ways to retrieve full datums associated to datum hashes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 #### Added
 
+- [📌 #28](https://github.com/CardanoSolutions/kupo/issues/28) - Support for the Babbage's era, including inline-datums.
+
 - [📌 #17](https://github.com/CardanoSolutions/kupo/issues/20) - New command-line flag: `--prune-utxo`. When set, inputs that are spent on-chain will be removed from the index. Once-synced, 
   the index therefore only contain the current ledger UTxO set. When not set, spent inputs are kept in the index but are now marked accordingly to record if and when they've spent.
 
@@ -9,14 +11,26 @@
 
   Consequently, there's also a new (possibly `null`) field `spent_at` returned for each match result. When set, it indicates the slot in which the input was found being spent. 
 
-  - `GET v1/matches[?(spent|unspent)]` → [🕮  API Reference](https://cardanosolutions.github.io/kupo/#operation/getAllMatches)
+  - `GET v1/matches[?(spent|unspent)]` → [📖 API Reference](https://cardanosolutions.github.io/kupo/#operation/getAllMatches)
   - `GET v1/matches/{pattern-fragment}[?(spent|unspent)]` → [📖 API Reference](https://cardanosolutions.github.io/kupo/#operation/getMatches1Ary)
   - `GET v1/matches/{pattern-fragment}/{pattern-fragment}[?(spent|unspent)]` → [📖 API Reference](https://cardanosolutions.github.io/kupo/#operation/getMatches2Ary)
 
-[📌 #24](https://github.com/CardanoSolutions/kupo/issues/24) - New HTTP endpoint to retrieve a point on-chain from a given slot. The endpoint is flexible and allows for retrieving the ancestor 
+<br/>
+
+- [📌 #21](https://github.com/CardanoSolutions/kupo/issues/21) New HTTP endpoint to retrieve Plutus' datum pre-image from a datum hash digest. Behind the scene, Kupo now track any datum found in transactions' witnesses set or output (inline datums). Note that, datums that aren't associated to any existing pattern matches are eventually garbage-collected. 
+  - `GET v1/datums/{datum-hash}` [📖 API Reference](https://cardanosolutions.github.io/kupo/#operation/getDatumByHash)
+
+<br/>
+
+- [📌 #40](https://github.com/CardanoSolutions/kupo/issues/40) New HTTP endpoint to retrieve patterns that _includes_ a given pattern. Useful to check if an address is matched by a given configuration. 
+  - `GET v1/patterns/{pattern-fragment}[/{pattern-fragment}]` [📖 API Reference](https://cardanosolutions.github.io/kupo/#operation/matchPattern1Ary)
+
+<br/>
+
+- [📌 #24](https://github.com/CardanoSolutions/kupo/issues/24) - New HTTP endpoint to retrieve a point on-chain from a given slot. The endpoint is flexible and allows for retrieving the ancestor 
   of a known point very easily. This is handy in combination with other protocols that leverage on-chain points and intersections (like [Ogmios' chain-sync](https://ogmios.dev/mini-protocols/local-chain-sync/)). 
 
-  - `GET v1/checkpoints/{slot-no}[?strict]` → [🕮  API Reference](https://cardanosolutions.github.io/kupo/#operation/getCheckpointBySlot)
+  - `GET v1/checkpoints/{slot-no}[?strict]` → [📖 API Reference](https://cardanosolutions.github.io/kupo/#operation/getCheckpointBySlot)
 
 #### Changed
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ See [projects 🎯](https://github.com/CardanoSolutions/kupo/projects).
 | <a href="https://github.com/CardanoSolutions/kupo/actions/workflows/docker.yaml"><img src="https://img.shields.io/github/workflow/status/cardanosolutions/kupo/Docker?style=for-the-badge&label=&logo=Docker&logoColor=000000&color=f9dd24" /></a> | Docker build, shipping images to [Dockerhub](https://hub.docker.com/r/cardanosolutions/kupo) |
 | <a href="https://github.com/CardanoSolutions/kupo/actions/workflows/nix.yaml"><img src="https://img.shields.io/github/workflow/status/cardanosolutions/kupo/Nix?style=for-the-badge&label=&logo=NixOS&logoColor=000000&color=f9dd24" /></a> | Nix build, providing static binary executables as artifacts. | 
 | <a href="https://github.com/CardanoSolutions/kupo/actions/workflows/pages/pages-build-deployment"><img src="https://img.shields.io/github/deployments/cardanosolutions/kupo/github-pages?style=for-the-badge&label=&logo=readthedocs&logoColor=000000&color=f9dd24"></a> | User manual and API reference deployment. |
-| <img src="https://img.shields.io/static/v1?style=for-the-badge&label=&message=85%&logo=codecov&logoColor=000000&color=f9dd24"> | Test code coverage. |
+| <img src="https://img.shields.io/static/v1?style=for-the-badge&label=&message=88%&logo=codecov&logoColor=000000&color=f9dd24"> | Test code coverage. |
 
 # Alternatives
 

--- a/db/v2.0.0/003.sql
+++ b/db/v2.0.0/003.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS binary_data (
+  binary_data_hash BLOB NOT NULL,
+  binary_data BLOB NOT NULL,
+  PRIMARY KEY (binary_data_hash)
+);
+
+CREATE INDEX IF NOT EXISTS binaryDataByHash ON binary_data(binary_data_hash);

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -302,6 +302,19 @@ components:
           minLength: 64
           maxLength: 64
 
+    Datum:
+      title: Datum
+      type: object
+      required:
+        - datum
+      additionalProperties: false
+      properties:
+        datum:
+          type: string
+          description: A serialized Plutus' datum.
+          contentEncoding: base16
+          example: d87980
+
     DatumHash:
       oneOf:
         - title: Digest
@@ -345,15 +358,21 @@ components:
         - created_at
         - spent_at
       properties:
-        transaction_id: { "$ref": "#/components/schemas/TransactionId" }
-        output_index: { "$ref": "#/components/schemas/OutputIndex" }
-        address: { "$ref": "#/components/schemas/Address" }
-        value: { "$ref": "#/components/schemas/Value" }
-        datum_hash: { "$ref": "#/components/schemas/DatumHash" }
-        created_at: { "$ref": "#/components/schemas/Point" }
+        transaction_id:
+          $ref: "#/components/schemas/TransactionId"
+        output_index:
+          $ref: "#/components/schemas/OutputIndex"
+        address:
+          $ref: "#/components/schemas/Address"
+        value:
+          $ref: "#/components/schemas/Value"
+        datum_hash:
+          $ref: "#/components/schemas/DatumHash"
+        created_at:
+          $ref: "#/components/schemas/Point"
         spent_at:
           oneOf:
-            - { "$ref": "#/components/schemas/Point" }
+            - $ref: "#/components/schemas/Point"
             - type: "null"
 
     OutputIndex:
@@ -366,9 +385,9 @@ components:
       description: |
           A matching pattern for addresses. See [Pattern](#section/Pattern)
       anyOf:
-        - { "$ref": "#/components/schemas/Wildcard" }
-        - { "$ref": "#/components/schemas/AddressParameter" }
-        - { "$ref": "#/components/schemas/Credential" }
+        - $ref: "#/components/schemas/Wildcard"
+        - $ref: "#/components/schemas/AddressParameter"
+        - $ref: "#/components/schemas/Credential"
 
     Point:
       type: object
@@ -377,8 +396,10 @@ components:
         - slot_no
         - header_hash
       properties:
-        slot_no: { "$ref": "#/components/schemas/SlotNo" }
-        header_hash: { "$ref": "#/components/schemas/HeaderHash" }
+        slot_no:
+          $ref: "#/components/schemas/SlotNo"
+        header_hash:
+          $ref: "#/components/schemas/HeaderHash"
 
     SlotNo: &slotNo
       type: integer
@@ -412,7 +433,7 @@ components:
             type: string
             pattern: ^[a-f0-9]{56}(.[a-f0-9]{2,64})?$
           additionalProperties:
-            x-additionalPropertiesName: "{policy_id}.{asset_name}"
+            x-additionalPropertiesName: "{policy-id}.{asset-name}"
             type: integer
             description: A quantity of some asset.
           example:
@@ -454,19 +475,19 @@ components:
 
   parameters:
     pattern-fragment:
-      name: pattern-fragment
+      name: pattern_fragment
       in: path
       required: true
       schema:
         anyOf:
-          - { "$ref": "#/components/schemas/Wildcard" }
-          - { "$ref": "#/components/schemas/AddressParameter" }
-          - { "$ref": "#/components/schemas/Credential" }
+          - $ref: "#/components/schemas/Wildcard"
+          - $ref: "#/components/schemas/AddressParameter"
+          - $ref: "#/components/schemas/Credential"
       description: |
         A pattern fragment (i.e. a wildcard, an address or a credential). See [Pattern](#section/Pattern) for more details.
 
     slot-no:
-      name: slot-no
+      name: slot_no
       in: path
       required: true
       schema:
@@ -489,7 +510,7 @@ components:
       description: |
         A query flag (i.e. `?unspent`) filter matches by status, to get only 'unspent' matches.
 
-    policy_id:
+    policy-id:
       name: policy_id
       in: query
       required: false
@@ -503,7 +524,7 @@ components:
       example:
         1220099e5e430475c219518179efc7e6c8289db028904834025d5b086
 
-    asset_name:
+    asset-name:
       name: asset_name
       in: query
       required: false
@@ -527,12 +548,26 @@ components:
       description: |
         A query flag (i.e. `?strict`) to only look for checkpoints that strictly match the provided slot. The behavior otherwise is to look for the largest nearest slot smaller or equal to the one provided.
 
+    datum-hash:
+      name: datum_hash
+      in: path
+      required: true
+      schema:
+        type: string
+        contentEncoding: base16
+        minLength: 64
+        maxLength: 64
+        example: 309706b92ad8340cd6a5d31bf9d2e682fdab9fc8865ee3de14e09dedf9b1b635
+      description:
+        A datum blake2b-256 hash digest.
+
 tags:
   - name: Matches
   - name: Checkpoints
     description: |
       An API for inspecting checkpoints known of the database. A checkpoint really is a point on-chain that directly references a block. They are comprised of an absolute slot
       number and a block header hash. Kupo records all such points as it processes blocks. In particular, they are also used to resume synchronization upon restart.
+  - name: Datums
   - name: Patterns
   - name: Health
 
@@ -546,10 +581,10 @@ paths:
         Retrieve all matches from the database, in descending `slot_no` order. Results are streamed to the client for more efficiency.
         Note that this is generally a bad idea for indexes built off permissive patterns (e.g. `*`) for the server will yield a large response.
       parameters:
-        - { "$ref": "#/components/parameters/spent" }
-        - { "$ref": "#/components/parameters/unspent" }
-        - { "$ref": "#/components/parameters/policy_id" }
-        - { "$ref": "#/components/parameters/asset_name" }
+        - $ref: "#/components/parameters/spent"
+        - $ref: "#/components/parameters/unspent"
+        - $ref: "#/components/parameters/policy-id"
+        - $ref: "#/components/parameters/asset-name"
       responses:
         200:
           description: OK
@@ -557,7 +592,8 @@ paths:
             "application/json;charset=utf-8":
               schema:
                 type: array
-                items: { "$ref": "#/components/schemas/Match" }
+                items:
+                  $ref: "#/components/schemas/Match"
 
   /v1/matches/{pattern-fragment}:
     get: &getMatches
@@ -568,11 +604,11 @@ paths:
         Retrieve matches from the database matching the given pattern, in descending `slot_no` order. Results are streamed to the client for more efficiency.
         See [Pattern](#section/Pattern) for more information about constructing patterns.
       parameters:
-        - { "$ref": "#/components/parameters/pattern-fragment" }
-        - { "$ref": "#/components/parameters/spent" }
-        - { "$ref": "#/components/parameters/unspent" }
-        - { "$ref": "#/components/parameters/policy_id" }
-        - { "$ref": "#/components/parameters/asset_name" }
+        - $ref: "#/components/parameters/pattern-fragment"
+        - $ref: "#/components/parameters/spent"
+        - $ref: "#/components/parameters/unspent"
+        - $ref: "#/components/parameters/policy-id"
+        - $ref: "#/components/parameters/asset-name"
       responses:
         200:
           description: OK
@@ -580,30 +616,34 @@ paths:
             "application/json;charset=utf-8":
               schema:
                 type: array
-                items: { "$ref": "#/components/schemas/Match" }
+                items:
+                  $ref: "#/components/schemas/Match"
         400:
           description: Bad Request
           content:
             "application/json;charset=utf-8":
-              schema: { "$ref": "#/components/schemas/BadRequest" }
+              schema:
+                $ref: "#/components/schemas/BadRequest"
 
     delete: &deleteMatches
       operationId: deleteMatches
       tags: ["Matches"]
       summary: Delete Matches (*)
       description: |
-          Delete all matches matching the given pattern. Note that this operation is only allowed if the provided pattern isn't a currently active pattern.
+        Delete all matches matching the given pattern. Note that this operation is only allowed if the provided pattern isn't a currently active pattern.
       responses:
         200:
           description: OK
           content:
             "application/json;charset=utf-8":
-              schema: { "$ref": "#/components/schemas/Deleted" }
+              schema:
+                $ref: "#/components/schemas/Deleted"
         400:
           description: Bad Request
           content:
             "application/json;charset=utf-8":
-              schema: { "$ref": "#/components/schemas/BadRequest" }
+              schema:
+                $ref: "#/components/schemas/BadRequest"
 
   /v1/matches/{pattern-fragment}/{pattern-fragment}:
     get:
@@ -615,6 +655,32 @@ paths:
       <<: *deleteMatches
       operationId: deleteMatches2Ary
       summary: Delete Matches (*/*)
+
+  /v1/datums/{datum-hash}:
+    get:
+      operationdId: getDatumByHash
+      tags: ["Datums"]
+      summary: Get Datum by Hash
+      description: |
+        Retrieve the datum pre-image (i.e. full resolved datum) associated to a given datum hash digest.
+      parameters:
+        - $ref: "#/components/parameters/datum-hash"
+      responses:
+        200:
+          description: OK
+          content:
+            "application/json;charset=utf-8":
+              schema:
+                oneOf:
+                  - $ref: "#/components/schemas/Datum"
+                  - title: Nothing
+                    type: "null"
+        400:
+          description: Bad Request
+          content:
+            "application/json;charset=utf-8":
+              schema:
+                $ref: "#/components/schemas/BadRequest"
 
   /v1/patterns:
     get:
@@ -630,7 +696,8 @@ paths:
             "application/json;charset=utf-8":
               schema:
                 type: array
-                items: { "$ref": "#/components/schemas/Pattern" }
+                items:
+                  $ref: "#/components/schemas/Pattern"
 
   /v1/patterns/{pattern-fragment}:
     get: &getPattern
@@ -646,7 +713,7 @@ paths:
         >
         > If all results matched by `y` are also matched by `x`, then `x` is said to include `y`.
       parameters:
-        - { "$ref": "#/components/parameters/pattern-fragment" }
+        - $ref: "#/components/parameters/pattern-fragment"
       responses:
         200:
           description: OK
@@ -655,7 +722,7 @@ paths:
               schema:
                 type: array
                 items:
-                  { "$ref": "#/components/schemas/Pattern" }
+                  $ref: "#/components/schemas/Pattern"
 
     delete: &deletePattern
       operationId: deletePattern1Ary
@@ -666,18 +733,20 @@ paths:
         **NOT** remove the corresponding matches nor will it halt or restart synchronization.
         The server will continue filtering new blocks but, will that pattern removed.
       parameters:
-        - { "$ref": "#/components/parameters/pattern-fragment" }
+        - $ref: "#/components/parameters/pattern-fragment"
       responses:
         200:
           description: OK
           content:
             "application/json;charset=utf-8":
-              schema: { "$ref": "#/components/schemas/Deleted" }
+              schema:
+                $ref: "#/components/schemas/Deleted"
         400:
           description: Bad Request
           content:
             "application/json;charset=utf-8":
-              schema: { "$ref": "#/components/schemas/BadRequest" }
+              schema:
+                $ref: "#/components/schemas/BadRequest"
 
     put: &putPattern
       operationId: putPattern1Ary
@@ -687,7 +756,7 @@ paths:
         Add a new pattern to watch. This **does not** cause the server to re-sync however!
         Only new blocks will be matched against the pattern.
       parameters:
-        - { "$ref": "#/components/parameters/pattern-fragment" }
+        - $ref: "#/components/parameters/pattern-fragment"
       responses:
         200:
           description: OK
@@ -695,12 +764,14 @@ paths:
             "application/json;charset=utf-8":
               schema:
                 type: array
-                items: { "$ref": "#/components/schemas/Pattern" }
+                items:
+                  $ref: "#/components/schemas/Pattern"
         400:
           description: Bad Request
           content:
             "application/json;charset=utf-8":
-              schema: { "$ref": "#/components/schemas/BadRequest" }
+              schema:
+                $ref: "#/components/schemas/BadRequest"
 
   /v1/patterns/{pattern-fragment}/{pattern-fragment}:
     get:
@@ -734,7 +805,8 @@ paths:
             "application/json;charset=utf-8":
               schema:
                 type: array
-                items: { "$ref": "#/components/schemas/Point" }
+                items:
+                  $ref: "#/components/schemas/Point"
 
   /v1/checkpoints/{slot-no}:
     get:
@@ -746,8 +818,8 @@ paths:
         will for for the closest (i.e. most recent) slot that is **before** the provided slot number. This is particularly useful to find ancestors to known slots
         in order to use them for references on-chain.
       parameters:
-        - { "$ref": "#/components/parameters/slot-no" }
-        - { "$ref": "#/components/parameters/strict" }
+        - $ref: "#/components/parameters/slot-no"
+        - $ref: "#/components/parameters/strict"
       responses:
         200:
           description: OK
@@ -755,7 +827,7 @@ paths:
             "application/json;charset=utf-8":
               schema:
                 oneOf:
-                  - { "$ref": "#/components/schemas/Point" }
+                  - $ref: "#/components/schemas/Point"
                   - type: "null"
 
   /v1/health:
@@ -770,4 +842,5 @@ paths:
           description: OK
           content:
             "application/json;charset=utf-8":
-              schema: { "$ref": "#/components/schemas/Health" }
+              schema:
+                $ref: "#/components/schemas/Health"

--- a/kupo.cabal
+++ b/kupo.cabal
@@ -19,6 +19,7 @@ license:        MPL-2.0
 license-file:   LICENSE
 build-type:     Simple
 extra-source-files:
+    db/fiddle.sql
     db/v1.0.0-beta/001.sql
     db/v1.0.0/001.sql
     db/v1.0.0/002.sql
@@ -45,11 +46,11 @@ library
       Kupo.App.ChainSync
       Kupo.App.ChainSync.Direct
       Kupo.App.ChainSync.Ogmios
+      Kupo.App.Configuration
       Kupo.App.Health
       Kupo.App.Http
       Kupo.App.Http.HealthCheck
       Kupo.App.Mailbox
-      Kupo.Configuration
       Kupo.Control.MonadAsync
       Kupo.Control.MonadCatch
       Kupo.Control.MonadDatabase
@@ -61,6 +62,7 @@ library
       Kupo.Control.MonadTime
       Kupo.Data.Cardano
       Kupo.Data.ChainSync
+      Kupo.Data.Configuration
       Kupo.Data.Database
       Kupo.Data.Health
       Kupo.Data.Http.Default
@@ -69,6 +71,7 @@ library
       Kupo.Data.Http.GetCheckpointMode
       Kupo.Data.Http.Response
       Kupo.Data.Http.Status
+      Kupo.Data.Http.StatusFlag
       Kupo.Data.Ogmios
       Kupo.Data.Pattern
       Kupo.Options
@@ -231,9 +234,9 @@ test-suite unit
   type: exitcode-stdio-1.0
   main-is: Spec.hs
   other-modules:
+      Test.Kupo.App.ConfigurationSpec
       Test.Kupo.App.HttpSpec
       Test.Kupo.App.MailboxSpec
-      Test.Kupo.ConfigurationSpec
       Test.Kupo.Data.CardanoSpec
       Test.Kupo.Data.DatabaseSpec
       Test.Kupo.Data.Generators

--- a/kupo.cabal
+++ b/kupo.cabal
@@ -25,6 +25,7 @@ extra-source-files:
     db/v1.0.1/001.sql
     db/v2.0.0/001.sql
     db/v2.0.0/002.sql
+    db/v2.0.0/003.sql
 data-files:
     docs/openapi.yaml
 

--- a/src/Kupo.hs
+++ b/src/Kupo.hs
@@ -82,26 +82,10 @@ kupo Tracers{tracerChainSync, tracerConfiguration, tracerHttp, tracerDatabase} =
             , chainProducer
             , workDir
             , inputManagement
+            , longestRollback
             }
         } <- ask
 
-    -- 43200 slots = k/f slots
-    --
-    -- TODO: k and f should be pulled from the protocol parameters (e.g. via
-    -- local-state-query).
-    --
-    -- Otherwise, the current value may start to be insufficient if the values
-    -- of `k` or `f` change in the future. In practice,
-    --
-    -- (a) there's very little chance that it will change significantly;
-    -- (b) this kind of change are announced upfront days, if not weeks / months before
-    --
-    -- Arbitrarily larger values could be used to cope with future changes
-    -- since the only impact is on the 'checkpoints' table in the database. We
-    -- use this value to trim old checkpoints that are not needed for
-    -- re-establishing an intersection. Since checkpoints are small, storing
-    -- more is cheap.
-    let longestRollback = 43200
     let dbFile = case workDir of
             Dir dir  -> dir </> "kupo.sqlite3"
             InMemory -> ":memory:"

--- a/src/Kupo/App.hs
+++ b/src/Kupo/App.hs
@@ -8,28 +8,26 @@ module Kupo.App
     ( -- * ChainProducer
       withChainProducer
 
-      -- * Producer/Consumer
+      -- * Producer / Consumer / Gardener
     , producer
     , consumer
+    , gardener
     ) where
 
 import Kupo.Prelude
 
+import Control.Monad.Class.MonadTimer
+    ( MonadDelay (..) )
 import Kupo.App.ChainSync
     ( TraceChainSync (..) )
+import Kupo.App.Configuration
+    ( TraceConfiguration (..), parseNetworkParameters )
 import Kupo.App.Mailbox
     ( Mailbox, flushMailbox, newMailbox, putMailbox )
-import Kupo.Configuration
-    ( ChainProducer (..)
-    , InputManagement (..)
-    , NetworkParameters (..)
-    , TraceConfiguration (..)
-    , parseNetworkParameters
-    )
 import Kupo.Control.MonadCatch
     ( MonadCatch (..) )
 import Kupo.Control.MonadDatabase
-    ( Database (..), MonadDatabase (..) )
+    ( Database (..), MonadDatabase (DBTransaction), TraceDatabase (..) )
 import Kupo.Control.MonadLog
     ( MonadLog (..), Tracer )
 import Kupo.Control.MonadOuroboros
@@ -39,9 +37,24 @@ import Kupo.Control.MonadSTM
 import Kupo.Control.MonadThrow
     ( MonadThrow (..) )
 import Kupo.Data.Cardano
-    ( Block, IsBlock, Point, SlotNo (..), Tip, getPoint, getPointSlotNo )
+    ( Block
+    , IsBlock
+    , Point
+    , SlotNo (..)
+    , Tip
+    , distanceToTip
+    , getPoint
+    , getPointSlotNo
+    )
 import Kupo.Data.ChainSync
     ( ChainSyncHandler (..), IntersectionNotFoundException (..) )
+import Kupo.Data.Configuration
+    ( ChainProducer (..)
+    , Configuration (..)
+    , InputManagement (..)
+    , LongestRollback (..)
+    , NetworkParameters (..)
+    )
 import Kupo.Data.Database
     ( binaryDataToRow, pointToRow, resultToRow )
 import Kupo.Data.Pattern
@@ -113,7 +126,7 @@ mailboxSize :: Natural
 mailboxSize = 100
 
 --
--- Producer / Consumer
+-- Producer / Consumer / Gardener
 --
 
 producer
@@ -144,12 +157,13 @@ consumer
         )
     => Tracer IO TraceChainSync
     -> InputManagement
+    -> LongestRollback
     -> (Tip Block -> Maybe SlotNo -> m ())
     -> Mailbox m (Tip Block, block)
     -> TVar m [Pattern]
     -> Database m
-    -> m ()
-consumer tr inputManagement notifyTip mailbox patternsVar Database{..} = forever $ do
+    -> m Void
+consumer tr inputManagement longestRollback notifyTip mailbox patternsVar Database{..} = forever $ do
     (blks, patterns) <- atomically $ (,) <$> flushMailbox mailbox <*> readTVar patternsVar
     let (lastKnownTip, lastKnownBlk) = last blks
     let lastKnownPoint = getPoint lastKnownBlk
@@ -160,7 +174,7 @@ consumer tr inputManagement notifyTip mailbox patternsVar Database{..} = forever
     runTransaction $ do
         insertCheckpoints (foldr ((:) . pointToRow . getPoint . snd) [] blks)
         insertInputs newInputs
-        onSpentInputs spentInputs
+        onSpentInputs lastKnownTip lastKnownSlot spentInputs
         insertBinaryData bins
   where
     codecs = Codecs
@@ -170,8 +184,63 @@ consumer tr inputManagement notifyTip mailbox patternsVar Database{..} = forever
         , toBinaryData = binaryDataToRow
         }
 
+    unstableWindow = getLongestRollback longestRollback
+
     onSpentInputs = case inputManagement of
         MarkSpentInputs ->
-            void . Map.traverseWithKey markInputsByReference
+            \_ _ -> void . Map.traverseWithKey markInputsByReference
         RemoveSpentInputs ->
-            traverse_ deleteInputsByReference
+            \lastKnownTip lastKnownSlot ->
+                -- Only delete when safe (i.e. deep enough in the chain).
+                -- Otherwise, mark as 'spent' and leave the pruning to the
+                -- periodic 'gardener' / garbage-collector.
+                if distanceToTip lastKnownTip lastKnownSlot > unstableWindow then
+                    traverse_ deleteInputsByReference
+                else
+                    void . Map.traverseWithKey markInputsByReference
+
+-- | Periodically garbage collect the database from entries that aren't of
+-- interest. This is mainly the case for:
+--
+-- - spent inputs that are _definitely spent_
+-- - binary data stored in the database that isn't associated with any known input
+--
+-- Indeed, when kupo is set in 'RemoveSpentInputs' mode, it trims the database
+-- as inputs get spent. However, Cardano being a decentralized and only
+-- eventually immutable data-source. Indeed, the most recent part of the chain
+-- (i.e. last k blocks) _may change unpredictably. By removing 'spent inputs'
+-- too early, we may take the risk of removing an input which may be reinstatated
+-- later (because the chain forked and the transaction spending that input isn't
+-- included in that fork).
+--
+-- In brief, we can only delete inputs after `k` blocks (or `3*k/f` slots) have
+-- passed (since it is guaranteed to have `k` blocks in a `3*k/f` slot window).
+gardener
+    :: forall m.
+        ( MonadSTM m
+        , MonadLog m
+        , MonadDelay m
+        , Monad (DBTransaction m)
+        )
+    => Tracer IO TraceDatabase
+    -> Configuration
+    -> (forall a. (Database m -> m a) -> m a)
+    -> m Void
+gardener tr config withDatabase = forever $ do
+    threadDelay pruneThrottleDelay
+    logWith tr DatabaseBeginGarbageCollection
+    withDatabase $ \Database{..} -> do
+        (prunedInputs, prunedBinaryData) <- runImmediateTransaction $ do
+            let
+                pruneInputsWhenApplicable =
+                    case inputManagement of
+                        RemoveSpentInputs -> pruneInputs
+                        MarkSpentInputs -> pure 0
+             in
+                (,) <$> pruneInputsWhenApplicable <*> pruneBinaryData
+        logWith tr $ DatabaseExitGarbageCollection { prunedInputs, prunedBinaryData }
+  where
+    Configuration
+        { pruneThrottleDelay
+        , inputManagement
+        } = config

--- a/src/Kupo/App/ChainSync/Ogmios.hs
+++ b/src/Kupo/App/ChainSync/Ogmios.hs
@@ -61,9 +61,12 @@ connect
     -> IO ()
 connect ConnectionStatusToggle{toggleConnected} host port action =
     WS.runClientWith host port "/"
-        WS.defaultConnectionOptions
-        [("Sec-WebSocket-Protocol", "ogmios.v1:compact")]
-        (\ws -> toggleConnected >> action ws)
+        -- TODO: Try to negotiate compact mode v2 once available.
+        --
+        -- See [ogmios#237](https://github.com/CardanoSolutions/ogmios/issues/237)
+        --
+        -- [("Sec-WebSocket-Protocol", "ogmios.v1:compact")]
+        WS.defaultConnectionOptions [] (\ws -> toggleConnected >> action ws)
 
 data CannotResolveAddressException = CannotResolveAddress
     { host :: String

--- a/src/Kupo/App/Configuration.hs
+++ b/src/Kupo/App/Configuration.hs
@@ -2,31 +2,12 @@
 --  License, v. 2.0. If a copy of the MPL was not distributed with this
 --  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-{-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DuplicateRecordFields #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE RecordWildCards #-}
 
-{-# OPTIONS_GHC -fno-warn-orphans #-}
-
-module Kupo.Configuration
-    (
-    -- * Configuration
-      Configuration (..)
-    , WorkDir (..)
-    , InputManagement (..)
-    , ChainProducer (..)
-    , LongestRollback (..)
-
-    -- * NetworkParameters
-    , NetworkParameters (..)
-    , parseNetworkParameters
-
-    -- ** Parameters Components
-    , NetworkMagic (..)
-    , EpochSlots (..)
-    , SystemStart (..)
-    , mkSystemStart
+module Kupo.App.Configuration
+    ( -- * NetworkParameters
+      parseNetworkParameters
 
     -- * Application Setup
     , startOrResume
@@ -42,129 +23,31 @@ import Kupo.Prelude
 
 import Control.Monad.Trans.Except
     ( throwE, withExceptT )
-import Data.Aeson
-    ( (.:) )
 import Data.Aeson.Lens
     ( key, _String )
-import Data.Time.Clock.POSIX
-    ( posixSecondsToUTCTime )
-import Data.Time.Format.ISO8601
-    ( iso8601ParseM )
 import Kupo.Control.MonadDatabase
-    ( Database (..), LongestRollback (..) )
+    ( Database (..) )
 import Kupo.Control.MonadLog
     ( HasSeverityAnnotation (..), MonadLog (..), Severity (..), Tracer )
-import Kupo.Control.MonadOuroboros
-    ( EpochSlots (..), NetworkMagic (..) )
 import Kupo.Control.MonadSTM
     ( MonadSTM (..) )
 import Kupo.Control.MonadThrow
     ( MonadThrow (..) )
 import Kupo.Data.Cardano
     ( Block, Point (..), SlotNo (..), getPointSlotNo )
+import Kupo.Data.Configuration
+    ( Configuration (..), NetworkParameters (..) )
 import Kupo.Data.Database
     ( patternFromRow, patternToRow, pointFromRow )
 import Kupo.Data.Pattern
     ( Pattern (..), patternToText )
-import Ouroboros.Consensus.BlockchainTime.WallClock.Types
-    ( SystemStart (..) )
 import System.FilePath.Posix
     ( replaceFileName )
 
 import qualified Data.Aeson as Json
 import qualified Data.Yaml as Yaml
-import Kupo.Control.MonadTime
-    ( DiffTime )
 
--- | Application-level configuration.
-data Configuration = Configuration
-    { chainProducer :: !ChainProducer
-        -- ^ Where the data comes from: cardano-node vs ogmios
-    , workDir :: !WorkDir
-        -- ^ Where to store the data: in-memory vs specific location on-disk
-    , serverHost :: !String
-        -- ^ Hostname for the API HTTP server
-    , serverPort :: !Int
-        -- ^ Port for the API HTTP Server
-    , since :: !(Maybe (Point Block))
-        -- ^ Point from when a *new* synchronization should start
-    , patterns :: ![Pattern]
-        -- ^ List of address patterns to look for when synchronizing
-    , inputManagement :: !InputManagement
-        -- ^ Behavior to adopt towards spent inputs (prune or mark-and-leave)
-    , longestRollback :: !LongestRollback
-        -- ^ Number of slots before which data can be considered immutable
-    , pruneThrottleDelay :: !DiffTime
-        -- ^ Delay between each garbage-collection of database data
-    } deriving (Generic, Eq, Show)
 
--- | Where does kupo pulls its data from. Both 'cardano-node' and 'ogmios' are
--- equivalent in the capabilities and information they offer; a cardano-node
--- will have to be through a local connection (domain socket) whereas ogmios can
--- happen _over the wire_ on a remote server but is slower overall. So both have
--- trade-offs.
-data ChainProducer
-    = CardanoNode
-        { nodeSocket :: !FilePath
-        , nodeConfig :: !FilePath
-        }
-    | Ogmios
-        { ogmiosHost :: !String
-        , ogmiosPort :: !Int
-        }
-    deriving (Generic, Eq, Show)
-
--- | Database working directory. 'in-memory' runs the database in hot memory,
--- only suitable for non-permissive patterns or testing.
-data WorkDir
-    = Dir FilePath
-    | InMemory
-    deriving (Generic, Eq, Show)
-
--- | What to do with inputs that are spent. There are two options:
---
--- - 'Mark': keeps all spent inputs in the index, but marks them as spent or
--- unspent. Clients may then query filtered results based on their status.
---
--- - 'Remove': which deletes any spent inputs from the index, keeping it
--- concise.
---
--- There are use-cases for both behavior, hence why is is a user-configured
--- behavior. The default should be the less destructive one, which is 'Mark'.
-data InputManagement
-    = MarkSpentInputs
-    | RemoveSpentInputs
-    deriving (Generic, Eq, Show)
-
-data NetworkParameters = NetworkParameters
-    { networkMagic :: !NetworkMagic
-    , systemStart :: !SystemStart
-    , slotsPerEpoch :: !EpochSlots
-    } deriving stock (Generic, Eq, Show)
-      deriving anyclass (ToJSON)
-
-deriving newtype instance ToJSON EpochSlots
-deriving newtype instance ToJSON SystemStart
-deriving newtype instance ToJSON NetworkMagic
-
-instance FromJSON NetworkParameters where
-    parseJSON = Json.withObject "NetworkParameters" $ \obj -> do
-        nm <- obj .: "networkMagic"
-        ss <- obj .: "systemStart" >>= parseISO8601
-        k  <- obj .: "protocolConsts" >>= Json.withObject "protocolConst" (.: "k")
-        pure NetworkParameters
-            { networkMagic =
-                NetworkMagic (fromIntegral @Integer nm)
-            , systemStart =
-                SystemStart ss
-            , slotsPerEpoch  =
-                EpochSlots (fromIntegral @Integer $ 10 * k)
-            }
-      where
-        parseISO8601 (toString @Text -> str) =
-            case iso8601ParseM str of
-                Nothing -> fail "couldn't parse ISO-8601 date-time."
-                Just t  -> pure t
 
 parseNetworkParameters :: FilePath -> IO NetworkParameters
 parseNetworkParameters configFile = runOrDie $ do
@@ -191,13 +74,6 @@ parseNetworkParameters configFile = runOrDie $ do
 
     decodeYaml :: FromJSON a => FilePath -> ExceptT String IO a
     decodeYaml = withExceptT prettyParseException . ExceptT . Yaml.decodeFileEither
-
--- | Construct a 'SystemStart' from a number of seconds.
-mkSystemStart :: Int -> SystemStart
-mkSystemStart =
-    SystemStart . posixSecondsToUTCTime . toPicoResolution . toEnum
-  where
-    toPicoResolution = (*1000000000000)
 
 --
 -- Application Bootstrapping
@@ -230,14 +106,6 @@ startOrResume tr configuration Database{..} = do
                 , oldestCheckpoint
                 }
 
-    nSpent <- runTransaction countSpentInputs
-    case inputManagement of
-        RemoveSpentInputs | nSpent > 0 -> do
-            logWith tr errConflictingUtxoManagementOption
-            throwIO ConflictingOptionsException
-        _ ->
-            pure ()
-
     case (since, checkpoints) of
         (Nothing, []) -> do
             logWith tr errNoStartingPoint
@@ -254,7 +122,7 @@ startOrResume tr configuration Database{..} = do
             pure [pt]
 
   where
-    Configuration{since, inputManagement} = configuration
+    Configuration{since} = configuration
 
     errNoStartingPoint = ConfigurationInvalidOrMissingOption
         "No '--since' provided and no checkpoints found in the \
@@ -269,17 +137,6 @@ startOrResume tr configuration Database{..} = do
         \--since point? Please dispel the confusion by either choosing \
         \a different starting point (or none at all) or by using a \
         \fresh new database."
-
-    errConflictingUtxoManagementOption = ConfigurationInvalidOrMissingOption
-        "It appears that the application was restarted with a conflicting \
-        \behavior w.r.t. UTxO management. Indeed, `--prune-utxo` indicates \
-        \that inputs should be pruned from the database when spent. However \
-        \inputs marked as 'spent' were found in the database, which suggests \
-        \that it was first constructed without the flag `--prune-utxo`. \
-        \Continuing would lead to a inconsistent state and is therefore \
-        \prevented. \n\nShould you still want to proceed, make sure to first \
-        \prune all spent inputs from the database using the following \
-        \query: \n\n\t DELETE FROM inputs WHERE spent_at IS NOT NULL;"
 
 newPatternsCache
     :: forall m.

--- a/src/Kupo/Control/MonadAsync.hs
+++ b/src/Kupo/Control/MonadAsync.hs
@@ -4,7 +4,7 @@
 
 module Kupo.Control.MonadAsync
     ( MonadAsync (..)
-    , concurrently3
+    , concurrently4
     , forConcurrently_
     , mapConcurrently_
     ) where
@@ -12,5 +12,11 @@ module Kupo.Control.MonadAsync
 import Control.Monad.Class.MonadAsync
     ( MonadAsync (..), forConcurrently_, mapConcurrently_ )
 
-concurrently3 :: MonadAsync m => m a -> m b -> m c -> m ()
-concurrently3 a b c = concurrently_ a (concurrently_ b c)
+concurrently4 :: MonadAsync m => m a -> m b -> m c -> m d -> m ()
+concurrently4 a b c d =
+    concurrently_ a
+        ( concurrently_ b
+            ( concurrently_ c
+                d
+            )
+        )

--- a/src/Kupo/Control/MonadDatabase.hs
+++ b/src/Kupo/Control/MonadDatabase.hs
@@ -86,12 +86,16 @@ class (Monad m, Monad (DBTransaction m)) => MonadDatabase (m :: Type -> Type) wh
         -> (Database m -> m a)
         -> m a
 
-data ConnectionType = LongLived | ShortLived
-    deriving (Eq, Show)
-
+-- | A thin wrapper around the number of slots we consider to be the _longest
+-- rollback_. This impacts how long we have to keep data in the database before
+-- removing it, as well as how we create checkpoints when looking for chain
+-- intersection with the chain-producer.
 newtype LongestRollback = LongestRollback
     { getLongestRollback :: Word64
-    } deriving newtype (Integral, Real, Num, Enum, Ord, Eq)
+    } deriving newtype (Integral, Real, Num, Enum, Ord, Eq, Show)
+
+data ConnectionType = LongLived | ShortLived
+    deriving (Eq, Show)
 
 data Input = Input
     { outputReference :: ByteString

--- a/src/Kupo/Data/Cardano.hs
+++ b/src/Kupo/Data/Cardano.hs
@@ -78,6 +78,7 @@ module Kupo.Data.Cardano
     -- * DatumHash
     , DatumHash
     , datumHashFromText
+    , datumHashToText
     , datumHashFromBytes
     , unsafeDatumHashFromBytes
     , datumHashToJson
@@ -697,6 +698,12 @@ datumHashFromBytes bytes
         Just (unsafeDatumHashFromBytes bytes)
     | otherwise =
         Nothing
+
+datumHashToText
+    :: DatumHash
+    -> Text
+datumHashToText =
+    encodeBase16 . Ledger.originalBytes
 
 datumHashFromText
     :: Text

--- a/src/Kupo/Data/Cardano.hs
+++ b/src/Kupo/Data/Cardano.hs
@@ -77,12 +77,14 @@ module Kupo.Data.Cardano
 
     -- * DatumHash
     , DatumHash
+    , datumHashFromText
     , datumHashFromBytes
     , unsafeDatumHashFromBytes
     , datumHashToJson
 
     -- * BinaryData
     , BinaryData
+    , binaryDataToJson
     , binaryDataFromBytes
     , unsafeBinaryDataFromBytes
 
@@ -696,6 +698,14 @@ datumHashFromBytes bytes
     | otherwise =
         Nothing
 
+datumHashFromText
+    :: Text
+    -> Maybe DatumHash
+datumHashFromText str =
+    case datumHashFromBytes <$> decodeBase16 (encodeUtf8 str) of
+        Right (Just hash) -> Just hash
+        _ -> Nothing
+
 unsafeDatumHashFromBytes
     :: forall crypto.
         ( HasCallStack
@@ -719,6 +729,12 @@ datumHashToJson =
 
 type BinaryData =
     Ledger.BinaryData (BabbageEra StandardCrypto)
+
+binaryDataToJson
+    :: BinaryData
+    -> Json.Encoding
+binaryDataToJson =
+    Json.text . encodeBase16 . Ledger.originalBytes
 
 binaryDataFromBytes
     :: ByteString

--- a/src/Kupo/Data/Cardano.hs
+++ b/src/Kupo/Data/Cardano.hs
@@ -132,6 +132,7 @@ module Kupo.Data.Cardano
       -- * Tip
     , Tip (..)
     , getTipSlotNo
+    , distanceToTip
 
       -- * WithOrigin
     , WithOrigin (..)
@@ -949,6 +950,11 @@ getTipSlotNo tip =
     case Ouroboros.getTipSlotNo tip of
         Origin -> SlotNo 0
         At sl  -> sl
+
+distanceToTip :: Tip Block -> SlotNo -> Word64
+distanceToTip (getTipSlotNo -> SlotNo a) (SlotNo b)
+    | a > b = a - b
+    | otherwise = b - a
 
 -- Point
 

--- a/src/Kupo/Data/Configuration.hs
+++ b/src/Kupo/Data/Configuration.hs
@@ -1,0 +1,148 @@
+--  This Source Code Form is subject to the terms of the Mozilla Public
+--  License, v. 2.0. If a copy of the MPL was not distributed with this
+--  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Kupo.Data.Configuration
+    (
+    -- * Configuration
+      Configuration (..)
+    , WorkDir (..)
+    , InputManagement (..)
+    , ChainProducer (..)
+    , LongestRollback (..)
+
+    -- * NetworkParameters
+    , NetworkParameters (..)
+
+    -- ** Parameters Components
+    , NetworkMagic (..)
+    , EpochSlots (..)
+    , SystemStart (..)
+    , mkSystemStart
+    ) where
+
+import Kupo.Prelude
+
+import Data.Aeson
+    ( (.:) )
+import Data.Time.Clock.POSIX
+    ( posixSecondsToUTCTime )
+import Data.Time.Format.ISO8601
+    ( iso8601ParseM )
+import Kupo.Control.MonadDatabase
+    ( LongestRollback (..) )
+import Kupo.Control.MonadOuroboros
+    ( EpochSlots (..), NetworkMagic (..) )
+import Kupo.Control.MonadTime
+    ( DiffTime )
+import Kupo.Data.Cardano
+    ( Block, Point (..) )
+import Kupo.Data.Pattern
+    ( Pattern (..) )
+import Ouroboros.Consensus.BlockchainTime.WallClock.Types
+    ( SystemStart (..) )
+
+import qualified Data.Aeson as Json
+
+-- | Application-level configuration.
+data Configuration = Configuration
+    { chainProducer :: !ChainProducer
+        -- ^ Where the data comes from: cardano-node vs ogmios
+    , workDir :: !WorkDir
+        -- ^ Where to store the data: in-memory vs specific location on-disk
+    , serverHost :: !String
+        -- ^ Hostname for the API HTTP server
+    , serverPort :: !Int
+        -- ^ Port for the API HTTP Server
+    , since :: !(Maybe (Point Block))
+        -- ^ Point from when a *new* synchronization should start
+    , patterns :: ![Pattern]
+        -- ^ List of address patterns to look for when synchronizing
+    , inputManagement :: !InputManagement
+        -- ^ Behavior to adopt towards spent inputs (prune or mark-and-leave)
+    , longestRollback :: !LongestRollback
+        -- ^ Number of slots before which data can be considered immutable
+    , pruneThrottleDelay :: !DiffTime
+        -- ^ Delay between each garbage-collection of database data
+    } deriving (Generic, Eq, Show)
+
+-- | Where does kupo pulls its data from. Both 'cardano-node' and 'ogmios' are
+-- equivalent in the capabilities and information they offer; a cardano-node
+-- will have to be through a local connection (domain socket) whereas ogmios can
+-- happen _over the wire_ on a remote server but is slower overall. So both have
+-- trade-offs.
+data ChainProducer
+    = CardanoNode
+        { nodeSocket :: !FilePath
+        , nodeConfig :: !FilePath
+        }
+    | Ogmios
+        { ogmiosHost :: !String
+        , ogmiosPort :: !Int
+        }
+    deriving (Generic, Eq, Show)
+
+-- | Database working directory. 'in-memory' runs the database in hot memory,
+-- only suitable for non-permissive patterns or testing.
+data WorkDir
+    = Dir FilePath
+    | InMemory
+    deriving (Generic, Eq, Show)
+
+-- | What to do with inputs that are spent. There are two options:
+--
+-- - 'Mark': keeps all spent inputs in the index, but marks them as spent or
+-- unspent. Clients may then query filtered results based on their status.
+--
+-- - 'Remove': which deletes any spent inputs from the index, keeping it
+-- concise.
+--
+-- There are use-cases for both behavior, hence why is is a user-configured
+-- behavior. The default should be the less destructive one, which is 'Mark'.
+data InputManagement
+    = MarkSpentInputs
+    | RemoveSpentInputs
+    deriving (Generic, Eq, Show)
+
+data NetworkParameters = NetworkParameters
+    { networkMagic :: !NetworkMagic
+    , systemStart :: !SystemStart
+    , slotsPerEpoch :: !EpochSlots
+    } deriving stock (Generic, Eq, Show)
+      deriving anyclass (ToJSON)
+
+deriving newtype instance ToJSON EpochSlots
+deriving newtype instance ToJSON SystemStart
+deriving newtype instance ToJSON NetworkMagic
+
+instance FromJSON NetworkParameters where
+    parseJSON = Json.withObject "NetworkParameters" $ \obj -> do
+        nm <- obj .: "networkMagic"
+        ss <- obj .: "systemStart" >>= parseISO8601
+        k  <- obj .: "protocolConsts" >>= Json.withObject "protocolConst" (.: "k")
+        pure NetworkParameters
+            { networkMagic =
+                NetworkMagic (fromIntegral @Integer nm)
+            , systemStart =
+                SystemStart ss
+            , slotsPerEpoch  =
+                EpochSlots (fromIntegral @Integer $ 10 * k)
+            }
+      where
+        parseISO8601 (toString @Text -> str) =
+            case iso8601ParseM str of
+                Nothing -> fail "couldn't parse ISO-8601 date-time."
+                Just t  -> pure t
+
+-- | Construct a 'SystemStart' from a number of seconds.
+mkSystemStart :: Int -> SystemStart
+mkSystemStart =
+    SystemStart . posixSecondsToUTCTime . toPicoResolution . toEnum
+  where
+    toPicoResolution = (*1000000000000)

--- a/src/Kupo/Data/Database.hs
+++ b/src/Kupo/Data/Database.hs
@@ -26,7 +26,9 @@ module Kupo.Data.Database
       -- * Datum / BinaryData
     , datumToRow
     , datumFromRow
+    , datumHashToRow
     , binaryDataToRow
+    , binaryDataFromRow
 
       -- * Filtering
     , StatusFlag (..)
@@ -169,14 +171,26 @@ datumToRow = \case
     Ledger.Datum bin ->
         Just (binaryDataToRow (Ledger.hashBinaryData bin) bin)
 
+datumHashToRow
+    :: DatumHash
+    -> ByteString
+datumHashToRow =
+    serialize'
+
 binaryDataToRow
     :: DatumHash
     -> BinaryData
     -> DB.BinaryData
 binaryDataToRow hash bin = DB.BinaryData
-    { DB.binaryDataHash = serialize' hash
+    { DB.binaryDataHash = datumHashToRow hash
     , DB.binaryData = serialize' (Ledger.binaryDataToData bin)
     }
+
+binaryDataFromRow
+    :: DB.BinaryData
+    -> BinaryData
+binaryDataFromRow =
+    unsafeBinaryDataFromBytes . DB.binaryData
 
 --
 -- Pattern

--- a/src/Kupo/Data/Http/Error.hs
+++ b/src/Kupo/Data/Http/Error.hs
@@ -75,6 +75,14 @@ invalidSlotNo =
                  \number. That is, an non-negative integer."
         }
 
+malformedDatumHash :: Response
+malformedDatumHash =
+    responseJson status400 Default.headers $ HttpError
+        { hint = "The given path parameter isn't a well-formed datum hash digest. \
+                 \This must be a blake2b-256 hash digest encoded in base16 (\
+                 \thus, 64 characters once encoded)."
+        }
+
 notFound :: Response
 notFound =
     responseJson status404 Default.headers $ HttpError

--- a/src/Kupo/Data/Http/StatusFlag.hs
+++ b/src/Kupo/Data/Http/StatusFlag.hs
@@ -1,0 +1,60 @@
+--  This Source Code Form is subject to the terms of the Mozilla Public
+--  License, v. 2.0. If a copy of the MPL was not distributed with this
+--  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+module Kupo.Data.Http.StatusFlag
+    ( StatusFlag (..)
+    , isNoStatusFlag
+    , hideTransientGhostInputs
+    , statusFlagFromQueryParams
+    ) where
+
+import Kupo.Prelude
+
+import Kupo.Data.Configuration
+    ( InputManagement (..) )
+import qualified Network.HTTP.Types.URI as Http
+
+data StatusFlag
+    = NoStatusFlag
+    | OnlySpent
+    | OnlyUnspent
+
+isNoStatusFlag :: StatusFlag -> Bool
+isNoStatusFlag = \case
+    NoStatusFlag -> True
+    _ -> False
+
+-- | Because the chain is only eventually immutable, kupo does not remove recent
+-- data right away. Thus, it is possible that, even though the configuration
+-- asked to prune all spent inputs, some remains present in the database and
+-- marked as 'spent'. Yet, this is an implementation detail and we therefore
+-- gives clients the illusion that there's no 'spent' inputs in the database if
+-- they're running with the 'RemoveSpentInputs' option enabled.
+hideTransientGhostInputs
+    :: InputManagement
+    -> StatusFlag
+    -> StatusFlag
+hideTransientGhostInputs inputManagement statusFlag =
+    case inputManagement of
+        MarkSpentInputs ->
+           statusFlag
+        RemoveSpentInputs ->
+            OnlyUnspent
+
+statusFlagFromQueryParams
+    :: Http.Query
+    -> Maybe StatusFlag
+statusFlagFromQueryParams = \case
+    ("spent", val):rest -> do
+        guard (isNothing val)
+        guardM (isNoStatusFlag <$> statusFlagFromQueryParams rest)
+        Just OnlySpent
+    ("unspent", val):rest -> do
+        guard (isNothing val)
+        guardM (isNoStatusFlag <$> statusFlagFromQueryParams rest)
+        Just OnlyUnspent
+    [] ->
+        Just NoStatusFlag
+    _:rest ->
+        statusFlagFromQueryParams rest

--- a/src/Kupo/Data/Pattern.hs
+++ b/src/Kupo/Data/Pattern.hs
@@ -384,7 +384,7 @@ matchBlock Codecs{..} patterns blk =
 
         , concatMap (flip (mapMaybeOutputs @block) tx . match pt) patterns ++ produced
 
-        , Map.foldMapWithKey (\k -> pure . toBinaryData k) (datums @block tx) ++ witnessed
+        , Map.foldMapWithKey (\k -> pure . toBinaryData k) (witnessedDatums @block tx) ++ witnessed
         )
 
     match

--- a/src/Kupo/Data/Pattern.hs
+++ b/src/Kupo/Data/Pattern.hs
@@ -37,7 +37,7 @@ import Kupo.Data.Cardano
     , Blake2b_224
     , Blake2b_256
     , Block
-    , DatumHash
+    , Datum
     , Input
     , IsBlock (..)
     , Output
@@ -52,13 +52,14 @@ import Kupo.Data.Cardano
     , digest
     , digestSize
     , getAddress
-    , getDatumHash
+    , getDatum
     , getDelegationPartBytes
     , getOutputIndex
     , getPaymentPartBytes
     , getPointSlotNo
     , getTransactionId
     , getValue
+    , hashDatum
     , headerHashToJson
     , isBootstrap
     , outputIndexToJson
@@ -298,7 +299,7 @@ data Result = Result
     { outputReference :: OutputReference
     , address :: Address
     , value :: Value
-    , datumHash :: Maybe DatumHash
+    , datum :: Datum
     , createdAt :: Point Block
     , spentAt :: Maybe (Point Block)
     } deriving (Show, Eq)
@@ -316,7 +317,7 @@ resultToJson Result{..} = Json.pairs $ mconcat
     , Json.pair "value"
         (valueToJson value)
     , Json.pair "datum_hash"
-        (maybe Json.null_ datumHashToJson datumHash)
+        (maybe Json.null_ datumHashToJson (hashDatum datum))
     , Json.pair "created_at"
         (Json.pairs $ mconcat
             [ Json.pair "slot_no"
@@ -384,7 +385,7 @@ matchBlock toResult toSlotNo toInput patterns blk =
             { outputReference
             , address = getAddress out
             , value = getValue out
-            , datumHash = getDatumHash out
+            , datum = getDatum out
             , createdAt = pt
             , spentAt = Nothing
             }

--- a/src/Kupo/Options.hs
+++ b/src/Kupo/Options.hs
@@ -89,6 +89,8 @@ parserInfo = info (helper <*> parser) $ mempty
                     <*> optional sinceOption
                     <*> many patternOption
                     <*> inputManagementOption
+                    <*> pure 43200 -- TODO: should be pulled from genesis parameters
+                    <*> pure 60 -- TOOD: make configurable through CLI
                 )
             <*> (tracersOption <|> Tracers
                     <$> fmap Const (logLevelOption "http-server")

--- a/src/Kupo/Options.hs
+++ b/src/Kupo/Options.hs
@@ -31,21 +31,22 @@ import Data.Char
     ( toUpper )
 import Kupo.App.ChainSync
     ( TraceChainSync )
+import Kupo.App.Configuration
+    ( TraceConfiguration )
 import Kupo.App.Http
     ( TraceHttpServer )
-import Kupo.Configuration
-    ( ChainProducer (..)
-    , Configuration (..)
-    , InputManagement (..)
-    , TraceConfiguration
-    , WorkDir (..)
-    )
 import Kupo.Control.MonadDatabase
     ( TraceDatabase )
 import Kupo.Control.MonadLog
     ( Severity (..), Tracer, TracerDefinition (..), TracerHKD, defaultTracers )
 import Kupo.Data.Cardano
     ( Block, Point (..), pointFromText )
+import Kupo.Data.Configuration
+    ( ChainProducer (..)
+    , Configuration (..)
+    , InputManagement (..)
+    , WorkDir (..)
+    )
 import Kupo.Data.Pattern
     ( Pattern, patternFromText )
 import Options.Applicative.Help.Pretty
@@ -90,7 +91,7 @@ parserInfo = info (helper <*> parser) $ mempty
                     <*> many patternOption
                     <*> inputManagementOption
                     <*> pure 43200 -- TODO: should be pulled from genesis parameters
-                    <*> pure 60 -- TOOD: make configurable through CLI
+                    <*> pure 120 -- TOOD: make configurable through CLI
                 )
             <*> (tracersOption <|> Tracers
                     <$> fmap Const (logLevelOption "http-server")

--- a/test/Test/Kupo/App/ConfigurationSpec.hs
+++ b/test/Test/Kupo/App/ConfigurationSpec.hs
@@ -6,18 +6,19 @@
 -- because it's test code and, having it fail would be instantly caught.
 {-# OPTIONS_GHC -fno-warn-incomplete-uni-patterns #-}
 
-module Test.Kupo.ConfigurationSpec
+module Test.Kupo.App.ConfigurationSpec
     ( spec
     ) where
 
 import Kupo.Prelude
 
-import Kupo.Configuration
+import Kupo.App.Configuration
+    ( parseNetworkParameters )
+import Kupo.Data.Configuration
     ( EpochSlots (..)
     , NetworkMagic (..)
     , NetworkParameters (..)
     , mkSystemStart
-    , parseNetworkParameters
     )
 import Test.Hspec
     ( Spec, context, parallel, shouldBe, specify )

--- a/test/Test/Kupo/App/HttpSpec.hs
+++ b/test/Test/Kupo/App/HttpSpec.hs
@@ -288,6 +288,8 @@ databaseStub = Database
         \_ -> liftIO (abs <$> generate arbitrary)
     , listPatterns = \mk -> lift $ do
         fmap (mk . patternToRow) <$> generate (listOf1 genPattern)
+    , insertBinaryData =
+        \_ -> return ()
     , rollbackTo =
         \_ -> return Nothing
     , runTransaction = \r ->

--- a/test/Test/Kupo/App/HttpSpec.hs
+++ b/test/Test/Kupo/App/HttpSpec.hs
@@ -41,9 +41,11 @@ import Kupo.Control.MonadDatabase
 import Kupo.Control.MonadSTM
     ( MonadSTM (..) )
 import Kupo.Data.Database
-    ( patternToRow, pointToRow, resultToRow )
+    ( binaryDataToRow, patternToRow, pointToRow, resultToRow )
 import Kupo.Data.Health
     ( Health )
+import Kupo.Data.Pattern
+    ( Pattern )
 import Network.HTTP.Media.MediaType
     ( MediaType, (//), (/:) )
 import Network.HTTP.Media.RenderHeader
@@ -55,9 +57,15 @@ import Test.Hspec
 import Test.Hspec.QuickCheck
     ( prop )
 import Test.Kupo.Data.Generators
-    ( genHealth, genNonGenesisPoint, genPattern, genResult )
+    ( genBinaryData
+    , genDatumHash
+    , genHealth
+    , genNonGenesisPoint
+    , genPattern
+    , genResult
+    )
 import Test.QuickCheck
-    ( arbitrary, counterexample, elements, generate, listOf1 )
+    ( arbitrary, counterexample, elements, generate, listOf1, oneof )
 import Test.QuickCheck.Monadic
     ( assert, monadicIO, monitor, run )
 
@@ -65,8 +73,6 @@ import qualified Data.Aeson as Json
 import qualified Data.OpenApi as OpenApi
 import qualified Data.Text as T
 import qualified Data.Yaml as Yaml
-import Kupo.Data.Pattern
-    ( Pattern )
 import qualified Network.HTTP.Types.Header as Http
 import qualified Network.HTTP.Types.Status as Http
 import qualified Network.Wai as Wai
@@ -156,6 +162,14 @@ spec = do
             res & Wai.assertStatus (Http.statusCode Http.status200)
             res & assertJson schema
 
+        session specification get "/v1/datums/{datum-hash}" $ \assertJson endpoint -> do
+            let schema = findSchema specification endpoint Http.status200
+            res <- Wai.request $ Wai.defaultRequest
+                { Wai.requestMethod = "GET" }
+                & flip Wai.setPath "/v1/datums/309706b92ad8340cd6a5d31bf9d2e682fdab9fc8865ee3de14e09dedf9b1b635"
+            res & Wai.assertStatus (Http.statusCode Http.status200)
+            res & assertJson schema
+
         session specification get "/v1/patterns" $ \assertJson endpoint -> do
             let schema = findSchema specification endpoint Http.status200
             res <- Wai.request $ Wai.setPath Wai.defaultRequest "/v1/patterns"
@@ -240,6 +254,14 @@ spec = do
                 & Wai.assertStatus (Http.statusCode Http.status400)
             resBadRequest
                 & Wai.assertHeader Http.hContentType (renderHeader mediaTypeJson)
+
+        session' "🕱 GET /v1/datums/{datum-hash}" $ do
+            resBadRequest <- Wai.request $ Wai.defaultRequest
+                & flip Wai.setPath "/v1/datums/foo"
+            resBadRequest
+                & Wai.assertStatus (Http.statusCode Http.status400)
+            resBadRequest
+                & Wai.assertHeader Http.hContentType (renderHeader mediaTypeJson)
   where
     noWildcard :: [Pattern]
     noWildcard =
@@ -290,6 +312,11 @@ databaseStub = Database
         fmap (mk . patternToRow) <$> generate (listOf1 genPattern)
     , insertBinaryData =
         \_ -> return ()
+    , getBinaryData =
+        \_ mk -> liftIO $ generate $ do
+            binaryDataHash <- genDatumHash
+            binaryData <- oneof [pure Nothing, Just <$> genBinaryData]
+            pure $ mk . binaryDataToRow binaryDataHash <$> binaryData
     , rollbackTo =
         \_ -> return Nothing
     , runTransaction = \r ->

--- a/test/Test/Kupo/Data/CardanoSpec.hs
+++ b/test/Test/Kupo/Data/CardanoSpec.hs
@@ -13,19 +13,23 @@ import Kupo.Prelude
 import Kupo.Data.Cardano
     ( pattern GenesisPoint
     , SlotNo (..)
+    , datumHashFromText
     , headerHashFromText
     , pointFromText
     , slotNoFromText
     )
+import Kupo.Data.Cardano
+    ( datumHashToText )
 import Test.Hspec
     ( Spec, context, parallel, shouldBe, specify )
 import Test.Hspec.QuickCheck
     ( prop )
+import Test.Kupo.Data.Generators
+    ( genDatumHash )
 import Test.QuickCheck
     ( Gen, arbitrary, forAll, property, vectorOf, (===) )
 
 import qualified Data.ByteString as BS
-
 spec :: Spec
 spec = parallel $ do
     context "pointFromText" $ do
@@ -41,6 +45,11 @@ spec = parallel $ do
     context "slotNoFromText" $ do
         prop "forall (s :: Word64). slotNoFromText (show s) === Just{}" $ \(s :: Word64) ->
             slotNoFromText (show s) === Just (SlotNo s)
+
+    context "datumHashFromText ↔ datumHashToText" $ do
+        prop "forall (x :: DatumHash). datumHashFromText (datumHashToText x) === x" $
+            forAll genDatumHash $ \x ->
+                datumHashFromText (datumHashToText x) === Just x
 
     context "headerHashFromText" $ do
         prop "forall (bs :: ByteString). bs .size 32 => headerHashFromText (base16 bs) === Just{}" $

--- a/test/Test/Kupo/Data/Generators.hs
+++ b/test/Test/Kupo/Data/Generators.hs
@@ -10,6 +10,7 @@ import Kupo.Prelude
 
 import Kupo.Data.Cardano
     ( Address
+    , BinaryData
     , Blake2b_224
     , Blake2b_256
     , Block
@@ -86,18 +87,20 @@ genDatum :: Gen Datum
 genDatum = frequency
     [ (1, pure noDatum)
     , (5, fromDatumHash <$> genDatumHash)
-    , (5, fromBinaryData <$> elements
-        [ "d87980"
-            & unsafeDecodeBase16
-            & unsafeBinaryDataFromBytes
-        , "0e"
-            & unsafeDecodeBase16
-            & unsafeBinaryDataFromBytes
-        , "9f43666f6fd905239fa0ffff"
-            & unsafeDecodeBase16
-            & unsafeBinaryDataFromBytes
-        ]
-      )
+    , (5, fromBinaryData <$> genBinaryData)
+    ]
+
+genBinaryData :: Gen BinaryData
+genBinaryData = elements
+    [ "d87980"
+        & unsafeDecodeBase16
+        & unsafeBinaryDataFromBytes
+    , "0e"
+        & unsafeDecodeBase16
+        & unsafeBinaryDataFromBytes
+    , "9f43666f6fd905239fa0ffff"
+        & unsafeDecodeBase16
+        & unsafeBinaryDataFromBytes
     ]
 
 genHeaderHash :: Gen (HeaderHash Block)

--- a/test/Test/Kupo/Fixture.hs
+++ b/test/Test/Kupo/Fixture.hs
@@ -11,7 +11,14 @@ import Kupo.Prelude
 import Kupo.Control.MonadDatabase
     ( Checkpoint (..) )
 import Kupo.Data.Cardano
-    ( Block, pattern GenesisPoint, Point )
+    ( BinaryData
+    , Block
+    , DatumHash
+    , pattern GenesisPoint
+    , Point
+    , unsafeBinaryDataFromBytes
+    , unsafeDatumHashFromBytes
+    )
 import Kupo.Data.Database
     ( pointFromRow )
 
@@ -104,3 +111,12 @@ eraBoundaries =
     , ("Alonzo", lastMaryPoint)
     , ("Babbage", lastAlonzoPoint)
     ]
+
+someDatumHash :: DatumHash
+someDatumHash = unsafeDatumHashFromBytes $ unsafeDecodeBase16
+    "0118AD9F6A79B8DFAB690DCB66EA6244A382891525789B405F7AF7DC61635578"
+
+-- pre-image of 'someDatumHash'
+someDatum :: BinaryData
+someDatum = unsafeBinaryDataFromBytes $ unsafeDecodeBase16
+    "D8799F581C1C0BFECF6C69E1D0D540897ECC0B66844B5FB5030FB488672A47F6FB8040401A001E8480D87980FF"

--- a/test/Test/Kupo/OptionsSpec.hs
+++ b/test/Test/Kupo/OptionsSpec.hs
@@ -14,14 +14,14 @@ import Kupo.Prelude
 
 import Data.List
     ( isInfixOf )
-import Kupo.Configuration
+import Kupo.Control.MonadLog
+    ( Severity (..), TracerDefinition (..), defaultTracers )
+import Kupo.Data.Configuration
     ( ChainProducer (..)
     , Configuration (..)
     , InputManagement (..)
     , WorkDir (..)
     )
-import Kupo.Control.MonadLog
-    ( Severity (..), TracerDefinition (..), defaultTracers )
 import Kupo.Data.Pattern
     ( MatchBootstrap (..), Pattern (..) )
 import Kupo.Options

--- a/test/Test/KupoSpec.hs
+++ b/test/Test/KupoSpec.hs
@@ -332,6 +332,8 @@ skippableContext prefix skippableSpec = do
                     , since = Nothing
                     , patterns = []
                     , inputManagement = MarkSpentInputs
+                    , longestRollback = 43200
+                    , pruneThrottleDelay = 60
                     }
             context cardanoNode $ around (withTempDirectory ref defaultCfg) $
                 skippableSpec manager
@@ -350,6 +352,8 @@ skippableContext prefix skippableSpec = do
                     , since = Nothing
                     , patterns = []
                     , inputManagement = MarkSpentInputs
+                    , longestRollback = 43200
+                    , pruneThrottleDelay = 60
                     }
             context ogmios $ around (withTempDirectory ref defaultCfg) $
                 skippableSpec manager
@@ -447,7 +451,6 @@ newHttpClient manager cfg = HttpClient
 
     waitUntilM :: IO Bool -> IO ()
     waitUntilM predicate = do
-        checkpoints <- listCheckpoints
         predicate >>= \case
             True ->
                 return ()

--- a/test/Test/KupoSpec.hs
+++ b/test/Test/KupoSpec.hs
@@ -20,16 +20,10 @@ import Data.List
     ( maximum )
 import Kupo
     ( kupo, newEnvironment, runWith, version, withTracers )
+import Kupo.App.Configuration
+    ( ConflictingOptionsException, NoStartingPointException )
 import Kupo.App.Http
     ( healthCheck )
-import Kupo.Configuration
-    ( ChainProducer (..)
-    , Configuration (..)
-    , ConflictingOptionsException
-    , InputManagement (..)
-    , NoStartingPointException
-    , WorkDir (..)
-    )
 import Kupo.Control.MonadAsync
     ( race_ )
 import Kupo.Control.MonadDelay
@@ -52,6 +46,12 @@ import Kupo.Data.Cardano
     )
 import Kupo.Data.ChainSync
     ( IntersectionNotFoundException )
+import Kupo.Data.Configuration
+    ( ChainProducer (..)
+    , Configuration (..)
+    , InputManagement (..)
+    , WorkDir (..)
+    )
 import Kupo.Data.Http.GetCheckpointMode
     ( GetCheckpointMode (..) )
 import Kupo.Data.Pattern
@@ -184,16 +184,6 @@ spec = skippableContext "End-to-end" $ \manager -> do
                 { workDir = Dir tmp
                 , since = Just somePoint
                 , patterns = [MatchAny IncludingBootstrap]
-                }
-            shouldThrowTimeout @ConflictingOptionsException 1 (kupo tr `runWith` env)
-          )
-
-        ( do -- Can't restart with different utxo management behavior
-            env <- newEnvironment $ cfg
-                { workDir = Dir tmp
-                , since = Just somePoint
-                , patterns = [MatchAny OnlyShelley]
-                , inputManagement = RemoveSpentInputs
                 }
             shouldThrowTimeout @ConflictingOptionsException 1 (kupo tr `runWith` env)
           )


### PR DESCRIPTION
Fixes #21 

- :round_pushpin: **Store full datum from output, in a separate table.**
    The external API remains however unchanged for now and the server will still return datum hashes from the JSON response.

- :round_pushpin: **Store datum witnessed in transactions.**
    The strategy is store all datums, and have a throttled worker which
  prune unmatched datums every minutes or so to keep the database clean.

  Note that, the `Result` type has been modified to now always carry a
  `Datum`; which can be either nothing, a hash or a full resolved datum.

  This is used interchangeably when matching results in outputs as well
  as when fetching results from the database. However, at this stage,
  fetching from the database will always yield either a hash or nothing
  (because we don't perform the joint query by default to resolve a
  datum) EVEN IF the original result had an inline datum. Conversely,
  when an original result had only a hash, if resolved, it'll instead
  carry a full resolved datum.

  This makes it convenient to manipulate results and to build an API
  around it. Note that the JSON instance still always returns datum
  hashes (when present), but will also return resolved datum when asked.

- :round_pushpin: **Add datum to Ogmios 'PartialTransaction' representation.**
  
- :round_pushpin: **Implement API logic to retrieve datums on-demand.**
    Datum are specified by hash digest and can only be retrieved one at a
  time, which should be sufficient for _most anticipated use-cases_.

  If needs be, we can also implement batch fetching of datums matching
  certain patterns or, can provide a flag to resolve when querying
  address matches.

- :round_pushpin: **Store raw binary-data hashes in database**
    Do not store them as CBOR-encoded binary strings.

  (a) It makes the database easier to explore and inspect
  (b) It's shorter (2 bytes, but still shorter) and slightly faster to do

- :round_pushpin: **Write e2e scenario waiting for a real testnet datum**
    Adding a utility function to poll the API until a certain knwon datum is seen in a transaction. Ideally, we would need slightly more complex scenarios where we can check for datums coming from witnesses and datums coming from inlined outputs. Will do eventually.

- :round_pushpin: **Fix Ogmios integration, remove compact mode.**
    We need access to the witness! Because that's where we can find the datum.

- :round_pushpin: **Update CHANGELOG with recent additions.**
  
- :round_pushpin: **Enhance configuration with longest rollback and prune throttle delay**
    As well as a few comments. In the end, having those hard-coded parameter floating around isn't good. So we better make them part of the configuration even if not actually user-configurable, they still make for application-level configuration.

- :round_pushpin: **Implement inputs & binary-data garbage collector**
    This is really killing two birds one stone. On the one hand:

  - Kupo "needs" to cleanup the database from unused binary-data. This is
    because the strategy for fetching binary-data is relatively 'dumb':
    It stores everything it sees. Though, in practice, only a fraction of
    that is relevant to end-users. Since the binary store is a
    hash-based content index, it is not a big issue to keep data around
    and carbage collect it later. What to garbage collect is defined by
    data being linked to a known input. If there's no relationship, it's
    removed.

  On the other hand, there's a bugfix:

  - Kupo has an option `--prune-utxo` to remove inputs from the database
    as they're spent. But, removing utxo _as soon as_ they are observed
    spent is risky (or more exactly, a source bug!). Indeed, data is
    only eventually immutable on the chain, and this also applies to
    data that is _consumed_. Thus, a UTxO that is spent on a certain
    fork may still exist on a different fork. Upon rollback, ite
    therefore rolls back the state of the whole database but, it doesn't
    necessarily get to re-observe inputs that it has just deleted (could
    have been created way back). And it ends up in a state where, some
    inputs that should be in the database, isn't.

  This commits tries to fix both issue in a rather simple and elegant
  way. It introduces a "garbage collector" for the database. In fact, Kupo
  already has logic to mark inputs for deletion (that's the default
  behavior when `--prune-utxo` isn't specified). That's half a garbage
  collector already! All that remains is a thread which comes and
  periodically collect results that are 'ripe' (i.e. inputs that are
  more than k blocks in the past).

  Note that, to not over-complexify things, kupo always look at the node
  tip and the database tip and consider inputs to be old enough if they
  are far enough from those tips. In practice, this is _less optimal_
  than looking at the network tip which is supposedly further in the
  future (or at minima, equal to the node's tip when fully synced).
  Thus, when the node isn't fully synced, it may keep data in the
  database for longer than necessary. This saves us from having to track
  the network tip and make things even more complex. The beauty of this
  solution is that the database can fully do pruning on its own to
  maintain its own integrity (since it already stores checkpoints, so it
  has a notion of 'tip').

  Regarding the binary data (i.e. datums), it suffices to remove datums
  that aren't associated to inputs. Since kupo only removes inputs when
  they are truly gone (and have a probability of 0 to magically
  re-appear in a fork), then the binary data are also transitively in
  sync with the tip and consistent.

  Finally, I had to remove a e2e scenario and a configuration guard
  which was ensuring that the database not contain any "spent"
  inputs if passed '--prune-utxo'. This is no longer true and while I
  could tweak / complexify the query to only count inputs mark 'spent'
  and old enough etc... Since this was mostly a UX safeguard to prevent
  people shooting themselves in the foot, it's okay-ish to remove. At
  least for now. Hopefully.

  Fixes #44

---

TODO:

- [x] Periodically remove un-matched datums from the database. 
- [ ] Additional e2e scenario highlighting an inline-datum. 
