### PR TITLE
arm64 arch docker image

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -54,6 +54,7 @@ jobs:
       with:
         context: .
         push: true
+        platforms: linux/amd64,linux/arm64
         tags: ${{ steps.base-variables.outputs.image }}:latest
         target: ${{ matrix.target }}
         cache-from: type=registry,ref=${{ steps.base-variables.outputs.image }}:latest
@@ -65,6 +66,7 @@ jobs:
       with:
         context: .
         push: true
+        platforms: linux/amd64,linux/arm64
         tags: ${{ steps.base-variables.outputs.image }}:${{ steps.tag-variables.outputs.tag }}
         target: ${{ matrix.target }}
         cache-from: type=registry,ref=${{ steps.base-variables.outputs.image }}:latest


### PR DESCRIPTION
- arm64 image can be used to run on Raspberry pi, aws graviton, other cloud arm based instance and saves cost