### PR TITLE
Rollback to given point when inserting patterns

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,5 +2,5 @@
 	path = config
 	url = git@github.com:input-output-hk/cardano-configurations.git
 [submodule "test/ogmios"]
-	path = test/ogmios
+	path = test/vectors/ogmios
 	url = git@github.com:cardanosolutions/ogmios.git

--- a/.stylish-haskell.yaml
+++ b/.stylish-haskell.yaml
@@ -46,13 +46,15 @@ columns: 80 # Should match .editorconfig
 steps:
   - imports:
       align: none
-      empty_list_align: inherit
       list_align: new_line
-      list_padding: 4
       long_list_align: new_line_multiline
+      empty_list_align: inherit
+      list_padding: 4
       pad_module_names: false
       separate_lists: true
       space_surround: true
+      post_qualify: true
+      group_imports: false
 
   - language_pragmas:
       align: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 #### Added
 
-- [📌 #28](https://github.com/CardanoSolutions/kupo/issues/28) - Support for the Babbage's era, including inline-datums & reference scripts. 
+- [📌 #28](https://github.com/CardanoSolutions/kupo/issues/28) - Support for synchronization through the Babbage's era, including capturing inline-datums & reference scripts. 
 
 - [📌 #17](https://github.com/CardanoSolutions/kupo/issues/20) - New command-line flag: `--prune-utxo`. When set, inputs that are spent on-chain will be removed from the index. Once-synced, 
   the index therefore only contain the current ledger UTxO set. When not set, spent inputs are kept in the index but are now marked accordingly to record if and when they've spent.
@@ -61,6 +61,8 @@ increase the time needed for collecting garbage. Optimal value depends on your u
 - [📌 #17](https://github.com/CardanoSolutions/kupo/issues/20) - The `slot_no` and `header_hash` fields are no longer accessible on top-level match result objects. Instead, they're now nested under a `created_at` field, analogous to how `spent_at` has been introduced. 
 
 - [📌 #24](https://github.com/CardanoSolutions/kupo/issues/24) - Fixed a bug where listing checkpoints would sometimes return duplicate entries. 
+
+- [📌 #39](https://github.com/CardanoSolutions/kupo/issues/39) - Inserting a new pattern (i.e. `PUT v1/patterns/{pattern-fragment}`) now requires to provide a rollback point, to which the server will rollback and start synchronizing again. The old behavior can be recovered by simply passing the most recent checkpoint as a rollback point. Note that, you may add an already existing pattern if you only need, for some reason, to rollback the indexer to some previous point in time. See the [📖 API Reference](https://cardanosolutions.github.io/kupo/#operation/putPattern1Ary) for details.
 
 - Fixed a bug where the server would systematically reject any request to dynamically remove a pattern (because deemed overlapping with existing patterns). 
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <hr/>
 
-**Kupo** is fast, lightweight and configurable **chain-index** for the Cardano blockchain. It synchronizes data from the blockchain according to **patterns** matching addresses present in transaction outputs and builds a **lookup table** from **matches** to their associated **output references**, **values** and **datum hashes**.
+**Kupo** is fast, lightweight and configurable **chain-index** for the Cardano blockchain. It synchronizes data from the blockchain according to **patterns** matching addresses present in transaction outputs and builds a **lookup table** from matches to their associated **output references**, **values**, **datums** and **scripts**. 
 
 <p align="center">
   <img src="./docs/architecture-diagram.png" />

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -422,6 +422,63 @@ components:
           type: integer
           minimum: 0
 
+    ForcedRollback:
+      type: object
+      additionalProperties: false
+      required:
+        - rollback_to
+      properties:
+        rollback_to:
+          type: object
+          required:
+            - slot_no
+          description: |
+            A mandatory point to rollback the synchronization to.
+            Note that the synchronization will therefore begin starting from the point **immediately after** the provided point!
+
+            > <sup><strong>NOTE (1)</strong></sup> <br/>
+            > If you need to query ancestors from any given known point, see [GET /v1/checkpoints/{slot-no}](http://localhost:8000/#operation/getCheckpointBySlot)
+
+            > <sup><strong>NOTE (2)</strong></sup> <br/>
+            > The `header_hash` is **optional**! However if provided, Kupo will check that it rolls back exactly to the specified point by comparing header hashes.
+          properties:
+            slot_no:
+              $ref: "#/components/schemas/SlotNo"
+            header_hash:
+              $ref: "#/components/schemas/HeaderHash"
+        limit:
+          type: string
+          description: |
+            Specify the server behavior when rolling back out of the _safe
+            zone_. As mentioned in the user manual, when running Kupo with
+            `--prune-utxo` enabled, the server gets rid of spent UTxOs, but it
+            only does so after a certain time. That time is exactly `129600`
+            slots (or 36h on Mainnet/Testnet). This is because the core
+            protocol cannot roll back further than this particular depth and it
+            is the point after which it is 100% safe to remove data from the
+            database.
+
+            However, this endpoint allows you to break this invariant and
+            rollback to points that are even older in the past. As a
+            consequence, while syncing, the index may be in a somewhat
+            inconsistent state because some inputs spent at a later time may
+            not have been recovered during the rollback. This may be surprising
+            if you're expecting to see and query those transient inputs after
+            rolling back.
+
+            By default, you won't be allowed to rollback beyond the safe zone.
+            If, however, you know what you're doing, you're kindly asked to
+            pass `unsafe_allow_beyond_safe_zone` as a token of acknowledgment.
+            Passing `within_safe_zone` has no effects other than the default.
+
+            Note that, once synchronized again, the index will always be in the
+            expected state and problems reflecting reality only occurs _while
+            catching up_, after a long rollback.
+          default: within_safe_zone
+          enum:
+          - unsafe_allow_beyond_safe_zone
+          - within_safe_zone
+
     HeaderHash:
       type: string
       description: A blake2b-256 hash digest of a block header.
@@ -600,6 +657,36 @@ components:
               description: Absolute slot number of the current tip of the node.
 
   parameters:
+    asset-name:
+      name: asset_name
+      in: query
+      required: false
+      allowEmptyValue: false
+      schema:
+        type: string
+        contentEncoding: base16
+        pattern: ^[a-f0-9]{2,64}$
+      description: |
+        Filter matches to only include results whose value carries assets associated with the given asset id (i.e. (`policy_id`, `asset_name`)).
+
+        This filter can only be used **in conjunction with `policy_id`.**
+      example:
+        08661220099e
+
+    datum-hash:
+      name: datum_hash
+      in: path
+      required: true
+      schema:
+        type: string
+        contentEncoding: base16
+        minLength: 64
+        maxLength: 64
+        pattern: ^[a-f0-9]{64}$
+        example: 309706b92ad8340cd6a5d31bf9d2e682fdab9fc8865ee3de14e09dedf9b1b635
+      description:
+        A datum blake2b-256 hash digest.
+
     pattern-fragment:
       name: pattern_fragment
       in: path
@@ -611,30 +698,6 @@ components:
           - $ref: "#/components/schemas/Credential"
       description: |
         A pattern fragment (i.e. a wildcard, an address or a credential). See [Pattern](#section/Pattern) for more details.
-
-    slot-no:
-      name: slot_no
-      in: path
-      required: true
-      schema:
-        type: integer
-        minimum: 0
-
-    spent:
-      name: spent
-      in: query
-      required: false
-      allowEmptyValue: true
-      description: |
-        A query flag (i.e. `?spent`) to filter matches by status, to get only 'spent' matches.  Note that, when running kupo with `--prune-utxo`, this will always return an empty list of results.
-
-    unspent:
-      name: unspent
-      in: query
-      required: false
-      allowEmptyValue: true
-      description: |
-        A query flag (i.e. `?unspent`) filter matches by status, to get only 'unspent' matches.
 
     policy-id:
       name: policy_id
@@ -652,44 +715,6 @@ components:
       example:
         1220099e5e430475c219518179efc7e6c8289db028904834025d5b086
 
-    asset-name:
-      name: asset_name
-      in: query
-      required: false
-      allowEmptyValue: false
-      schema:
-        type: string
-        contentEncoding: base16
-        pattern: ^[a-f0-9]{2,64}$
-      description: |
-        Filter matches to only include results whose value carries assets associated with the given asset id (i.e. (`policy_id`, `asset_name`)).
-
-        This filter can only be used **in conjunction with `policy_id`.**
-      example:
-        08661220099e
-
-    strict:
-      name: strict
-      in: query
-      required: false
-      allowEmptyValue: true
-      description: |
-        A query flag (i.e. `?strict`) to only look for checkpoints that strictly match the provided slot. The behavior otherwise is to look for the largest nearest slot smaller or equal to the one provided.
-
-    datum-hash:
-      name: datum_hash
-      in: path
-      required: true
-      schema:
-        type: string
-        contentEncoding: base16
-        minLength: 64
-        maxLength: 64
-        pattern: ^[a-f0-9]{64}$
-        example: 309706b92ad8340cd6a5d31bf9d2e682fdab9fc8865ee3de14e09dedf9b1b635
-      description:
-        A datum blake2b-256 hash digest.
-
     script-hash:
       name: script_hash
       in: path
@@ -703,6 +728,38 @@ components:
         example: 309706b92ad8340cd6a5d31bf9d2e682fdab9fc8865ee3de14e09ded
       description:
         A script blake2b-224 hash digest of a script.
+
+    slot-no:
+      name: slot_no
+      in: path
+      required: true
+      schema:
+        type: integer
+        minimum: 0
+
+    spent:
+      name: spent
+      in: query
+      required: false
+      allowEmptyValue: true
+      description: |
+        A query flag (i.e. `?spent`) to filter matches by status, to get only 'spent' matches.  Note that, when running kupo with `--prune-utxo`, this will always return an empty list of results.
+
+    strict:
+      name: strict
+      in: query
+      required: false
+      allowEmptyValue: true
+      description: |
+        A query flag (i.e. `?strict`) to only look for checkpoints that strictly match the provided slot. The behavior otherwise is to look for the largest nearest slot smaller or equal to the one provided.
+
+    unspent:
+      name: unspent
+      in: query
+      required: false
+      allowEmptyValue: true
+      description: |
+        A query flag (i.e. `?unspent`) filter matches by status, to get only 'unspent' matches.
 
 tags:
   - name: Matches
@@ -949,6 +1006,11 @@ paths:
         Only new blocks will be matched against the pattern.
       parameters:
         - $ref: "#/components/parameters/pattern-fragment"
+      requestBody:
+        content:
+          "application/json;charset=utf-8":
+            schema:
+              $ref: "#/components/schemas/ForcedRollback"
       responses:
         200:
           description: OK

--- a/kupo.cabal
+++ b/kupo.cabal
@@ -65,6 +65,7 @@ library
       Kupo.Data.Http.Default
       Kupo.Data.Http.Error
       Kupo.Data.Http.FilterMatchesBy
+      Kupo.Data.Http.ForcedRollback
       Kupo.Data.Http.GetCheckpointMode
       Kupo.Data.Http.Response
       Kupo.Data.Http.Status

--- a/kupo.cabal
+++ b/kupo.cabal
@@ -243,6 +243,7 @@ test-suite unit
       Test.Kupo.Data.DatabaseSpec
       Test.Kupo.Data.Generators
       Test.Kupo.Data.Http.FilterMatchesBySpec
+      Test.Kupo.Data.Http.ForcedRollbackSpec
       Test.Kupo.Data.OgmiosSpec
       Test.Kupo.Data.Pattern.Fixture
       Test.Kupo.Data.PatternSpec

--- a/src/Kupo/App/Http.hs
+++ b/src/Kupo/App/Http.hs
@@ -30,10 +30,12 @@ import Kupo.Control.MonadSTM
     ( MonadSTM (..) )
 import Kupo.Data.Cardano
     ( DatumHash
+    , Point
     , ScriptHash
     , SlotNo (..)
     , binaryDataToJson
     , datumHashFromText
+    , distanceToSlot
     , getPointSlotNo
     , hasAssetId
     , hasPolicyId
@@ -43,6 +45,10 @@ import Kupo.Data.Cardano
     , slotNoFromText
     , slotNoToText
     )
+import Kupo.Data.ChainSync
+    ( ForcedRollbackHandler (..) )
+import Kupo.Data.Configuration
+    ( LongestRollback (..) )
 import Kupo.Data.Database
     ( applyStatusFlag
     , binaryDataFromRow
@@ -58,6 +64,8 @@ import Kupo.Data.Health
     ( Health (..) )
 import Kupo.Data.Http.FilterMatchesBy
     ( FilterMatchesBy (..), filterMatchesBy )
+import Kupo.Data.Http.ForcedRollback
+    ( ForcedRollback (..), ForcedRollbackLimit (..), decodeForcedRollback )
 import Kupo.Data.Http.GetCheckpointMode
     ( GetCheckpointMode (..), getCheckpointModeFromQuery )
 import Kupo.Data.Http.Response
@@ -82,15 +90,18 @@ import Network.HTTP.Types.Status
 import Network.Wai
     ( Application
     , Middleware
+    , Request
     , Response
     , pathInfo
     , queryString
     , requestMethod
     , responseStatus
+    , strictRequestBody
     )
 
 import qualified Data.Aeson as Json
 import qualified Data.Aeson.Encoding as Json
+import qualified Data.Aeson.Types as Json
 import qualified Kupo.Data.Http.Default as Default
 import qualified Kupo.Data.Http.Error as Errors
 import qualified Network.HTTP.Types.Header as Http
@@ -104,15 +115,16 @@ import qualified Network.Wai.Handler.Warp as Warp
 httpServer
     :: Tracer IO TraceHttpServer
     -> (forall a. (Database IO -> IO a) -> IO a)
+    -> (Point -> ForcedRollbackHandler IO -> IO ())
     -> TVar IO [Pattern]
     -> IO Health
     -> String
     -> Int
     -> IO ()
-httpServer tr withDatabase patternsVar readHealth host port =
+httpServer tr withDatabase forceRollback patternsVar readHealth host port =
     Warp.runSettings settings
         $ tracerMiddleware tr
-        $ app withDatabase patternsVar readHealth
+        $ app withDatabase forceRollback patternsVar readHealth
   where
     settings = Warp.defaultSettings
         & Warp.setPort port
@@ -126,10 +138,11 @@ httpServer tr withDatabase patternsVar readHealth host port =
 
 app
     :: (forall a. (Database IO -> IO a) -> IO a)
+    -> (Point -> ForcedRollbackHandler IO -> IO ())
     -> TVar IO [Pattern]
     -> IO Health
     -> Application
-app withDatabase patternsVar readHealth req send =
+app withDatabase forceRollback patternsVar readHealth req send =
     case pathInfo req of
         ("v1" : "health" : args) ->
             routeHealth (requestMethod req, args)
@@ -239,12 +252,16 @@ app withDatabase patternsVar readHealth req send =
                         <*> pure (patternFromPath args)
                         <*> readTVarIO patternsVar
             send res
-        ("PUT", args) ->
+        ("PUT", args) -> do
+            pointOrSlotNo <- requestBodyJson decodeForcedRollback req
             withDatabase $ \db -> do
                 headers <- responseHeaders readHealth
                 send =<< handlePutPattern
                             headers
+                            readHealth
+                            forceRollback
                             patternsVar
+                            pointOrSlotNo
                             (patternFromPath args)
                             db
         ("DELETE", args) ->
@@ -453,23 +470,72 @@ handleDeletePattern headers patternsVar query Database{..} = do
 
 handlePutPattern
     :: [Http.Header]
+    -> IO Health
+    -> (Point -> ForcedRollbackHandler IO -> IO ())
     -> TVar IO [Pattern]
+    -> Maybe ForcedRollback
     -> Maybe Text
     -> Database IO
     -> IO Response
-handlePutPattern headers patternsVar query Database{..} = do
-    case query >>= patternFromText of
-        Nothing ->
+handlePutPattern headers readHealth forceRollback patternsVar mPointOrSlot query Database{..} = do
+    mPoint <- traverse
+        (\ForcedRollback{since, limit} -> (, limit) <$> resolvePointOrSlot since)
+        mPointOrSlot
+
+    case (query >>= patternFromText, mPoint) of
+        (Nothing, _) ->
             pure Errors.invalidPattern
-        Just p  -> do
-            runReadWriteTransaction $ insertPatterns [patternToRow p]
-            patterns <- atomically $ do
-                modifyTVar' patternsVar (nub . (p :))
-                readTVar patternsVar
-            pure $ responseJsonEncoding status200 headers $
-                Json.list
-                    (Json.text . patternToText)
-                    patterns
+        (_, Nothing) ->
+            pure Errors.malformedPoint
+        (_, Just (Nothing, _)) ->
+            pure Errors.nonExistingPoint
+        (Just p, Just (Just point, lim)) -> do
+            tip <- mostRecentNodeTip <$> readHealth
+            let d = distanceToSlot <$> tip <*> pure (getPointSlotNo point)
+            case ((LongestRollback <$> d) > Just longestRollback, lim) of
+                (True, OnlyAllowRollbackWithinSafeZone) ->
+                    pure Errors.unsafeRollbackBeyondSafeZone
+                _ ->
+                    putPatternAt p point
+  where
+    resolvePointOrSlot :: Either SlotNo Point -> IO (Maybe Point)
+    resolvePointOrSlot = \case
+        Right pt -> do
+            let successor = unSlotNo $ succ $ getPointSlotNo pt
+            pts <- runReadOnlyTransaction $ listAncestorsDesc successor 1 pointFromRow
+            return $ case pts of
+                [pt'] | pt == pt' ->
+                    Just pt
+                _ ->
+                    Nothing
+
+        Left sl -> do
+            let successor = unSlotNo (succ sl)
+            pts <- runReadOnlyTransaction $ listAncestorsDesc successor 1 pointFromRow
+            return $ case pts of
+                [pt] | sl == getPointSlotNo pt ->
+                    Just pt
+                _ ->
+                    Nothing
+
+    putPatternAt :: Pattern -> Point -> IO Response
+    putPatternAt p point = do
+        response <- newEmptyTMVarIO
+        forceRollback point $ ForcedRollbackHandler
+            { onSuccess = do
+                runReadWriteTransaction $ insertPatterns [patternToRow p]
+                patterns <- atomically $ do
+                    modifyTVar' patternsVar (nub . (p :))
+                    readTVar patternsVar
+                atomically $ putTMVar response $ responseJsonEncoding status200 headers $
+                    Json.list
+                        (Json.text . patternToText)
+                        patterns
+
+            , onFailure = do
+                atomically (putTMVar response Errors.failedToRollback)
+            }
+        atomically (takeTMVar response)
 
 --
 -- Helpers
@@ -486,6 +552,16 @@ responseHeaders readHealth =
     toHeaders slot =
         ("X-Most-Recent-Checkpoint", encodeUtf8 $ slotNoToText $ fromMaybe 0 slot)
         : Default.headers
+
+requestBodyJson
+    :: (Json.Value -> Json.Parser a)
+    -> Request
+    -> IO (Maybe a)
+requestBodyJson parser req = do
+    bytes <- strictRequestBody req
+    case Json.parse parser <$> Json.decodeStrict' (toStrict bytes) of
+        Just (Json.Success a) -> return (Just a)
+        _ -> return Nothing
 
 --
 -- Tracer

--- a/src/Kupo/Control/MonadDelay.hs
+++ b/src/Kupo/Control/MonadDelay.hs
@@ -11,7 +11,9 @@ import Kupo.Prelude
 
 import Control.Monad.Class.MonadTimer
     ( MonadDelay (..) )
+import Kupo.Control.MonadTime
+    ( DiffTime )
 
-foreverCalmly :: (MonadDelay m) => m a -> m a
+foreverCalmly :: (MonadDelay m) => m DiffTime -> m Void
 foreverCalmly a = do
-    let a' = a *> threadDelay 5 *> a' in a'
+    let a' = a >>= threadDelay >> a' in a'

--- a/src/Kupo/Data/Cardano.hs
+++ b/src/Kupo/Data/Cardano.hs
@@ -280,8 +280,8 @@ import qualified Cardano.Ledger.Block as Ledger
 import qualified Cardano.Ledger.Coin as Ledger
 import qualified Cardano.Ledger.Core as Ledger.Core
 import qualified Cardano.Ledger.Credential as Ledger
-import qualified Cardano.Ledger.Era as Ledger.Era
 import qualified Cardano.Ledger.Era as Ledger
+import qualified Cardano.Ledger.Era as Ledger.Era
 import qualified Cardano.Ledger.Hashes as Ledger
 import qualified Cardano.Ledger.Keys as Ledger
 import qualified Cardano.Ledger.Mary.Value as Ledger
@@ -289,8 +289,8 @@ import qualified Cardano.Ledger.SafeHash as Ledger
 import qualified Cardano.Ledger.Shelley.BlockChain as Ledger.Shelley
 import qualified Cardano.Ledger.Shelley.Tx as Ledger.Shelley
 import qualified Cardano.Ledger.ShelleyMA.AuxiliaryData as Ledger.MaryAllegra
-import qualified Cardano.Ledger.ShelleyMA.Timelocks as Ledger.MaryAllegra
 import qualified Cardano.Ledger.ShelleyMA.Timelocks as Ledger
+import qualified Cardano.Ledger.ShelleyMA.Timelocks as Ledger.MaryAllegra
 import qualified Cardano.Ledger.ShelleyMA.TxBody as Ledger.MaryAllegra
 import qualified Cardano.Ledger.TxIn as Ledger
 import qualified Codec.CBOR.Read as Cbor

--- a/src/Kupo/Data/Cardano.hs
+++ b/src/Kupo/Data/Cardano.hs
@@ -171,6 +171,7 @@ module Kupo.Data.Cardano
     , pattern BlockPoint
     , pointFromText
     , pointToJson
+    , pointSlot
     , getPointSlotNo
     , getPointHeaderHash
     , unsafeGetPointHeaderHash

--- a/src/Kupo/Data/Cardano.hs
+++ b/src/Kupo/Data/Cardano.hs
@@ -1415,6 +1415,7 @@ slotNoFromText :: Text -> Maybe SlotNo
 slotNoFromText txt = do
     (slotNo, remSlotNo) <- either (const Nothing) Just (T.decimal txt)
     guard (T.null remSlotNo)
+    guard (slotNo < maxBound `div` 2 - 1)
     pure (SlotNo slotNo)
 
 slotNoToText :: SlotNo -> Text

--- a/src/Kupo/Data/ChainSync.hs
+++ b/src/Kupo/Data/ChainSync.hs
@@ -3,7 +3,8 @@
 --  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 module Kupo.Data.ChainSync
-    ( IntersectionNotFoundException (..)
+    ( ForcedRollbackHandler (..)
+    , IntersectionNotFoundException (..)
     ) where
 
 import Kupo.Prelude
@@ -11,12 +12,23 @@ import Kupo.Prelude
 import Kupo.Data.Cardano
     ( SlotNo, WithOrigin (..) )
 
+data ForcedRollbackHandler (m :: Type -> Type) = ForcedRollbackHandler
+    { onSuccess :: m ()
+    , onFailure :: m ()
+    }
+
 -- | Exception thrown when creating a chain-sync client from an invalid list of
 -- points.
-data IntersectionNotFoundException = IntersectionNotFound
-    { requestedPoints :: [WithOrigin SlotNo]
-        -- ^ Provided points for intersection.
-    , tip :: WithOrigin SlotNo
-        -- ^ Current known tip of the chain.
-    } deriving (Show)
+data IntersectionNotFoundException
+    = IntersectionNotFound
+        { requestedPoints :: [WithOrigin SlotNo]
+            -- ^ Provided points for intersection.
+        , tip :: WithOrigin SlotNo
+            -- ^ Current known tip of the chain.
+        }
+    | ForcedIntersectionNotFound
+        { point :: WithOrigin SlotNo
+            -- ^ Forced intersection point
+        }
+    deriving (Show)
 instance Exception IntersectionNotFoundException

--- a/src/Kupo/Data/Http/ForcedRollback.hs
+++ b/src/Kupo/Data/Http/ForcedRollback.hs
@@ -1,0 +1,59 @@
+--  This Source Code Form is subject to the terms of the Mozilla Public
+--  License, v. 2.0. If a copy of the MPL was not distributed with this
+--  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+module Kupo.Data.Http.ForcedRollback
+    ( ForcedRollback (..)
+    , decodeForcedRollback
+    , ForcedRollbackLimit (..)
+    ) where
+
+import Kupo.Prelude
+
+import Data.Aeson
+    ( (.!=), (.:), (.:?) )
+import Kupo.Data.Cardano
+    ( Point, SlotNo (..), pointFromText, slotNoFromText )
+
+import qualified Data.Aeson as Json
+import qualified Data.Aeson.Types as Json
+
+data ForcedRollback = ForcedRollback
+    { since :: Either SlotNo Point
+    , limit :: ForcedRollbackLimit
+    } deriving (Generic, Show)
+
+data ForcedRollbackLimit
+    = UnsafeAllowRollbackBeyondSafeZone
+    | OnlyAllowRollbackWithinSafeZone
+    deriving (Generic, Show)
+
+decodeForcedRollback :: Json.Value -> Json.Parser ForcedRollback
+decodeForcedRollback =
+    Json.withObject "ForcedRollback" $ \o -> do
+        since <- (o .: "rollback_to") >>= decodePointOrSlotNo
+        limit <- ((o .:? "limit") >>= traverse decodeForcedRollbackLimit) .!= OnlyAllowRollbackWithinSafeZone
+        pure $ ForcedRollback { since, limit }
+  where
+    decodeForcedRollbackLimit =
+        Json.withText "ForcedRollbackLimit" $ \case
+            "unsafe_allow_beyond_safe_zone" ->
+                pure UnsafeAllowRollbackBeyondSafeZone
+            "within_safe_zone" ->
+                pure OnlyAllowRollbackWithinSafeZone
+            _otherwise ->
+                fail "Invalid limit. Must be either of 'unsafe_allow_beyond_safe_zone' or 'within_safe_zone'."
+
+    decodePointOrSlotNo =
+        Json.withObject "PointOrSlotNo" $ \o -> do
+            (slotNo :: Word) <- o .: "slot_no"
+            mHeaderHash <- o .:? "header_hash"
+            case mHeaderHash of
+                Nothing ->
+                    case slotNoFromText (show slotNo) of
+                        Nothing -> fail "decodePointOrSlotNo(SlotNo)"
+                        Just sl -> pure (Left sl)
+                Just headerHash ->
+                    case pointFromText (show slotNo <> "." <> headerHash) of
+                        Nothing -> fail "decodePointOrSlotNo(Point)"
+                        Just pt -> pure (Right pt)

--- a/src/Kupo/Data/Http/ForcedRollback.hs
+++ b/src/Kupo/Data/Http/ForcedRollback.hs
@@ -3,9 +3,14 @@
 --  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 module Kupo.Data.Http.ForcedRollback
-    ( ForcedRollback (..)
+    ( -- * ForcedRollback
+      ForcedRollback (..)
+    , forcedRollbackToJson
     , decodeForcedRollback
+      -- ** ForcedRollbackLimit
     , ForcedRollbackLimit (..)
+    , forcedRollbackLimitToJson
+    , decodeForcedRollbackLimit
     ) where
 
 import Kupo.Prelude
@@ -13,20 +18,30 @@ import Kupo.Prelude
 import Data.Aeson
     ( (.!=), (.:), (.:?) )
 import Kupo.Data.Cardano
-    ( Point, SlotNo (..), pointFromText, slotNoFromText )
+    ( Point
+    , SlotNo (..)
+    , pointFromText
+    , pointToJson
+    , slotNoFromText
+    , slotNoToJson
+    )
 
 import qualified Data.Aeson as Json
+import qualified Data.Aeson.Encoding as Json
 import qualified Data.Aeson.Types as Json
 
 data ForcedRollback = ForcedRollback
     { since :: Either SlotNo Point
     , limit :: ForcedRollbackLimit
-    } deriving (Generic, Show)
+    } deriving (Generic, Show, Eq)
 
-data ForcedRollbackLimit
-    = UnsafeAllowRollbackBeyondSafeZone
-    | OnlyAllowRollbackWithinSafeZone
-    deriving (Generic, Show)
+forcedRollbackToJson :: ForcedRollback -> Json.Encoding
+forcedRollbackToJson ForcedRollback{since,limit} = Json.pairs $ mconcat
+    [ Json.pair "rollback_to" (either singletonSlotNo pointToJson since)
+    , Json.pair "limit" (forcedRollbackLimitToJson limit)
+    ]
+  where
+    singletonSlotNo = Json.pairs . Json.pair "slot_no" . slotNoToJson
 
 decodeForcedRollback :: Json.Value -> Json.Parser ForcedRollback
 decodeForcedRollback =
@@ -35,15 +50,6 @@ decodeForcedRollback =
         limit <- ((o .:? "limit") >>= traverse decodeForcedRollbackLimit) .!= OnlyAllowRollbackWithinSafeZone
         pure $ ForcedRollback { since, limit }
   where
-    decodeForcedRollbackLimit =
-        Json.withText "ForcedRollbackLimit" $ \case
-            "unsafe_allow_beyond_safe_zone" ->
-                pure UnsafeAllowRollbackBeyondSafeZone
-            "within_safe_zone" ->
-                pure OnlyAllowRollbackWithinSafeZone
-            _otherwise ->
-                fail "Invalid limit. Must be either of 'unsafe_allow_beyond_safe_zone' or 'within_safe_zone'."
-
     decodePointOrSlotNo =
         Json.withObject "PointOrSlotNo" $ \o -> do
             (slotNo :: Word) <- o .: "slot_no"
@@ -57,3 +63,27 @@ decodeForcedRollback =
                     case pointFromText (show slotNo <> "." <> headerHash) of
                         Nothing -> fail "decodePointOrSlotNo(Point)"
                         Just pt -> pure (Right pt)
+
+-- ** ForcedRollbackLimit
+
+data ForcedRollbackLimit
+    = UnsafeAllowRollbackBeyondSafeZone
+    | OnlyAllowRollbackWithinSafeZone
+    deriving (Generic, Show, Eq)
+
+forcedRollbackLimitToJson :: ForcedRollbackLimit -> Json.Encoding
+forcedRollbackLimitToJson = \case
+    UnsafeAllowRollbackBeyondSafeZone ->
+        Json.text "unsafe_allow_beyond_safe_zone"
+    OnlyAllowRollbackWithinSafeZone ->
+        Json.text "within_safe_zone"
+
+decodeForcedRollbackLimit :: Json.Value -> Json.Parser ForcedRollbackLimit
+decodeForcedRollbackLimit =
+    Json.withText "ForcedRollbackLimit" $ \case
+        "unsafe_allow_beyond_safe_zone" ->
+            pure UnsafeAllowRollbackBeyondSafeZone
+        "within_safe_zone" ->
+            pure OnlyAllowRollbackWithinSafeZone
+        _otherwise ->
+            fail "Invalid limit. Must be either of 'unsafe_allow_beyond_safe_zone' or 'within_safe_zone'."

--- a/src/Kupo/Data/Ogmios.hs
+++ b/src/Kupo/Data/Ogmios.hs
@@ -66,7 +66,6 @@ import Kupo.Data.Cardano
     , scriptHashFromText
     , slotNoToJson
     , transactionIdFromHash
-    , transactionIdFromHash
     , unsafeMakeSafeHash
     , unsafeValueFromList
     , withReferences

--- a/src/Kupo/Data/Ogmios.hs
+++ b/src/Kupo/Data/Ogmios.hs
@@ -70,8 +70,6 @@ import Kupo.Data.Cardano
     , unsafeValueFromList
     , withReferences
     )
-import Kupo.Data.ChainSync
-    ( IntersectionNotFoundException (..) )
 import Kupo.Data.PartialBlock
     ( PartialBlock (..), PartialTransaction (..) )
 import Kupo.Data.Pattern
@@ -80,8 +78,6 @@ import Ouroboros.Consensus.Cardano.Block
     ( CardanoEras )
 import Ouroboros.Consensus.HardFork.Combinator
     ( OneEraHash (..) )
-import Ouroboros.Network.Block
-    ( pointSlot )
 
 import qualified Data.Aeson.Encoding as Json
 import qualified Data.Aeson.Key as Key
@@ -130,10 +126,10 @@ encodePoint = \case
 -- Decoders
 
 decodeFindIntersectResponse
-    :: [Point]
+    :: (WithOrigin SlotNo -> e)
     -> Json.Value
-    -> Json.Parser (Either IntersectionNotFoundException ())
-decodeFindIntersectResponse (fmap pointSlot -> requestedPoints) json =
+    -> Json.Parser (Either e ())
+decodeFindIntersectResponse wrapException json =
     decodeIntersectionFound json <|> decodeIntersectionNotFound json
   where
     decodeIntersectionFound = Json.withObject "FindIntersectResponse" $ \o -> do
@@ -142,7 +138,7 @@ decodeFindIntersectResponse (fmap pointSlot -> requestedPoints) json =
 
     decodeIntersectionNotFound = Json.withObject "FindIntersectResponse" $ \o -> do
         tip <- o .: "result" >>= (.: "IntersectionNotFound") >>= (.: "tip") >>= decodeSlotNoOrOrigin
-        return (Left IntersectionNotFound{requestedPoints, tip})
+        return (Left (wrapException tip))
 
 decodeRequestNextResponse
     :: Json.Value

--- a/src/Kupo/Data/Pattern.hs
+++ b/src/Kupo/Data/Pattern.hs
@@ -310,7 +310,7 @@ data Result = Result
     , datum :: Datum
     , scriptReference :: ScriptReference
     , createdAt :: Point
-    , spentAt :: Maybe (Point)
+    , spentAt :: Maybe Point
     } deriving (Show, Eq)
 
 resultToJson

--- a/src/Kupo/Prelude.hs
+++ b/src/Kupo/Prelude.hs
@@ -34,6 +34,9 @@ module Kupo.Prelude
     , decodeFull'
     , unsafeDeserialize'
 
+      -- * JSON
+    , eitherDecodeJson
+
       -- * System
     , hijackSigTerm
     , ConnectionStatusToggle (..)
@@ -44,6 +47,8 @@ module Kupo.Prelude
 
 import Cardano.Binary
     ( decodeFull', serialize', unsafeDeserialize' )
+import Control.Arrow
+    ( left )
 import Control.Lens
     ( Lens', at, (^?), (^?!) )
 import Data.Aeson
@@ -108,6 +113,10 @@ import System.Posix.Signals
 
 import qualified Data.Aeson as Json
 import qualified Data.Aeson.Encoding as Json
+import qualified Data.Aeson.Internal as Json
+import qualified Data.Aeson.Parser as Json
+import qualified Data.Aeson.Parser.Internal as Json
+import qualified Data.Aeson.Types as Json
 import qualified Data.ByteString.Base58 as Base58
 
 data ConnectionStatusToggle m = ConnectionStatusToggle
@@ -158,3 +167,10 @@ defaultGenericToEncoding =
 -- elements.
 nubOn :: Eq b => (a -> b) -> [a] -> [a]
 nubOn b = nubBy (on (==) b)
+
+eitherDecodeJson
+    :: (Json.Value -> Json.Parser a)
+    -> LByteString
+    -> Either String a
+eitherDecodeJson decoder =
+    left snd . Json.eitherDecodeWith Json.jsonEOF (Json.iparse decoder)

--- a/stack.yaml
+++ b/stack.yaml
@@ -5,3 +5,9 @@ compiler: ghc-8.10.7 # Simply for reference, already inferred from the resolver.
 packages:
 - .
 - modules/websockets-json
+
+# Uncomment compile with profiling enabled.
+#
+# ghc-options:
+#   plutus-core:
+#     -fexternal-interpreter

--- a/test/Test/Kupo/App/Http/Client.hs
+++ b/test/Test/Kupo/App/Http/Client.hs
@@ -2,8 +2,6 @@
 --  License, v. 2.0. If a copy of the MPL was not distributed with this
 --  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-{-# LANGUAGE PatternSynonyms #-}
-
 module Test.Kupo.App.Http.Client where
 
 import Kupo.Prelude
@@ -26,7 +24,6 @@ import Kupo.Data.Cardano
     , Blake2b_256
     , Datum
     , DatumHash
-    , pattern GenesisPoint
     , OutputReference
     , Point
     , Script
@@ -262,20 +259,13 @@ decodeOutputReference o = mkOutputReference
     <*> o .: "output_index"
 
 decodePoint :: Json.Value -> Json.Parser Point
-decodePoint v = decodePointSlot v <|> decodeGenesisPoint v
-  where
-    decodeGenesisPoint =
-        Json.withText "GenesisPoint" $ \t -> do
-            guard (t == "origin")
-            pure GenesisPoint
-
-    decodePointSlot =
-        Json.withObject "Point" $ \o -> do
-            (slotNo :: Word) <- o .: "slot_no"
-            headerHash <- o .: "header_hash"
-            case pointFromText (show slotNo <> "." <> headerHash) of
-                Nothing -> fail "decodePoint"
-                Just pt -> pure pt
+decodePoint =
+    Json.withObject "Point" $ \o -> do
+        (slotNo :: Word) <- o .: "slot_no"
+        headerHash <- o .: "header_hash"
+        case pointFromText (show slotNo <> "." <> headerHash) of
+            Nothing -> fail "decodePoint"
+            Just pt -> pure pt
 
 decodeAddress
     :: Text

--- a/test/Test/Kupo/AppSpec.hs
+++ b/test/Test/Kupo/AppSpec.hs
@@ -96,6 +96,7 @@ import Test.Kupo.Data.Generators
     , genDatumHash
     , genHeaderHash
     , genInputManagement
+    , genNonGenesisPoint
     , genOutput
     , genOutputReference
     , genScript
@@ -253,7 +254,7 @@ instance Show (Event r) where
 
 data Response (r :: Type -> Type)
     = Unit ()
-    | Checkpoint Point
+    | Checkpoint (Maybe Point)
     | Utxo (Set OutputReference)
     | DatumByHash (Maybe BinaryData)
     | ScriptByHash (Maybe Script)
@@ -265,7 +266,7 @@ instance Show (Response r) where
         Unit () ->
             "()"
         Checkpoint pt ->
-            toString $ "(Checkpoint " <> showPoint pt <> ")"
+            toString $ "(Checkpoint " <> maybe "NULL" showPoint pt <> ")"
         Utxo outRefs ->
             toString $ "(Utxo " <> T.intercalate "," (showOutputReference <$> Set.toList outRefs) <> ")"
         DatumByHash bin ->
@@ -525,7 +526,11 @@ generator inputManagement model =
             ]
         blocks@(tip:_) -> Just $ frequency
             [ (3, pure GetMostRecentCheckpoint)
-            , (3, GetPreviousCheckpoint <$> elements (getPointSlotNo . blockPoint <$> blocks))
+            , (3, GetPreviousCheckpoint <$> oneof
+                [ getPointSlotNo <$> genNonGenesisPoint
+                , elements (getPointSlotNo . blockPoint <$> blocks)
+                ]
+              )
             , (5, pure GetUtxo)
             , (5, GetDatumByHash <$> genOrSelectDatum inputManagement model)
             , (3, GetScriptByHash <$> genOrSelectScript model)
@@ -746,9 +751,9 @@ semantics pause HttpClient{..} queue = \case
             cp' <- getMostRecentCheckpoint
             pure (cp' < cp)
     GetMostRecentCheckpoint -> do
-        Checkpoint <$> getMostRecentCheckpoint
+        Checkpoint . Just <$> getMostRecentCheckpoint
     GetPreviousCheckpoint sl -> do
-        Checkpoint <$> getPreviousCheckpoint sl
+        Checkpoint <$> getCheckpointBySlot GetCheckpointClosestAncestor sl
     GetUtxo -> do
         Utxo . foldMap (Set.singleton . outputReference) <$> getAllMatches OnlyUnspent
     GetDatumByHash hash ->
@@ -762,11 +767,6 @@ semantics pause HttpClient{..} queue = \case
         listCheckpoints <&> \case
             [] -> GenesisPoint
             h:_ -> h
-
-    getPreviousCheckpoint =
-        getCheckpointBySlot GetCheckpointClosestAncestor
-        >=>
-        maybe (fail "getPreviousCheckpoint: no previous checkpoint") pure
 
 -- | Here we mock the server behavior using our model; this is used within the
 -- generator itself, to advance the state-machine. Because the model is our
@@ -782,15 +782,15 @@ mock model = \case
         pure (Unit ())
     GetMostRecentCheckpoint ->
         pure $ Checkpoint $ case currentChain model of
-            []  -> GenesisPoint
-            h:_ -> blockPoint h
+            []  -> Just GenesisPoint
+            h:_ -> Just (blockPoint h)
     GetPreviousCheckpoint sl ->
         let
             search = \case
-                [] -> GenesisPoint
+                [] -> Nothing
                 (blockPoint -> h):rest ->
                     if getPointSlotNo h <= sl
-                    then h
+                    then Just h
                     else search rest
          in
             pure $ Checkpoint $ search (currentChain model)

--- a/test/Test/Kupo/Data/CardanoSpec.hs
+++ b/test/Test/Kupo/Data/CardanoSpec.hs
@@ -13,7 +13,6 @@ import Kupo.Prelude
 import Kupo.Data.Cardano
     ( Blake2b_224
     , pattern GenesisPoint
-    , SlotNo (..)
     , datumHashFromText
     , datumHashToText
     , digest

--- a/test/Test/Kupo/Data/CardanoSpec.hs
+++ b/test/Test/Kupo/Data/CardanoSpec.hs
@@ -46,15 +46,15 @@ spec = parallel $ do
         specify "origin" $ do
             pointFromText "origin" `shouldBe` Just GenesisPoint
 
-        prop "{slotNo}.{blockHeaderHash}" $ \(s :: Word64) -> forAll (genBytes 32) $ \bytes ->
-            let txt = show s <> "." <> encodeBase16 bytes
-             in case pointFromText txt of
-                    Just{}  -> property True
-                    Nothing -> property False
+        prop "{slotNo}.{blockHeaderHash}" $
+            forAll genSlotNo $ \s ->
+                forAll (genBytes 32) $ \bytes ->
+                    let txt = slotNoToText s <> "." <> encodeBase16 bytes
+                     in case pointFromText txt of
+                            Just{}  -> property True
+                            Nothing -> property False
 
     context "SlotNo" $ do
-        prop "forall (s :: Word64). slotNoFromText (show s) === Just{}" $ \(s :: Word64) ->
-            slotNoFromText (show s) === Just (SlotNo s)
         prop "forall (s :: SlotNo). slotNoFromText (slotNoToText s) === Just{}" $
             forAll genSlotNo $ \s ->
                 slotNoFromText (slotNoToText s) === Just s

--- a/test/Test/Kupo/Data/CardanoSpec.hs
+++ b/test/Test/Kupo/Data/CardanoSpec.hs
@@ -39,6 +39,7 @@ import Test.QuickCheck
     ( Gen, arbitrary, forAll, property, vectorOf, (===) )
 
 import qualified Data.ByteString as BS
+
 spec :: Spec
 spec = parallel $ do
     context "pointFromText" $ do

--- a/test/Test/Kupo/Data/Generators.hs
+++ b/test/Test/Kupo/Data/Generators.hs
@@ -184,7 +184,7 @@ genOutput = mkOutput
 
 genSlotNo :: Gen SlotNo
 genSlotNo = do
-    SlotNo <$> arbitrary
+    SlotNo <$> choose (1, maxBound `div` 2  - 1)
 
 genTransactionId :: Gen TransactionId
 genTransactionId =

--- a/test/Test/Kupo/Data/Generators.hs
+++ b/test/Test/Kupo/Data/Generators.hs
@@ -50,6 +50,8 @@ import Kupo.Data.Configuration
     ( InputManagement (..) )
 import Kupo.Data.Health
     ( ConnectionStatus (..), Health (..) )
+import Kupo.Data.Http.ForcedRollback
+    ( ForcedRollback (..), ForcedRollbackLimit (..) )
 import Kupo.Data.Pattern
     ( Pattern, Result (..) )
 import System.IO.Unsafe
@@ -62,6 +64,7 @@ import Test.QuickCheck
     , elements
     , frequency
     , listOf
+    , oneof
     , suchThat
     , vector
     , vectorOf
@@ -212,6 +215,16 @@ genOutputValue = do
 genInputManagement :: Gen InputManagement
 genInputManagement =
     elements [MarkSpentInputs, RemoveSpentInputs]
+
+genForcedRollbackLimit :: Gen ForcedRollbackLimit
+genForcedRollbackLimit =
+    elements [UnsafeAllowRollbackBeyondSafeZone, OnlyAllowRollbackWithinSafeZone]
+
+genForcedRollback :: Gen ForcedRollback
+genForcedRollback =
+    ForcedRollback
+        <$> oneof [Left <$> genSlotNo, Right <$> genNonGenesisPoint]
+        <*> genForcedRollbackLimit
 
 --
 -- Helpers

--- a/test/Test/Kupo/Data/Http/ForcedRollbackSpec.hs
+++ b/test/Test/Kupo/Data/Http/ForcedRollbackSpec.hs
@@ -1,0 +1,45 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this
+-- file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+module Test.Kupo.Data.Http.ForcedRollbackSpec
+    ( spec
+    ) where
+
+import Kupo.Prelude
+
+import Kupo.Data.Http.ForcedRollback
+    ( decodeForcedRollback, forcedRollbackToJson )
+import Test.Hspec
+    ( Spec, context, parallel )
+import Test.Hspec.QuickCheck
+    ( prop )
+import Test.Kupo.Data.Generators
+    ( genForcedRollback )
+import Test.QuickCheck
+    ( Property, counterexample, forAll, (===) )
+
+import qualified Data.Aeson as Json
+import qualified Data.Aeson.Encoding as Json
+import qualified Data.Aeson.Types as Json
+
+spec :: Spec
+spec = parallel $ do
+    context "ForcedRollback" $ do
+        prop "JSON roundtrip" $
+            forAll genForcedRollback
+                (roundtripJSON forcedRollbackToJson decodeForcedRollback)
+
+roundtripJSON
+    :: (Show a, Eq a)
+    => (a -> Json.Encoding)
+    -> (Json.Value -> Json.Parser a)
+    -> a
+    -> Property
+roundtripJSON encode decode x = do
+    let bytes = Json.encodingToLazyByteString (encode x)
+    case eitherDecodeJson decode bytes of
+        Right x' ->
+            (x === x') & counterexample (decodeUtf8 $ toStrict bytes)
+        Left e ->
+            False & counterexample e

--- a/test/Test/Kupo/Data/OgmiosSpec.hs
+++ b/test/Test/Kupo/Data/OgmiosSpec.hs
@@ -31,12 +31,12 @@ import Data.Aeson.Types as Json
 spec :: Spec
 spec = parallel $ context "can decode relevant Ogmios' test vectors" $ do
     context "decodeFindIntersectResponse" $ do
-        let dir = "./test/ogmios/server/test/vectors/ChainSync/Response/FindIntersect"
+        let dir = "./test/vectors/ogmios/server/test/vectors/ChainSync/Response/FindIntersect"
         vectors <- runIO (listDirectory dir)
         propVector ((dir </>) <$> vectors) (decodeFindIntersectResponse [])
 
     context "decodeRequestNextResponse" $ do
-        let dir = "./test/ogmios/server/test/vectors/ChainSync/Response/RequestNext"
+        let dir = "./test/vectors/ogmios/server/test/vectors/ChainSync/Response/RequestNext"
         vectors <- runIO (listDirectory dir)
         propVector ((dir </>) <$> vectors) decodeRequestNextResponse
 

--- a/test/Test/Kupo/Data/OgmiosSpec.hs
+++ b/test/Test/Kupo/Data/OgmiosSpec.hs
@@ -10,6 +10,8 @@ import Kupo.Prelude
 
 import Data.List
     ( (!!) )
+import Kupo.App.ChainSync.Ogmios
+    ( intersectionNotFound )
 import Kupo.Data.Ogmios
     ( decodeFindIntersectResponse, decodeRequestNextResponse )
 import System.Directory
@@ -33,7 +35,7 @@ spec = parallel $ context "can decode relevant Ogmios' test vectors" $ do
     context "decodeFindIntersectResponse" $ do
         let dir = "./test/vectors/ogmios/server/test/vectors/ChainSync/Response/FindIntersect"
         vectors <- runIO (listDirectory dir)
-        propVector ((dir </>) <$> vectors) (decodeFindIntersectResponse [])
+        propVector ((dir </>) <$> vectors) (decodeFindIntersectResponse $ intersectionNotFound [])
 
     context "decodeRequestNextResponse" $ do
         let dir = "./test/vectors/ogmios/server/test/vectors/ChainSync/Response/RequestNext"

--- a/test/Test/Kupo/Fixture.hs
+++ b/test/Test/Kupo/Fixture.hs
@@ -175,3 +175,13 @@ someScriptInWitness = unsafeScriptFromBytes $ unsafeDecodeBase16
     \5ED76DBB6D8200581C1905A56D43DF143519B1B89CE9AF7188343410EE9F41C3\
     \3D97F50BFC8200581CB481306EE8B782E044726452C8E68FC2D649577A2A4972\
     \BFD61A8FB9"
+
+-- Some stake key in Shelley, present in addresses from early blocks of Shelley.
+someStakeKey :: ByteString
+someStakeKey = unsafeDecodeBase16
+    "06e2ae44dff6770dc0f4ada3cf4cf2605008e27aecdb332ad349fda7"
+
+-- Another stake key that can be seen in early Shelley blocks.
+someOtherStakeKey :: ByteString
+someOtherStakeKey = unsafeDecodeBase16
+    "8c19e0c753136fd37f7bdd0ad6e24b6faa8d4ab0cb1cf8b20439b63c"


### PR DESCRIPTION
Fixes #39 

---

- :round_pushpin: **Partially revert fe24612.**
    Do not bother end-users with the "origin" point in the checkpoint API.
  It is actually easier to simply consider that there's no previous
  checkpoint beyond the first slot. This keeps the interface simple and
  avoid cluttering the specification with a pointless case.

- :round_pushpin: **Bump stylish-haskell / hls to more recent versions.**
    I've been using a quite old version of stylish-haskell for a while because newer versions (>0.11.0.2) have been broken regarding the newline_multiline setting. But, with the way HLS bundles plugins, it becomes complicated to use specific plugin versions... one needs to re-compile HLS.

- :round_pushpin: **Enable (and require) rolling back to a past point when dynamically adding pattern**
    This was a bit more involved / complicated than I originally
  anticipated. The difficulty are plural, but the main pain points
  are:

  (a) The asynchronous and decoupled consumer/producer workers, and the
  need to keep them somewhat in sync. Rolling back the _producer_
  without introducing inconsistency in the _consumer_ is a bit tricky.
  One has to make sure that the consumer is only affected through its
  rollbackward/rollforward interface.

  (b) There's no guarantee that the rollback point given via the API
  exists. And even if it is, there's still a chance that this point
  vanishes between the moment we checked and the moment we look for
  intersection (especially for points that are close to the tip, more
  volatile). Yet, to look for an intersection, we must pause the
  chain-sync client and try to look for that intersection. If it works,
  great, we need to resume the client back to where it was. Here, we
  leverage the good symbiosis there's between the consumer/producer and
  the existing exception handlers and simply "restart" the process. This
  will fetch latest checkpoints from the database and resume the syncing
  as if nothing happen.

  (c) The rollbacks are triggered from the HTTP server, but everything
  is done very much asynchronously. So we need ways to yield back a
  response / status from the chain-sync client back to the HTTP server.
  This is achieved through the 'ForcedRollbackHandler'.

- :round_pushpin: **Write end-to-end scenarios to test rollback with pattern insertions**
    The strategy is relatively simple at the API level: start watching
  some address, add a pattern for another address and rollback to a
  point where we know we should've observed results for this address.

  Then, compare results. We know that the results of the second run must
  includes the results of the first run, and when patterns are
  non-overlapping we can even make additional assertions on the
  disjunction of the two sets of results.

  This commit also adds a few JSON roundtrip tests for the
  `ForcedRollback` type and, it has caught a bug regarding the list
  patterns endpoint (which was untested so far).

- :round_pushpin: **Add forced-rollback to the API specification.**
  
- :round_pushpin: **Fill-in CHANGELOG about #39.**