### PR TITLE
Extend patterns to also support asset id and policy id.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,4 +10,4 @@ insert_final_newline = true
 
 [*.hs]
 indent_size = 4
-max_line_length = 100
+max_line_length = 102

--- a/.editorconfig
+++ b/.editorconfig
@@ -10,4 +10,4 @@ insert_final_newline = true
 
 [*.hs]
 indent_size = 4
-max_line_length = 80
+max_line_length = 100

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 ## Nix
 /result
 /result-*
+
+## Cabal
+dist-newstyle

--- a/.stylish-haskell.yaml
+++ b/.stylish-haskell.yaml
@@ -42,18 +42,18 @@ language_extensions: &default-extensions
 - TypeSynonymInstances
 - ViewPatterns
 
-columns: 80 # Should match .editorconfig
+columns: 0 # Should match .editorconfig
 steps:
   - imports:
       align: none
       list_align: new_line
-      long_list_align: new_line_multiline
+      long_list_align: multiline
       empty_list_align: inherit
       list_padding: 4
       pad_module_names: false
       separate_lists: true
       space_surround: true
-      post_qualify: true
+      post_qualify: false
       group_imports: false
 
   - language_pragmas:

--- a/src/Kupo.hs
+++ b/src/Kupo.hs
@@ -33,39 +33,75 @@ module Kupo
 import Kupo.Prelude
 
 import Kupo.App
-    ( ChainSyncClient, TraceConsumer (..), consumer, gardener, newProducer )
+    ( ChainSyncClient
+    , TraceConsumer (..)
+    , consumer
+    , gardener
+    , newProducer
+    )
 import Kupo.App.ChainSync
-    ( withChainSyncExceptionHandler )
+    ( withChainSyncExceptionHandler
+    )
 import Kupo.App.Configuration
-    ( newPatternsCache, startOrResume )
+    ( newPatternsCache
+    , startOrResume
+    )
 import Kupo.App.Database
-    ( ConnectionType (..), newLock, withDatabase )
+    ( ConnectionType (..)
+    , newLock
+    , withDatabase
+    )
 import Kupo.App.Health
-    ( connectionStatusToggle, initializeHealth, readHealth, recordCheckpoint )
+    ( connectionStatusToggle
+    , initializeHealth
+    , readHealth
+    , recordCheckpoint
+    )
 import Kupo.App.Http
-    ( healthCheck, httpServer )
+    ( healthCheck
+    , httpServer
+    )
 import Kupo.App.Mailbox
-    ( Mailbox )
+    ( Mailbox
+    )
 import Kupo.Control.MonadAsync
-    ( concurrently4 )
+    ( concurrently4
+    )
 import Kupo.Control.MonadLog
-    ( TracerDefinition (..), nullTracer, withTracers )
+    ( TracerDefinition (..)
+    , nullTracer
+    , withTracers
+    )
 import Kupo.Control.MonadSTM
-    ( MonadSTM (..) )
+    ( MonadSTM (..)
+    )
 import Kupo.Data.Cardano
-    ( IsBlock, Point, Tip )
+    ( IsBlock
+    , Point
+    , Tip
+    )
 import Kupo.Data.ChainSync
-    ( ForcedRollbackHandler )
+    ( ForcedRollbackHandler
+    )
 import Kupo.Data.Configuration
-    ( Configuration (..), WorkDir (..) )
+    ( Configuration (..)
+    , WorkDir (..)
+    )
 import Kupo.Data.Health
-    ( Health, emptyHealth )
+    ( Health
+    , emptyHealth
+    )
 import Kupo.Options
-    ( Command (..), Tracers (..), parseOptions )
+    ( Command (..)
+    , Tracers (..)
+    , parseOptions
+    )
 import Kupo.Version
-    ( version )
+    ( version
+    )
 import System.FilePath
-    ( (</>) )
+    ( (</>)
+    )
 
 --
 -- Environment

--- a/src/Kupo/App/ChainSync.hs
+++ b/src/Kupo/App/ChainSync.hs
@@ -80,13 +80,17 @@ withChainSyncExceptionHandler tr ConnectionStatusToggle{toggleDisconnected} io =
 
     isRetryableIOException :: IOException -> Bool
     isRetryableIOException e =
-        isResourceVanishedError e || isDoesNotExistError e || isTryAgainError e
+        isResourceVanishedError e || isDoesNotExistError e || isTryAgainError e || isInvalidArgumentOnSocket e
       where
         isTryAgainError :: IOException -> Bool
         isTryAgainError = isInfixOf "resource exhausted" . show
 
         isResourceVanishedError :: IOException -> Bool
         isResourceVanishedError = isInfixOf "resource vanished" . show
+
+        -- NOTE: MacOS
+        isInvalidArgumentOnSocket :: IOException -> Bool
+        isInvalidArgumentOnSocket = isInfixOf "invalid argument (Socket operation on non-socket)" . show
 
     isRetryableConnectionException :: ConnectionException -> Bool
     isRetryableConnectionException = \case

--- a/src/Kupo/App/ChainSync.hs
+++ b/src/Kupo/App/ChainSync.hs
@@ -16,29 +16,44 @@ module Kupo.App.ChainSync
 import Kupo.Prelude
 
 import Control.Exception.Safe
-    ( IOException )
+    ( IOException
+    )
 import Data.List
-    ( isInfixOf )
+    ( isInfixOf
+    )
 import Data.Severity
-    ( HasSeverityAnnotation (..), Severity (..) )
+    ( HasSeverityAnnotation (..)
+    , Severity (..)
+    )
 import Data.Time.Clock
-    ( DiffTime )
+    ( DiffTime
+    )
 import Kupo.Control.MonadCatch
-    ( MonadCatch (..) )
+    ( MonadCatch (..)
+    )
 import Kupo.Control.MonadDelay
-    ( foreverCalmly )
+    ( foreverCalmly
+    )
 import Kupo.Control.MonadLog
-    ( Tracer, traceWith )
+    ( Tracer
+    , traceWith
+    )
 import Kupo.Control.MonadThrow
-    ( MonadThrow (..) )
+    ( MonadThrow (..)
+    )
 import Kupo.Data.Cardano
-    ( SlotNo, WithOrigin (..) )
+    ( SlotNo
+    , WithOrigin (..)
+    )
 import Kupo.Data.ChainSync
-    ( IntersectionNotFoundException (..) )
+    ( IntersectionNotFoundException (..)
+    )
 import Network.WebSockets
-    ( ConnectionException (..) )
+    ( ConnectionException (..)
+    )
 import System.IO.Error
-    ( isDoesNotExistError )
+    ( isDoesNotExistError
+    )
 
 withChainSyncExceptionHandler
     :: Tracer IO TraceChainSync

--- a/src/Kupo/App/ChainSync/Direct.hs
+++ b/src/Kupo/App/ChainSync/Direct.hs
@@ -9,21 +9,35 @@ module Kupo.App.ChainSync.Direct
 import Kupo.Prelude
 
 import Control.Monad.Class.MonadSTM
-    ( MonadSTM (..) )
+    ( MonadSTM (..)
+    )
 import Kupo.App.Mailbox
-    ( Mailbox, putHighFrequencyMessage, putIntermittentMessage )
+    ( Mailbox
+    , putHighFrequencyMessage
+    , putIntermittentMessage
+    )
 import Kupo.Control.MonadThrow
-    ( MonadThrow (..) )
+    ( MonadThrow (..)
+    )
 import Kupo.Data.Cardano
-    ( Point, Tip )
+    ( Point
+    , Tip
+    )
 import Kupo.Data.ChainSync
-    ( ForcedRollbackHandler (..), IntersectionNotFoundException (..) )
+    ( ForcedRollbackHandler (..)
+    , IntersectionNotFoundException (..)
+    )
 import Kupo.Data.Configuration
-    ( maxInFlight )
+    ( maxInFlight
+    )
 import Network.TypedProtocol.Pipelined
-    ( Nat (..), natToInt )
+    ( Nat (..)
+    , natToInt
+    )
 import Ouroboros.Network.Block
-    ( getTipSlotNo, pointSlot )
+    ( getTipSlotNo
+    , pointSlot
+    )
 import Ouroboros.Network.Protocol.ChainSync.ClientPipelined
     ( ChainSyncClientPipelined (..)
     , ClientPipelinedStIdle (..)

--- a/src/Kupo/App/ChainSync/Ogmios.hs
+++ b/src/Kupo/App/ChainSync/Ogmios.hs
@@ -14,15 +14,26 @@ module Kupo.App.ChainSync.Ogmios
 import Kupo.Prelude
 
 import Kupo.App.Mailbox
-    ( Mailbox, putHighFrequencyMessage, putIntermittentMessage )
+    ( Mailbox
+    , putHighFrequencyMessage
+    , putIntermittentMessage
+    )
 import Kupo.Control.MonadSTM
-    ( MonadSTM (..) )
+    ( MonadSTM (..)
+    )
 import Kupo.Control.MonadThrow
-    ( MonadThrow (..) )
+    ( MonadThrow (..)
+    )
 import Kupo.Data.Cardano
-    ( Point, SlotNo, Tip, WithOrigin, pointSlot )
+    ( Point
+    , SlotNo
+    , Tip
+    , WithOrigin
+    , pointSlot
+    )
 import Kupo.Data.Configuration
-    ( maxInFlight )
+    ( maxInFlight
+    )
 import Kupo.Data.Ogmios
     ( PartialBlock
     , RequestNextResponse (..)
@@ -33,7 +44,9 @@ import Kupo.Data.Ogmios
     )
 
 import Kupo.Data.ChainSync
-    ( ForcedRollbackHandler (..), IntersectionNotFoundException (..) )
+    ( ForcedRollbackHandler (..)
+    , IntersectionNotFoundException (..)
+    )
 import qualified Network.WebSockets as WS
 import qualified Network.WebSockets.Json as WS
 
@@ -113,8 +126,8 @@ connect ConnectionStatusToggle{toggleConnected} host port action =
         WS.defaultConnectionOptions [] (\ws -> toggleConnected >> action ws)
 
 data CannotResolveAddressException = CannotResolveAddress
-    { host :: String
-    , port :: Int
+    { host :: !String
+    , port :: !Int
     } deriving (Show)
 
 instance Exception CannotResolveAddressException

--- a/src/Kupo/App/Configuration.hs
+++ b/src/Kupo/App/Configuration.hs
@@ -22,27 +22,49 @@ module Kupo.App.Configuration
 import Kupo.Prelude
 
 import Control.Monad.Trans.Except
-    ( throwE, withExceptT )
+    ( throwE
+    , withExceptT
+    )
 import Data.Aeson.Lens
-    ( key, _String )
+    ( _String
+    , key
+    )
 import Kupo.App.Database
-    ( Database (..) )
+    ( Database (..)
+    )
 import Kupo.Control.MonadLog
-    ( HasSeverityAnnotation (..), MonadLog (..), Severity (..), Tracer )
+    ( HasSeverityAnnotation (..)
+    , MonadLog (..)
+    , Severity (..)
+    , Tracer
+    )
 import Kupo.Control.MonadSTM
-    ( MonadSTM (..) )
+    ( MonadSTM (..)
+    )
 import Kupo.Control.MonadThrow
-    ( MonadThrow (..) )
+    ( MonadThrow (..)
+    )
 import Kupo.Data.Cardano
-    ( Point, SlotNo (..), getPointSlotNo )
+    ( Point
+    , SlotNo (..)
+    , getPointSlotNo
+    )
 import Kupo.Data.Configuration
-    ( Configuration (..), NetworkParameters (..) )
+    ( Configuration (..)
+    , NetworkParameters (..)
+    )
 import Kupo.Data.Database
-    ( patternFromRow, patternToRow, pointFromRow )
+    ( patternFromRow
+    , patternToRow
+    , pointFromRow
+    )
 import Kupo.Data.Pattern
-    ( Pattern (..), patternToText )
+    ( Pattern (..)
+    , patternToText
+    )
 import System.FilePath.Posix
-    ( replaceFileName )
+    ( replaceFileName
+    )
 
 import qualified Data.Aeson as Json
 import qualified Data.Yaml as Yaml
@@ -136,7 +158,7 @@ newPatternsCache
     => Tracer IO TraceConfiguration
     -> Configuration
     -> Database m
-    -> m (TVar m [Pattern])
+    -> m (TVar m (Set Pattern))
 newPatternsCache tr configuration Database{..} = do
     alreadyKnownPatterns <- runReadOnlyTransaction (listPatterns patternFromRow)
     patterns <- case (alreadyKnownPatterns, configuredPatterns) of
@@ -154,7 +176,7 @@ newPatternsCache tr configuration Database{..} = do
         (xs, _) ->
             pure xs
     logWith tr $ ConfigurationPatterns (patternToText <$> patterns)
-    newTVarIO patterns
+    newTVarIO (fromList patterns)
   where
     Configuration{patterns = configuredPatterns} = configuration
 

--- a/src/Kupo/App/Health.hs
+++ b/src/Kupo/App/Health.hs
@@ -12,11 +12,17 @@ module Kupo.App.Health
 import Kupo.Prelude
 
 import Kupo.Control.MonadSTM
-    ( MonadSTM (..) )
+    ( MonadSTM (..)
+    )
 import Kupo.Data.Cardano
-    ( SlotNo (..), Tip, getTipSlotNo )
+    ( SlotNo (..)
+    , Tip
+    , getTipSlotNo
+    )
 import Kupo.Data.Health
-    ( ConnectionStatus (..), Health (..) )
+    ( ConnectionStatus (..)
+    , Health (..)
+    )
 
 -- | Safe and limited accessor to the health
 readHealth

--- a/src/Kupo/App/Http.hs
+++ b/src/Kupo/App/Http.hs
@@ -18,16 +18,21 @@ module Kupo.App.Http
 
 import Kupo.Prelude
 
-import Data.List
-    ( nub, (\\) )
 import Kupo.App.Database
-    ( Database (..) )
+    ( Database (..)
+    )
 import Kupo.App.Http.HealthCheck
-    ( healthCheck )
+    ( healthCheck
+    )
 import Kupo.Control.MonadLog
-    ( HasSeverityAnnotation (..), MonadLog (..), Severity (..), Tracer )
+    ( HasSeverityAnnotation (..)
+    , MonadLog (..)
+    , Severity (..)
+    , Tracer
+    )
 import Kupo.Control.MonadSTM
-    ( MonadSTM (..) )
+    ( MonadSTM (..)
+    )
 import Kupo.Data.Cardano
     ( DatumHash
     , Point
@@ -47,9 +52,11 @@ import Kupo.Data.Cardano
     , slotNoToText
     )
 import Kupo.Data.ChainSync
-    ( ForcedRollbackHandler (..) )
+    ( ForcedRollbackHandler (..)
+    )
 import Kupo.Data.Configuration
-    ( LongestRollback (..) )
+    ( LongestRollback (..)
+    )
 import Kupo.Data.Database
     ( applyStatusFlag
     , binaryDataFromRow
@@ -62,19 +69,33 @@ import Kupo.Data.Database
     , scriptHashToRow
     )
 import Kupo.Data.Health
-    ( Health (..) )
+    ( Health (..)
+    )
 import Kupo.Data.Http.FilterMatchesBy
-    ( FilterMatchesBy (..), filterMatchesBy )
+    ( FilterMatchesBy (..)
+    , filterMatchesBy
+    )
 import Kupo.Data.Http.ForcedRollback
-    ( ForcedRollback (..), ForcedRollbackLimit (..), decodeForcedRollback )
+    ( ForcedRollback (..)
+    , ForcedRollbackLimit (..)
+    , decodeForcedRollback
+    )
 import Kupo.Data.Http.GetCheckpointMode
-    ( GetCheckpointMode (..), getCheckpointModeFromQuery )
+    ( GetCheckpointMode (..)
+    , getCheckpointModeFromQuery
+    )
 import Kupo.Data.Http.Response
-    ( responseJson, responseJsonEncoding, responseStreamJson )
+    ( responseJson
+    , responseJsonEncoding
+    , responseStreamJson
+    )
 import Kupo.Data.Http.Status
-    ( Status (..), mkStatus )
+    ( Status (..)
+    , mkStatus
+    )
 import Kupo.Data.Http.StatusFlag
-    ( statusFlagFromQueryParams )
+    ( statusFlagFromQueryParams
+    )
 import Kupo.Data.Pattern
     ( Pattern (..)
     , Result (..)
@@ -86,7 +107,8 @@ import Kupo.Data.Pattern
     , wildcard
     )
 import Network.HTTP.Types.Status
-    ( status200 )
+    ( status200
+    )
 import Network.Wai
     ( Application
     , Middleware
@@ -102,6 +124,7 @@ import Network.Wai
 import qualified Data.Aeson as Json
 import qualified Data.Aeson.Encoding as Json
 import qualified Data.Aeson.Types as Json
+import qualified Data.Set as Set
 import qualified Kupo.Data.Http.Default as Default
 import qualified Kupo.Data.Http.Error as Errors
 import qualified Network.HTTP.Types.Header as Http
@@ -116,7 +139,7 @@ httpServer
     :: Tracer IO TraceHttpServer
     -> (forall a. (Database IO -> IO a) -> IO a)
     -> (Point -> ForcedRollbackHandler IO -> IO ())
-    -> TVar IO [Pattern]
+    -> TVar IO (Set Pattern)
     -> IO Health
     -> String
     -> Int
@@ -139,7 +162,7 @@ httpServer tr withDatabase forceRollback patternsVar readHealth host port =
 app
     :: (forall a. (Database IO -> IO a) -> IO a)
     -> (Point -> ForcedRollbackHandler IO -> IO ())
-    -> TVar IO [Pattern]
+    -> TVar IO (Set Pattern)
     -> IO Health
     -> Application
 app withDatabase forceRollback patternsVar readHealth req send =
@@ -167,7 +190,7 @@ app withDatabase forceRollback patternsVar readHealth req send =
         ("v1" : args) ->
             route args
 
-        _ ->
+        _unmatchedRoutes ->
             send Errors.notFound
 
     routeHealth = \case
@@ -288,7 +311,7 @@ pathParametersToText = \case
         Just arg0
     [arg0, arg1] ->
         Just (arg0 <> "/" <> arg1)
-    _ ->
+    _unexpectedPath ->
         Nothing
 
 --
@@ -332,14 +355,14 @@ handleGetCheckpointBySlot headers mSlotNo query Database{..} =
             handleGetCheckpointBySlot' slotNo mode
   where
     handleGetCheckpointBySlot' slotNo mode = do
-        let successor = succ (unSlotNo slotNo)
+        let successor = next (unSlotNo slotNo)
         points <- runReadOnlyTransaction (listAncestorsDesc successor 1 pointFromRow)
         pure $ responseJsonEncoding status200 headers $ case (points, mode) of
             ([point], GetCheckpointStrict) | getPointSlotNo point == slotNo ->
                 pointToJson point
             ([point], GetCheckpointClosestAncestor) ->
                 pointToJson point
-            _ ->
+            _pointNotFound ->
                 Json.null_
 
 --
@@ -387,7 +410,7 @@ handleGetMatches headers patternQuery queryParams Database{..} = do
                         \result -> hasAssetId (value result) assetId
                     MatchPolicyId policyId ->
                         \result -> hasPolicyId (value result) policyId
-                    _ ->
+                    _otherCasesAlreadyMatchedFromSQL ->
                         const True
 
             predicateB =
@@ -410,7 +433,7 @@ handleGetMatches headers patternQuery queryParams Database{..} = do
 
 handleDeleteMatches
     :: [Http.Header]
-    -> TVar IO [Pattern]
+    -> TVar IO (Set Pattern)
     -> Maybe Text
     -> Database IO
     -> IO Response
@@ -419,7 +442,7 @@ handleDeleteMatches headers patternsVar query Database{..} = do
     case query >>= patternFromText of
         Nothing -> do
             pure Errors.invalidPattern
-        Just p | p `overlaps` (patterns \\ [p]) -> do
+        Just p | p `overlaps` patterns -> do
             pure Errors.stillActivePattern
         Just p -> do
             n <- runReadWriteTransaction $ deleteInputsByAddress (patternToSql p)
@@ -479,7 +502,7 @@ handleGetScript headers scriptArg Database{..} = do
 handleGetPatterns
     :: [Http.Header]
     -> Maybe Text
-    -> (Pattern -> [Pattern])
+    -> (Pattern -> Set Pattern)
     -> Response
 handleGetPatterns headers patternQuery patterns = do
     case patternQuery >>= patternFromText of
@@ -492,7 +515,7 @@ handleGetPatterns headers patternQuery patterns = do
 
 handleDeletePattern
     :: [Http.Header]
-    -> TVar IO [Pattern]
+    -> TVar IO (Set Pattern)
     -> Maybe Text
     -> Database IO
     -> IO Response
@@ -502,7 +525,7 @@ handleDeletePattern headers patternsVar query Database{..} = do
             pure Errors.invalidPattern
         Just p -> do
             n <- runReadWriteTransaction $ deletePattern (patternToRow p)
-            atomically $ modifyTVar' patternsVar (\\ [p])
+            atomically $ modifyTVar' patternsVar (Set.delete p)
             pure $ responseJsonEncoding status200 headers $
                 Json.pairs $ mconcat
                     [ Json.pair "deleted" (Json.int n)
@@ -512,7 +535,7 @@ handlePutPattern
     :: [Http.Header]
     -> IO Health
     -> (Point -> ForcedRollbackHandler IO -> IO ())
-    -> TVar IO [Pattern]
+    -> TVar IO (Set Pattern)
     -> Maybe ForcedRollback
     -> Maybe Text
     -> Database IO
@@ -535,13 +558,13 @@ handlePutPattern headers readHealth forceRollback patternsVar mPointOrSlot query
             case ((LongestRollback <$> d) > Just longestRollback, lim) of
                 (True, OnlyAllowRollbackWithinSafeZone) ->
                     pure Errors.unsafeRollbackBeyondSafeZone
-                _ ->
+                _safeRollbackOrAllowedUnsafe ->
                     putPatternAt p point
   where
     resolvePointOrSlot :: Either SlotNo Point -> IO (Maybe Point)
     resolvePointOrSlot = \case
         Right pt -> do
-            let successor = unSlotNo $ succ $ getPointSlotNo pt
+            let successor = unSlotNo $ next $ getPointSlotNo pt
             pts <- runReadOnlyTransaction $ listAncestorsDesc successor 1 pointFromRow
             return $ case pts of
                 [pt'] | pt == pt' ->
@@ -551,16 +574,16 @@ handlePutPattern headers readHealth forceRollback patternsVar mPointOrSlot query
                 -- flexible and optimistically rollback to that point.
                 [] ->
                     Just pt
-                _ ->
+                _pointDoesNotMatch ->
                     Nothing
 
         Left sl -> do
-            let successor = unSlotNo (succ sl)
+            let successor = unSlotNo (next sl)
             pts <- runReadOnlyTransaction $ listAncestorsDesc successor 1 pointFromRow
             return $ case pts of
                 [pt] | sl == getPointSlotNo pt ->
                     Just pt
-                _ ->
+                _unexpectedPoint ->
                     Nothing
 
     putPatternAt :: Pattern -> Point -> IO Response
@@ -570,12 +593,12 @@ handlePutPattern headers readHealth forceRollback patternsVar mPointOrSlot query
             { onSuccess = do
                 runReadWriteTransaction $ insertPatterns [patternToRow p]
                 patterns <- atomically $ do
-                    modifyTVar' patternsVar (nub . (p :))
+                    modifyTVar' patternsVar (Set.insert p)
                     readTVar patternsVar
                 atomically $ putTMVar response $ responseJsonEncoding status200 headers $
                     Json.list
                         (Json.text . patternToText)
-                        patterns
+                        (toList patterns)
             , onFailure = do
                 atomically (putTMVar response Errors.failedToRollback)
             }
@@ -605,7 +628,7 @@ requestBodyJson parser req = do
     bytes <- strictRequestBody req
     case Json.parse parser <$> Json.decodeStrict' (toStrict bytes) of
         Just (Json.Success a) -> return (Just a)
-        _ -> return Nothing
+        _failureOrMalformed -> return Nothing
 
 --
 -- Tracer

--- a/src/Kupo/App/Mailbox.hs
+++ b/src/Kupo/App/Mailbox.hs
@@ -20,11 +20,12 @@ module Kupo.App.Mailbox
 import Kupo.Prelude
 
 import Kupo.Control.MonadSTM
-    ( MonadSTM (..) )
+    ( MonadSTM (..)
+    )
 
 data Mailbox m a b = Mailbox
-    { highFrequencyMessages :: TBQueue m a
-    , intermittentMessages :: TMVar m b
+    { highFrequencyMessages :: !(TBQueue m a)
+    , intermittentMessages :: !(TMVar m b)
     }
 
 newMailbox

--- a/src/Kupo/Control/MonadAsync.hs
+++ b/src/Kupo/Control/MonadAsync.hs
@@ -10,7 +10,10 @@ module Kupo.Control.MonadAsync
     ) where
 
 import Control.Monad.Class.MonadAsync
-    ( MonadAsync (..), forConcurrently_, mapConcurrently_ )
+    ( MonadAsync (..)
+    , forConcurrently_
+    , mapConcurrently_
+    )
 
 concurrently4 :: MonadAsync m => m a -> m b -> m c -> m d -> m ()
 concurrently4 a b c d =

--- a/src/Kupo/Control/MonadCatch.hs
+++ b/src/Kupo/Control/MonadCatch.hs
@@ -7,4 +7,5 @@ module Kupo.Control.MonadCatch
     ) where
 
 import Control.Monad.Class.MonadThrow
-    ( MonadCatch (..) )
+    ( MonadCatch (..)
+    )

--- a/src/Kupo/Control/MonadDelay.hs
+++ b/src/Kupo/Control/MonadDelay.hs
@@ -10,9 +10,11 @@ module Kupo.Control.MonadDelay
 import Kupo.Prelude
 
 import Control.Monad.Class.MonadTimer
-    ( MonadDelay (..) )
+    ( MonadDelay (..)
+    )
 import Kupo.Control.MonadTime
-    ( DiffTime )
+    ( DiffTime
+    )
 
 foreverCalmly :: (MonadDelay m) => m DiffTime -> m Void
 foreverCalmly a = do

--- a/src/Kupo/Control/MonadLog.hs
+++ b/src/Kupo/Control/MonadLog.hs
@@ -29,15 +29,26 @@ module Kupo.Control.MonadLog
 import Kupo.Prelude
 
 import Control.Concurrent
-    ( myThreadId )
+    ( myThreadId
+    )
 import Control.Monad.Class.MonadTime
-    ( getCurrentTime )
+    ( getCurrentTime
+    )
 import Control.Tracer
-    ( Tracer (..), natTracer, nullTracer, traceWith )
+    ( Tracer (..)
+    , natTracer
+    , nullTracer
+    , traceWith
+    )
 import Data.Aeson.Encoding
-    ( Encoding, encodingToLazyByteString, pair, pairs )
+    ( Encoding
+    , encodingToLazyByteString
+    , pair
+    , pairs
+    )
 import Data.Char
-    ( isLower )
+    ( isLower
+    )
 import Data.Generics.Tracers
     ( IsRecordOfTracers
     , SomeMsg (..)
@@ -47,11 +58,19 @@ import Data.Generics.Tracers
     , defaultTracers
     )
 import Data.Severity
-    ( HasSeverityAnnotation (..), Severity (..) )
+    ( HasSeverityAnnotation (..)
+    , Severity (..)
+    )
 import Kupo.Control.MonadSTM
-    ( newTMVarIO, withTMVar )
+    ( newTMVarIO
+    , withTMVar
+    )
 import System.IO
-    ( BufferMode (..), hSetBuffering, hSetEncoding, utf8 )
+    ( BufferMode (..)
+    , hSetBuffering
+    , hSetEncoding
+    , utf8
+    )
 
 import qualified Data.Aeson.Key as Json.Key
 import qualified Data.ByteString.Lazy.Char8 as BL8

--- a/src/Kupo/Control/MonadOuroboros.hs
+++ b/src/Kupo/Control/MonadOuroboros.hs
@@ -21,31 +21,48 @@ module Kupo.Control.MonadOuroboros
 import Kupo.Prelude
 
 import Cardano.Chain.Slotting
-    ( EpochSlots (..) )
+    ( EpochSlots (..)
+    )
 import Cardano.Ledger.Crypto
-    ( StandardCrypto )
+    ( StandardCrypto
+    )
 import Control.Tracer
-    ( nullTracer )
+    ( nullTracer
+    )
 import Data.Map.Strict
-    ( (!) )
+    ( (!)
+    )
 import Ouroboros.Consensus.Byron.Ledger.Config
-    ( CodecConfig (..) )
+    ( CodecConfig (..)
+    )
 import Ouroboros.Consensus.Cardano
-    ( CardanoBlock )
+    ( CardanoBlock
+    )
 import Ouroboros.Consensus.Cardano.Block
-    ( CodecConfig (..) )
+    ( CodecConfig (..)
+    )
 import Ouroboros.Consensus.Network.NodeToClient
-    ( ClientCodecs, Codecs' (..), clientCodecs )
+    ( ClientCodecs
+    , Codecs' (..)
+    , clientCodecs
+    )
 import Ouroboros.Consensus.Node.NetworkProtocolVersion
-    ( SupportedNetworkProtocolVersion (..) )
+    ( SupportedNetworkProtocolVersion (..)
+    )
 import Ouroboros.Consensus.Shelley.Ledger.Config
-    ( CodecConfig (..) )
+    ( CodecConfig (..)
+    )
 import Ouroboros.Network.Block
-    ( Point (..), StandardHash, Tip (..) )
+    ( Point (..)
+    , StandardHash
+    , Tip (..)
+    )
 import Ouroboros.Network.Driver.Simple
-    ( runPipelinedPeer )
+    ( runPipelinedPeer
+    )
 import Ouroboros.Network.Magic
-    ( NetworkMagic (..) )
+    ( NetworkMagic (..)
+    )
 import Ouroboros.Network.Mux
     ( MiniProtocol (..)
     , MiniProtocolLimits (..)
@@ -63,13 +80,19 @@ import Ouroboros.Network.NodeToClient
     , withIOManager
     )
 import Ouroboros.Network.Point
-    ( WithOrigin (..) )
+    ( WithOrigin (..)
+    )
 import Ouroboros.Network.Protocol.ChainSync.ClientPipelined
-    ( ChainSyncClientPipelined (..), chainSyncClientPeerPipelined )
+    ( ChainSyncClientPipelined (..)
+    , chainSyncClientPeerPipelined
+    )
 import Ouroboros.Network.Protocol.Handshake.Version
-    ( combineVersions, simpleSingletonVersions )
+    ( combineVersions
+    , simpleSingletonVersions
+    )
 import Ouroboros.Network.Snocket
-    ( Snocket (..) )
+    ( Snocket (..)
+    )
 
 import Ouroboros.Consensus.Protocol.Praos.Translate
     ()

--- a/src/Kupo/Control/MonadSTM.hs
+++ b/src/Kupo/Control/MonadSTM.hs
@@ -10,9 +10,12 @@ module Kupo.Control.MonadSTM
 import Kupo.Prelude
 
 import Control.Monad.Class.MonadSTM
-    ( MonadSTM (..) )
+    ( MonadSTM (..)
+    )
 import Control.Monad.Class.MonadThrow
-    ( MonadCatch (..), MonadMask (..) )
+    ( MonadCatch (..)
+    , MonadMask (..)
+    )
 
 -- | An exception-safe bracket-style acquisition of a TMVar.
 withTMVar :: (MonadSTM m, MonadMask m) => TMVar m a -> (a -> m b) -> m b

--- a/src/Kupo/Control/MonadThrow.hs
+++ b/src/Kupo/Control/MonadThrow.hs
@@ -7,4 +7,5 @@ module Kupo.Control.MonadThrow
     ) where
 
 import Control.Monad.Class.MonadThrow
-    ( MonadThrow (..) )
+    ( MonadThrow (..)
+    )

--- a/src/Kupo/Control/MonadTime.hs
+++ b/src/Kupo/Control/MonadTime.hs
@@ -16,11 +16,18 @@ module Kupo.Control.MonadTime
 import Kupo.Prelude
 
 import Control.Monad.Class.MonadTime
-    ( MonadTime (..), Time (..), addTime, diffTime )
+    ( MonadTime (..)
+    , Time (..)
+    , addTime
+    , diffTime
+    )
 import Control.Monad.Class.MonadTimer
-    ( timeout )
+    ( timeout
+    )
 import Data.Time.Clock
-    ( DiffTime, secondsToDiffTime )
+    ( DiffTime
+    , secondsToDiffTime
+    )
 
 millisecondsToDiffTime :: Integer -> DiffTime
 millisecondsToDiffTime = toEnum . fromInteger . (* 1_000_000_000)

--- a/src/Kupo/Data/ChainSync.hs
+++ b/src/Kupo/Data/ChainSync.hs
@@ -10,24 +10,26 @@ module Kupo.Data.ChainSync
 import Kupo.Prelude
 
 import Kupo.Data.Cardano
-    ( SlotNo, WithOrigin (..) )
+    ( SlotNo
+    , WithOrigin (..)
+    )
 
 data ForcedRollbackHandler (m :: Type -> Type) = ForcedRollbackHandler
-    { onSuccess :: m ()
-    , onFailure :: m ()
+    { onSuccess :: !(m ())
+    , onFailure :: !(m ())
     }
 
 -- | Exception thrown when creating a chain-sync client from an invalid list of
 -- points.
 data IntersectionNotFoundException
     = IntersectionNotFound
-        { requestedPoints :: [WithOrigin SlotNo]
+        { requestedPoints :: ![WithOrigin SlotNo]
             -- ^ Provided points for intersection.
-        , tip :: WithOrigin SlotNo
+        , tip :: !(WithOrigin SlotNo)
             -- ^ Current known tip of the chain.
         }
     | ForcedIntersectionNotFound
-        { point :: WithOrigin SlotNo
+        { point :: !(WithOrigin SlotNo)
             -- ^ Forced intersection point
         }
     deriving (Show)

--- a/src/Kupo/Data/Configuration.hs
+++ b/src/Kupo/Data/Configuration.hs
@@ -32,21 +32,30 @@ module Kupo.Data.Configuration
 import Kupo.Prelude
 
 import Data.Aeson
-    ( (.:) )
+    ( (.:)
+    )
 import Data.Time.Clock.POSIX
-    ( posixSecondsToUTCTime )
+    ( posixSecondsToUTCTime
+    )
 import Data.Time.Format.ISO8601
-    ( iso8601ParseM )
+    ( iso8601ParseM
+    )
 import Kupo.Control.MonadOuroboros
-    ( EpochSlots (..), NetworkMagic (..) )
+    ( EpochSlots (..)
+    , NetworkMagic (..)
+    )
 import Kupo.Control.MonadTime
-    ( DiffTime )
+    ( DiffTime
+    )
 import Kupo.Data.Cardano
-    ( Point )
+    ( Point
+    )
 import Kupo.Data.Pattern
-    ( Pattern (..) )
+    ( Pattern (..)
+    )
 import Ouroboros.Consensus.BlockchainTime.WallClock.Types
-    ( SystemStart (..) )
+    ( SystemStart (..)
+    )
 
 import qualified Data.Aeson as Json
 
@@ -100,7 +109,7 @@ data ChainProducer
 -- | Database working directory. 'in-memory' runs the database in hot memory,
 -- only suitable for non-permissive patterns or testing.
 data WorkDir
-    = Dir FilePath
+    = Dir !FilePath
     | InMemory
     deriving (Generic, Eq, Show)
 

--- a/src/Kupo/Data/Database.hs
+++ b/src/Kupo/Data/Database.hs
@@ -52,11 +52,15 @@ module Kupo.Data.Database
 import Kupo.Prelude
 
 import Cardano.Binary
-    ( decodeFull, serialize )
+    ( decodeFull
+    , serialize
+    )
 import Data.Binary
-    ( Get )
+    ( Get
+    )
 import Data.Bits
-    ( Bits (..) )
+    ( Bits (..)
+    )
 import Kupo.Data.Cardano
     ( Blake2b_224
     , Crypto
@@ -69,9 +73,11 @@ import Kupo.Data.Cardano
     , transactionIdToBytes
     )
 import Kupo.Data.Http.StatusFlag
-    ( StatusFlag (..) )
+    ( StatusFlag (..)
+    )
 import Ouroboros.Consensus.Block
-    ( ConvertRawHash (..) )
+    ( ConvertRawHash (..)
+    )
 
 import qualified Cardano.Ledger.Address as Ledger
 import qualified Cardano.Ledger.Alonzo.Data as Ledger
@@ -90,8 +96,8 @@ import qualified Kupo.Data.Pattern as App
 --
 
 data Checkpoint = Checkpoint
-    { checkpointHeaderHash :: ByteString
-    , checkpointSlotNo :: Word64
+    { checkpointHeaderHash :: !ByteString
+    , checkpointSlotNo :: !Word64
     } deriving (Show)
 
 pointFromRow
@@ -121,17 +127,17 @@ pointToRow = \case
 --
 
 data Input = Input
-    { outputReference :: ByteString
-    , address :: Text
-    , value :: ByteString
-    , datum :: Maybe BinaryData
-    , datumHash :: Maybe ByteString
-    , refScript :: Maybe ScriptReference
-    , refScriptHash :: Maybe ByteString
-    , createdAtSlotNo :: Word64
-    , createdAtHeaderHash :: ByteString
-    , spentAtSlotNo :: Maybe Word64
-    , spentAtHeaderHash :: Maybe ByteString
+    { outputReference :: !ByteString
+    , address :: !Text
+    , value :: !ByteString
+    , datum :: !(Maybe BinaryData)
+    , datumHash :: !(Maybe ByteString)
+    , refScript :: !(Maybe ScriptReference)
+    , refScriptHash :: !(Maybe ByteString)
+    , createdAtSlotNo :: !Word64
+    , createdAtHeaderHash :: !ByteString
+    , spentAtSlotNo :: !(Maybe Word64)
+    , spentAtHeaderHash :: !(Maybe ByteString)
     } deriving (Show)
 
 resultFromRow
@@ -209,8 +215,8 @@ patternFromRow p =
 --
 
 data BinaryData = BinaryData
-    { binaryDataHash :: ByteString
-    , binaryData :: ByteString
+    { binaryDataHash :: !ByteString
+    , binaryData :: !ByteString
     } deriving (Show)
 
 datumFromRow
@@ -266,8 +272,8 @@ binaryDataFromRow =
 --
 
 data ScriptReference = ScriptReference
-    { scriptHash :: ByteString
-    , script :: ByteString
+    { scriptHash :: !ByteString
+    , script :: !ByteString
     } deriving (Show)
 
 scriptHashToRow

--- a/src/Kupo/Data/Database.hs
+++ b/src/Kupo/Data/Database.hs
@@ -546,6 +546,10 @@ patternToSql = \case
         , "(    output_reference >= x'825820" <> txId <> "190100'\
           \ AND output_reference <= x'825820" <> txId <> "190100')"
         ]
+    App.MatchPolicyId{} ->
+        "address LIKE '%'"
+    App.MatchAssetId{} ->
+        "address LIKE '%'"
 
 applyStatusFlag :: StatusFlag -> Text -> Text
 applyStatusFlag = \case

--- a/src/Kupo/Data/Health.hs
+++ b/src/Kupo/Data/Health.hs
@@ -16,7 +16,9 @@ module Kupo.Data.Health
 import Kupo.Prelude
 
 import Kupo.Data.Cardano
-    ( SlotNo, slotNoToJson )
+    ( SlotNo
+    , slotNoToJson
+    )
 
 import qualified Data.Aeson.Encoding as Json
 

--- a/src/Kupo/Data/Http/Default.hs
+++ b/src/Kupo/Data/Http/Default.hs
@@ -8,7 +8,9 @@ module Kupo.Data.Http.Default
 
 
 import Network.HTTP.Types.Header
-    ( Header, hContentType )
+    ( Header
+    , hContentType
+    )
 
 headers :: [Header]
 headers =

--- a/src/Kupo/Data/Http/Error.hs
+++ b/src/Kupo/Data/Http/Error.hs
@@ -9,11 +9,17 @@ module Kupo.Data.Http.Error where
 import Kupo.Prelude
 
 import Kupo.Data.Http.Response
-    ( responseJson )
+    ( responseJson
+    )
 import Network.HTTP.Types.Status
-    ( status400, status404, status406, status500 )
+    ( status400
+    , status404
+    , status406
+    , status500
+    )
 import Network.Wai
-    ( Response )
+    ( Response
+    )
 
 import qualified Kupo.Data.Http.Default as Default
 

--- a/src/Kupo/Data/Http/FilterMatchesBy.hs
+++ b/src/Kupo/Data/Http/FilterMatchesBy.hs
@@ -24,10 +24,10 @@ import Kupo.Data.Cardano
 import qualified Network.HTTP.Types as Http
 
 data FilterMatchesBy
-    = FilterByAssetId AssetId
-    | FilterByPolicyId PolicyId
-    | FilterByTransactionId TransactionId
-    | FilterByOutputReference OutputReference
+    = FilterByAssetId !AssetId
+    | FilterByPolicyId !PolicyId
+    | FilterByTransactionId !TransactionId
+    | FilterByOutputReference !OutputReference
     | NoFilter
     deriving (Eq, Show, Generic)
 

--- a/src/Kupo/Data/Http/ForcedRollback.hs
+++ b/src/Kupo/Data/Http/ForcedRollback.hs
@@ -16,7 +16,10 @@ module Kupo.Data.Http.ForcedRollback
 import Kupo.Prelude
 
 import Data.Aeson
-    ( (.!=), (.:), (.:?) )
+    ( (.!=)
+    , (.:)
+    , (.:?)
+    )
 import Kupo.Data.Cardano
     ( Point
     , SlotNo (..)
@@ -31,8 +34,8 @@ import qualified Data.Aeson.Encoding as Json
 import qualified Data.Aeson.Types as Json
 
 data ForcedRollback = ForcedRollback
-    { since :: Either SlotNo Point
-    , limit :: ForcedRollbackLimit
+    { since :: !(Either SlotNo Point)
+    , limit :: !ForcedRollbackLimit
     } deriving (Generic, Show, Eq)
 
 forcedRollbackToJson :: ForcedRollback -> Json.Encoding

--- a/src/Kupo/Data/Http/Response.hs
+++ b/src/Kupo/Data/Http/Response.hs
@@ -11,15 +11,23 @@ module Kupo.Data.Http.Response
 import Kupo.Prelude
 
 import Data.IORef
-    ( mkWeakIORef )
+    ( mkWeakIORef
+    )
 import GHC.Weak
-    ( finalize )
+    ( finalize
+    )
 import Network.HTTP.Types.Header
-    ( Header, hContentLength )
+    ( Header
+    , hContentLength
+    )
 import Network.HTTP.Types.Status
-    ( status200 )
+    ( status200
+    )
 import Network.Wai
-    ( Response, responseLBS, responseStream )
+    ( Response
+    , responseLBS
+    , responseStream
+    )
 
 import qualified Data.Aeson as Json
 import qualified Data.Binary.Builder as B

--- a/src/Kupo/Data/Http/Status.hs
+++ b/src/Kupo/Data/Http/Status.hs
@@ -14,8 +14,8 @@ import Kupo.Prelude
 import qualified Network.HTTP.Types.Status as Http
 
 data Status = Status
-    { statusCode :: Int
-    , statusMessage :: Text
+    { statusCode :: !Int
+    , statusMessage :: !Text
     } deriving stock (Generic)
       deriving anyclass (ToJSON)
 

--- a/src/Kupo/Data/Http/StatusFlag.hs
+++ b/src/Kupo/Data/Http/StatusFlag.hs
@@ -12,7 +12,8 @@ module Kupo.Data.Http.StatusFlag
 import Kupo.Prelude
 
 import Kupo.Data.Configuration
-    ( InputManagement (..) )
+    ( InputManagement (..)
+    )
 import qualified Network.HTTP.Types.URI as Http
 
 data StatusFlag
@@ -23,7 +24,8 @@ data StatusFlag
 isNoStatusFlag :: StatusFlag -> Bool
 isNoStatusFlag = \case
     NoStatusFlag -> True
-    _ -> False
+    OnlyUnspent -> False
+    OnlySpent -> False
 
 -- | Because the chain is only eventually immutable, kupo does not remove recent
 -- data right away. Thus, it is possible that, even though the configuration

--- a/src/Kupo/Data/PartialBlock.hs
+++ b/src/Kupo/Data/PartialBlock.hs
@@ -26,17 +26,17 @@ import qualified Data.Set as Set
 -- | A partial representation of a Cardano Block. This only contains bits that
 -- are relevant to kupo. Rest isn't indexed.
 data PartialBlock = PartialBlock
-    { blockPoint :: Point
-    , blockBody :: [ PartialTransaction ]
+    { blockPoint :: !Point
+    , blockBody :: ![ PartialTransaction ]
     } deriving (Eq, Show)
 
 -- | A partial transaction, analogous to 'PartialBlock', trimmed down to the
 -- minimum.
 data PartialTransaction = PartialTransaction
-    { inputs :: [ Input ]
-    , outputs :: [ (OutputReference, Output) ]
-    , datums :: Map DatumHash BinaryData
-    , scripts :: Map ScriptHash Script
+    { inputs :: ![ Input ]
+    , outputs :: ![ (OutputReference, Output) ]
+    , datums :: !(Map DatumHash BinaryData)
+    , scripts :: !(Map ScriptHash Script)
     } deriving (Eq, Show)
 
 instance IsBlock PartialBlock where

--- a/src/Kupo/Data/Pattern.hs
+++ b/src/Kupo/Data/Pattern.hs
@@ -2,6 +2,7 @@
 --  License, v. 2.0. If a copy of the MPL was not distributed with this
 --  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+{-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE RecordWildCards #-}
@@ -19,8 +20,9 @@ module Kupo.Data.Pattern
     , wildcard
 
       -- * Matching
-    , matching
     , Codecs (..)
+    , Match (..)
+    , matching
     , matchBlock
 
       -- * Result
@@ -31,9 +33,11 @@ module Kupo.Data.Pattern
 import Kupo.Prelude
 
 import Codec.Binary.Bech32.TH
-    ( humanReadablePart )
+    ( humanReadablePart
+    )
 import Kupo.Data.Cardano
     ( Address
+    , AssetId
     , BinaryData
     , Blake2b_224
     , Blake2b_256
@@ -44,6 +48,7 @@ import Kupo.Data.Cardano
     , Output
     , OutputReference
     , Point
+    , PolicyId
     , Script
     , ScriptHash
     , ScriptReference (..)
@@ -53,6 +58,8 @@ import Kupo.Data.Cardano
     , addressFromBytes
     , addressToBytes
     , addressToJson
+    , assetNameFromText
+    , assetNameToText
     , datumHashToJson
     , digest
     , digestSize
@@ -65,6 +72,8 @@ import Kupo.Data.Cardano
     , getScript
     , getTransactionId
     , getValue
+    , hasAssetId
+    , hasPolicyId
     , hashDatum
     , hashScriptReference
     , headerHashToJson
@@ -74,6 +83,8 @@ import Kupo.Data.Cardano
     , outputIndexFromText
     , outputIndexToJson
     , outputReferenceToText
+    , policyIdFromText
+    , policyIdToText
     , scriptHashToJson
     , slotNoToJson
     , transactionIdFromText
@@ -81,14 +92,6 @@ import Kupo.Data.Cardano
     , transactionIdToText
     , unsafeGetPointHeaderHash
     , valueToJson
-    , PolicyId
-    , AssetId
-    , policyIdToText
-    , policyIdFromText
-    , assetNameToText
-    , assetNameFromText
-    , hasPolicyId
-    , hasAssetId
     )
 
 import qualified Codec.Binary.Bech32 as Bech32
@@ -99,25 +102,23 @@ import qualified Data.Set as Set
 import qualified Data.Text as T
 
 data Pattern
-    = MatchAny MatchBootstrap
-    | MatchExact Address
-    | MatchPayment ByteString
-    | MatchDelegation ByteString
-    | MatchPaymentAndDelegation ByteString ByteString
-    | MatchTransactionId TransactionId
-    | MatchOutputReference OutputReference
-    | MatchPolicyId PolicyId
-    | MatchAssetId AssetId
+    = MatchAny !MatchBootstrap
+    | MatchExact !Address
+    | MatchPayment !ByteString
+    | MatchDelegation !ByteString
+    | MatchPaymentAndDelegation !ByteString !ByteString
+    | MatchTransactionId !TransactionId
+    | MatchOutputReference !OutputReference
+    | MatchPolicyId !PolicyId
+    | MatchAssetId !AssetId
     deriving (Generic, Eq, Ord, Show)
 
 -- | Checks whether a given pattern overlaps with a list of other patterns. The
 -- inclusion is a deep inclusion such that for instance, (MatchPayment "a") is
 -- considered included in [MatchAny OnlyShelley].
-overlaps :: Pattern -> [Pattern] -> Bool
-overlaps p = \case
-    [] -> False
-    p':rest ->
-        overlapTwo (p, p') || overlapTwo (p', p) || overlaps p rest
+overlaps :: Pattern -> Set Pattern -> Bool
+overlaps p =
+    Set.foldr (\p' rest -> rest || overlapTwo (p, p') || overlapTwo (p', p)) False
   where
     overlapTwo = \case
         (MatchAny{}, _) ->
@@ -146,7 +147,7 @@ overlaps p = \case
             a == a'
         (MatchAssetId a, MatchPolicyId a') ->
             fst a == a'
-        _ ->
+        _nonOverlappingPatterns ->
             False
 
 -- | Checks whether a pattern x fully includes pattern y.
@@ -177,13 +178,13 @@ includes x y = case (x, y) of
         getTransactionId a == a'
     (MatchTransactionId a, MatchTransactionId a') ->
         a == a'
-    _ ->
+    _nonIncludedPatterns ->
         False
 
 -- | All patterns in the list that are fully covering the given pattern
 -- according to the definition given by 'includes'
-included :: Pattern -> [Pattern] -> [Pattern]
-included p = filter (`includes` p)
+included :: Pattern -> Set Pattern -> Set Pattern
+included p = Set.filter (`includes` p)
 
 wildcard :: Text
 wildcard = "*"
@@ -260,7 +261,7 @@ patternFromText txt = asum
                         MatchPaymentAndDelegation
                             <$> readerCredential payment
                             <*> readerCredential delegation
-            _ ->
+            _unexpectedSplit ->
                 empty
 
     -- NOTE: byte strings are interpreted either as verification key or
@@ -305,7 +306,7 @@ patternFromText txt = asum
                     <$> transactionIdFromText txId
                     <*> outputIndexFromText ix
                 pure (MatchOutputReference outRef)
-            _ ->
+            _unexpectedSplit ->
                 Nothing
 
     readerAssetId = do
@@ -317,7 +318,7 @@ patternFromText txt = asum
                     <$> policyIdFromText policyId
                     <*> assetNameFromText name
                 pure (MatchAssetId assetId)
-            _ ->
+            _unexpectedSplit ->
                 Nothing
 
     readerBase16 str action = do
@@ -364,7 +365,7 @@ matchingAddress = \case
             Just payment == getPaymentPartBytes addr
             &&
             Just delegation == getDelegationPartBytes addr
-    _ ->
+    _nonAddressPattern ->
         const False
 
 data MatchBootstrap
@@ -384,13 +385,13 @@ pattern OnlyShelley <- MatchBootstrap False
 {-# COMPLETE OnlyShelley, IncludingBootstrap #-}
 
 data Result = Result
-    { outputReference :: OutputReference
-    , address :: Address
-    , value :: Value
-    , datum :: Datum
-    , scriptReference :: ScriptReference
-    , createdAt :: Point
-    , spentAt :: Maybe Point
+    { outputReference :: !OutputReference
+    , address :: !Address
+    , value :: !Value
+    , datum :: !Datum
+    , scriptReference :: !ScriptReference
+    , createdAt :: !Point
+    , spentAt :: !(Maybe Point)
     } deriving (Show, Eq)
 
 resultToJson
@@ -434,12 +435,32 @@ resultToJson Result{..} = Json.pairs $ mconcat
 -- on-the-fly as we traverse the structure, rather than traversing all results a
 -- second time.
 data Codecs result slotNo input bin script = Codecs
-    { toResult :: Result -> result
-    , toSlotNo :: SlotNo -> slotNo
-    , toInput :: Input -> input
-    , toBinaryData :: DatumHash -> BinaryData -> bin
-    , toScript :: ScriptHash -> Script -> script
+    { toResult :: !(Result -> result)
+    , toSlotNo :: !(SlotNo -> slotNo)
+    , toInput :: !(Input -> input)
+    , toBinaryData :: !(DatumHash -> BinaryData -> bin)
+    , toScript :: !(ScriptHash -> Script -> script)
     }
+
+-- | A higher-level record to represent the aggregation of matched results.
+data Match result slotNo input bin script = Match
+    { consumed :: !(Map slotNo (Set input))
+    , produced :: ![result]
+    , datums :: ![bin]
+    , scripts :: ![script]
+    }
+
+instance Ord slotNo => Semigroup (Match result slotNo input bin script) where
+    a <> b = Match
+        { consumed = consumed a <> consumed b
+        , produced = produced a <> produced b
+        , datums = datums a <> datums b
+        , scripts = scripts a <> scripts b
+        }
+
+instance Ord slotNo => Monoid (Match result slotNo input bin script) where
+    mempty = Match mempty mempty mempty mempty
+
 
 -- | Match all outputs in transactions from a block that match any of the given
 -- pattern.
@@ -448,25 +469,25 @@ data Codecs result slotNo input bin script = Codecs
 -- multiple patterns. This is to facilitate building an index of matches to
 -- results.
 matchBlock
-    :: forall block result slotNo input bin scripts.
+    :: forall block result slotNo input bin script.
         ( IsBlock block
         , Ord input
         , Ord slotNo
         )
-    => Codecs result slotNo input bin scripts
-    -> [Pattern]
+    => Codecs result slotNo input bin script
+    -> Set Pattern
     -> block
-    -> (Map slotNo (Set input), [result], [bin], [scripts])
+    -> Match result slotNo input bin script
 matchBlock Codecs{..} patterns blk =
-    let pt = getPoint blk in foldBlock (fn pt) (mempty, mempty, mempty, mempty) blk
+    let pt = getPoint blk in foldBlock (fn pt) (Match mempty mempty mempty mempty) blk
   where
     fn
         :: Point
         -> BlockBody block
-        -> (Map slotNo (Set input), [result], [bin], [scripts])
-        -> (Map slotNo (Set input), [result], [bin], [scripts])
-    fn pt tx (consumed, produced, datums, scripts) =
-        ( Map.alter
+        -> Match result slotNo input bin script
+        -> Match result slotNo input bin script
+    fn pt tx Match{consumed, produced, datums, scripts} = Match
+        { consumed = Map.alter
             (\st -> Just $ Set.foldr
                 (Set.insert . toInput)
                 (fromMaybe mempty st)
@@ -475,18 +496,19 @@ matchBlock Codecs{..} patterns blk =
             (toSlotNo (getPointSlotNo pt))
             consumed
 
-        , matched ++ produced
+        , produced =
+            matched ++ produced
 
-        , Map.foldrWithKey
+        , datums = Map.foldrWithKey
             (\k v accum -> toBinaryData k v : accum)
             datums
             (witnessedDatums @block tx)
 
-        , Map.foldrWithKey
+        , scripts = Map.foldrWithKey
             (\k v accum -> toScript k v : accum)
             scripts
             (witnessedScripts @block tx)
-        )
+        }
       where
         matched =
             concatMap

--- a/src/Kupo/Options.hs
+++ b/src/Kupo/Options.hs
@@ -23,26 +23,42 @@ module Kupo.Options
     ) where
 
 import Kupo.Prelude hiding
-    ( group )
+    ( group
+    )
 
 import Options.Applicative
 
 import Data.Char
-    ( toUpper )
+    ( toUpper
+    )
 import Kupo.App
-    ( TraceConsumer, TraceGardener )
+    ( TraceConsumer
+    , TraceGardener
+    )
 import Kupo.App.Configuration
-    ( TraceConfiguration )
+    ( TraceConfiguration
+    )
 import Kupo.App.Database
-    ( TraceDatabase )
+    ( TraceDatabase
+    )
 import Kupo.App.Http
-    ( TraceHttpServer )
+    ( TraceHttpServer
+    )
 import Kupo.Control.MonadLog
-    ( Severity (..), Tracer, TracerDefinition (..), TracerHKD, defaultTracers )
+    ( Severity (..)
+    , Tracer
+    , TracerDefinition (..)
+    , TracerHKD
+    , defaultTracers
+    )
 import Kupo.Control.MonadTime
-    ( DiffTime, millisecondsToDiffTime )
+    ( DiffTime
+    , millisecondsToDiffTime
+    )
 import Kupo.Data.Cardano
-    ( Point, pointFromText )
+    ( Point
+    , pointFromText
+    )
 import Kupo.Data.Configuration
     ( ChainProducer (..)
     , Configuration (..)
@@ -50,18 +66,30 @@ import Kupo.Data.Configuration
     , WorkDir (..)
     )
 import Kupo.Data.Pattern
-    ( Pattern, patternFromText )
+    ( Pattern
+    , patternFromText
+    )
 import Options.Applicative.Help.Pretty
-    ( Doc, align, fillSep, hardline, indent, softbreak, string, text, vsep )
+    ( Doc
+    , align
+    , fillSep
+    , hardline
+    , indent
+    , softbreak
+    , string
+    , text
+    , vsep
+    )
 import Safe
-    ( readMay )
+    ( readMay
+    )
 
 import qualified Data.Text as T
 import qualified Data.Text.Read as T
 
 data Command
-    = Run Configuration (Tracers IO MinSeverities)
-    | HealthCheck String Int
+    = Run !Configuration !(Tracers IO MinSeverities)
+    | HealthCheck !String !Int
     | Version
     deriving (Eq, Show)
 
@@ -350,15 +378,15 @@ healthCheckCommand =
 
 data Tracers m (kind :: TracerDefinition) = Tracers
     { tracerHttp
-        :: TracerHKD kind (Tracer m TraceHttpServer)
+        :: !(TracerHKD kind (Tracer m TraceHttpServer))
     , tracerDatabase
-        :: TracerHKD kind (Tracer m TraceDatabase)
+        :: !(TracerHKD kind (Tracer m TraceDatabase))
     , tracerConsumer
-        :: TracerHKD kind (Tracer m TraceConsumer)
+        :: !(TracerHKD kind (Tracer m TraceConsumer))
     , tracerGardener
-        :: TracerHKD kind (Tracer m TraceGardener)
+        :: !(TracerHKD kind (Tracer m TraceGardener))
     , tracerConfiguration
-        :: TracerHKD kind (Tracer m TraceConfiguration)
+        :: !(TracerHKD kind (Tracer m TraceConfiguration))
     } deriving (Generic)
 
 deriving instance Show (Tracers m MinSeverities)

--- a/src/Kupo/Prelude.hs
+++ b/src/Kupo/Prelude.hs
@@ -20,6 +20,11 @@ module Kupo.Prelude
     , (^?!)
     , at
 
+      -- * Extras
+    , next
+    , prev
+    , safeToEnum
+
       -- Encoding
     , encodeBase16
     , decodeBase16
@@ -46,23 +51,45 @@ module Kupo.Prelude
     ) where
 
 import Cardano.Binary
-    ( decodeFull', serialize', unsafeDeserialize' )
+    ( decodeFull'
+    , serialize'
+    , unsafeDeserialize'
+    )
 import Control.Arrow
-    ( left )
+    ( left
+    )
 import Control.Lens
-    ( Lens', at, (^?), (^?!) )
+    ( Lens'
+    , at
+    , (^?!)
+    , (^?)
+    )
 import Data.Aeson
-    ( Encoding, FromJSON (..), GToJSON', ToJSON (..), Zero, genericToEncoding )
+    ( Encoding
+    , FromJSON (..)
+    , GToJSON'
+    , ToJSON (..)
+    , Zero
+    , genericToEncoding
+    )
 import Data.ByteString.Base16
-    ( decodeBase16, encodeBase16 )
+    ( decodeBase16
+    , encodeBase16
+    )
 import Data.ByteString.Base64
-    ( decodeBase64, encodeBase64 )
+    ( decodeBase64
+    , encodeBase64
+    )
 import Data.Generics.Internal.VL.Lens
-    ( view, (^.) )
+    ( view
+    , (^.)
+    )
 import Data.List
-    ( nubBy )
+    ( nubBy
+    )
 import GHC.Generics
-    ( Rep )
+    ( Rep
+    )
 import Relude hiding
     ( MVar
     , Nat
@@ -118,10 +145,15 @@ import qualified Data.Aeson.Parser as Json
 import qualified Data.Aeson.Parser.Internal as Json
 import qualified Data.Aeson.Types as Json
 import qualified Data.ByteString.Base58 as Base58
+import Relude.Extra
+    ( next
+    , prev
+    , safeToEnum
+    )
 
 data ConnectionStatusToggle m = ConnectionStatusToggle
-    { toggleConnected :: m ()
-    , toggleDisconnected :: m ()
+    { toggleConnected :: !(m ())
+    , toggleDisconnected :: !(m ())
     }
 
 -- | The runtime does not let the application terminate gracefully when a

--- a/src/Kupo/Version.hs
+++ b/src/Kupo/Version.hs
@@ -9,7 +9,8 @@ module Kupo.Version
 import Kupo.Prelude
 
 import Data.Version
-    ( showVersion )
+    ( showVersion
+    )
 
 import qualified Paths_kupo as Pkg
 

--- a/test/Test/Kupo/App/ConfigurationSpec.hs
+++ b/test/Test/Kupo/App/ConfigurationSpec.hs
@@ -13,7 +13,8 @@ module Test.Kupo.App.ConfigurationSpec
 import Kupo.Prelude
 
 import Kupo.App.Configuration
-    ( parseNetworkParameters )
+    ( parseNetworkParameters
+    )
 import Kupo.Data.Configuration
     ( EpochSlots (..)
     , NetworkMagic (..)
@@ -21,7 +22,12 @@ import Kupo.Data.Configuration
     , mkSystemStart
     )
 import Test.Hspec
-    ( Spec, context, parallel, shouldBe, specify )
+    ( Spec
+    , context
+    , parallel
+    , shouldBe
+    , specify
+    )
 
 spec :: Spec
 spec = parallel $ do

--- a/test/Test/Kupo/App/Http/Client.hs
+++ b/test/Test/Kupo/App/Http/Client.hs
@@ -7,17 +7,28 @@ module Test.Kupo.App.Http.Client where
 import Kupo.Prelude
 
 import Cardano.Crypto.Hash.Class
-    ( Hash, HashAlgorithm, hashFromTextAsHex )
+    ( Hash
+    , HashAlgorithm
+    , hashFromTextAsHex
+    )
 import Data.Aeson
-    ( (.!=), (.:), (.:?) )
+    ( (.!=)
+    , (.:)
+    , (.:?)
+    )
 import Data.Aeson.Lens
-    ( key, _String )
+    ( _String
+    , key
+    )
 import Data.List
-    ( maximum )
+    ( maximum
+    )
 import Kupo.Control.MonadCatch
-    ( MonadCatch (..) )
+    ( MonadCatch (..)
+    )
 import Kupo.Control.MonadDelay
-    ( MonadDelay (..) )
+    ( MonadDelay (..)
+    )
 import Kupo.Data.Cardano
     ( Address
     , BinaryData
@@ -47,13 +58,22 @@ import Kupo.Data.Cardano
     , unsafeValueFromList
     )
 import Kupo.Data.Http.ForcedRollback
-    ( ForcedRollback (..), ForcedRollbackLimit (..), forcedRollbackToJson )
+    ( ForcedRollback (..)
+    , ForcedRollbackLimit (..)
+    , forcedRollbackToJson
+    )
 import Kupo.Data.Http.GetCheckpointMode
-    ( GetCheckpointMode (..) )
+    ( GetCheckpointMode (..)
+    )
 import Kupo.Data.Http.StatusFlag
-    ( StatusFlag (..) )
+    ( StatusFlag (..)
+    )
 import Kupo.Data.Pattern
-    ( Pattern (..), Result (..), patternFromText, patternToText )
+    ( Pattern (..)
+    , Result (..)
+    , patternFromText
+    , patternToText
+    )
 import Network.HTTP.Client
     ( HttpException
     , Manager
@@ -67,7 +87,9 @@ import Network.HTTP.Client
     , parseRequest
     )
 import Network.HTTP.Types.Status
-    ( status200, status400 )
+    ( status200
+    , status400
+    )
 
 import qualified Data.Aeson as Json
 import qualified Data.Aeson.Encoding as Json
@@ -149,7 +171,7 @@ newHttpClientWith manager (serverHost, serverPort) =
                 req <- parseRequest (baseUrl <> "/health")
                 void (httpNoBody req manager) `catch` (\(_ :: HttpException) -> do
                     threadDelay 0.1
-                    loop (succ n))
+                    loop (next n))
 
     _waitUntilM :: IO Bool -> IO ()
     _waitUntilM predicate = do
@@ -320,7 +342,7 @@ decodeAddress txt =
     case patternFromText txt of
         Just (MatchExact addr) ->
             pure addr
-        _ ->
+        _notAnAddress ->
             empty
 
 decodeDatumHash
@@ -390,7 +412,7 @@ decodeValue = Json.withObject "Value" $ \o -> do
                 pure (policyId, assetName, quantity)
             [ decodeBase16' -> Right policyId ] -> do
                 pure (policyId, mempty, quantity)
-            _ ->
+            _invalidSplit ->
                 empty
 
 decodeHash

--- a/test/Test/Kupo/App/HttpSpec.hs
+++ b/test/Test/Kupo/App/HttpSpec.hs
@@ -9,7 +9,9 @@ module Test.Kupo.App.HttpSpec
     ) where
 
 import Kupo.Prelude hiding
-    ( get, put )
+    ( get
+    , put
+    )
 
 import Data.OpenApi
     ( OpenApi
@@ -37,31 +39,58 @@ import Data.OpenApi
     , validateJSON
     )
 import Kupo.App.Database
-    ( Database (..) )
+    ( Database (..)
+    )
 import Kupo.App.Http
-    ( app )
+    ( app
+    )
 import Kupo.Control.MonadSTM
-    ( MonadSTM (..) )
+    ( MonadSTM (..)
+    )
 import Kupo.Data.Cardano
-    ( pattern BlockPoint, SlotNo (..), unsafeHeaderHashFromBytes )
+    ( SlotNo (..)
+    , pattern BlockPoint
+    , unsafeHeaderHashFromBytes
+    )
 import Kupo.Data.ChainSync
-    ( ForcedRollbackHandler (..) )
+    ( ForcedRollbackHandler (..)
+    )
 import Kupo.Data.Database
-    ( binaryDataToRow, patternToRow, pointToRow, resultToRow, scriptToRow )
+    ( binaryDataToRow
+    , patternToRow
+    , pointToRow
+    , resultToRow
+    , scriptToRow
+    )
 import Kupo.Data.Health
-    ( ConnectionStatus (..), Health (..) )
+    ( ConnectionStatus (..)
+    , Health (..)
+    )
 import Kupo.Data.Pattern
-    ( Pattern )
+    ( Pattern
+    , patternToText
+    )
 import Network.HTTP.Media.MediaType
-    ( MediaType, (//), (/:) )
+    ( MediaType
+    , (//)
+    , (/:)
+    )
 import Network.HTTP.Media.RenderHeader
-    ( renderHeader )
+    ( renderHeader
+    )
 import Network.Wai
-    ( Application )
+    ( Application
+    )
 import Test.Hspec
-    ( Spec, parallel, runIO, shouldContain, specify )
+    ( Spec
+    , parallel
+    , runIO
+    , shouldContain
+    , specify
+    )
 import Test.Hspec.QuickCheck
-    ( prop )
+    ( prop
+    )
 import Test.Kupo.Data.Generators
     ( genBinaryData
     , genDatumHash
@@ -80,9 +109,14 @@ import Test.QuickCheck
     , generate
     , listOf1
     , oneof
+    , suchThat
     )
 import Test.QuickCheck.Monadic
-    ( assert, monadicIO, monitor, run )
+    ( assert
+    , monadicIO
+    , monitor
+    , run
+    )
 
 import qualified Data.Aeson as Json
 import qualified Data.OpenApi as OpenApi
@@ -93,6 +127,9 @@ import qualified Network.HTTP.Types.Status as Http
 import qualified Network.Wai as Wai
 import qualified Network.Wai.Test as Wai
 import qualified Prelude
+import Test.Kupo.Data.Pattern.Fixture
+    ( patterns
+    )
 import qualified Test.Kupo.Data.Pattern.Fixture as Fixture
 
 spec :: Spec
@@ -169,19 +206,12 @@ spec = do
 
         sessionWith noWildcard specification delete "/matches/{pattern-fragment}" $ \assertJson endpoint -> do
             let schema = findSchema specification endpoint Http.status200
-            fragment <- liftIO $ generate (elements Fixture.nonOverlappingUnaryFragments)
+            let allPatterns = (\(p, _, _) -> p) <$> patterns
+            fragment <- liftIO $ generate $
+                (patternToText <$> genPattern) `suchThat` (`notElem` allPatterns)
             res <- Wai.request $ Wai.defaultRequest
                 { Wai.requestMethod = "DELETE" }
-                & flip Wai.setPath ("/matches/" <> fragment)
-            res & Wai.assertStatus (Http.statusCode Http.status200)
-            res & assertJson schema
-
-        sessionWith noWildcard specification delete "/matches/{pattern-fragment}/{pattern-fragment}" $ \assertJson endpoint -> do
-            let schema = findSchema specification endpoint Http.status200
-            fragment <- liftIO $ generate (elements Fixture.nonOverlappingBinaryFragments)
-            res <- Wai.request $ Wai.defaultRequest
-                { Wai.requestMethod = "DELETE" }
-                & flip Wai.setPath ("/matches/" <> fragment)
+                & flip Wai.setPath ("/matches/" <> encodeUtf8 fragment)
             res & Wai.assertStatus (Http.statusCode Http.status200)
             res & assertJson schema
 
@@ -209,19 +239,10 @@ spec = do
 
         session specification delete "/patterns/{pattern-fragment}" $ \assertJson endpoint -> do
             let schema = findSchema specification endpoint Http.status200
-            fragment <- liftIO $ generate (elements Fixture.unaryFragments)
+            fragment <- liftIO $ generate $ patternToText <$> genPattern
             res <- Wai.request $ Wai.defaultRequest
                 { Wai.requestMethod = "DELETE" }
-                & flip Wai.setPath ("/patterns/" <> fragment)
-            res & Wai.assertStatus (Http.statusCode Http.status200)
-            res & assertJson schema
-
-        session specification delete "/patterns/{pattern-fragment}/{pattern-fragment}" $ \assertJson endpoint -> do
-            let schema = findSchema specification endpoint Http.status200
-            fragment <- liftIO $ generate (elements Fixture.binaryFragments)
-            res <- Wai.request $ Wai.defaultRequest
-                { Wai.requestMethod = "DELETE" }
-                & flip Wai.setPath ("/patterns/" <> fragment)
+                & flip Wai.setPath ("/patterns/" <> encodeUtf8 fragment)
             res & Wai.assertStatus (Http.statusCode Http.status200)
             res & assertJson schema
 
@@ -375,8 +396,8 @@ spec = do
 --
 
 newStubbedApplication :: [Pattern] -> IO Application
-newStubbedApplication patterns = do
-    patternsVar <- newTVarIO patterns
+newStubbedApplication defaultPatterns = do
+    patternsVar <- newTVarIO (fromList defaultPatterns)
     pure $ app
         (\callback -> callback databaseStub)
         (\_point ForcedRollbackHandler{onSuccess} -> onSuccess)
@@ -417,7 +438,7 @@ databaseStub = Database
             1 -> do
                 let headerHash = unsafeHeaderHashFromBytes $ unsafeDecodeBase16
                         "0000000000000000000000000000000000000000000000000000000000000000"
-                let point = BlockPoint (SlotNo (pred sl)) headerHash
+                let point = BlockPoint (SlotNo (prev sl)) headerHash
                 pure [mk (pointToRow point)]
             _otherwise -> do
                 fmap (mk . pointToRow) <$> generate (listOf1 genNonGenesisPoint)
@@ -502,9 +523,9 @@ sessionWith
        -> Wai.Session (Json.Value, [ValidationError])
        )
     -> Spec
-sessionWith patterns specification opL path callback =
+sessionWith defaultPatterns specification opL path callback =
     prop (method <> " " <> toString path) $ monadicIO $ do
-        stub <- run (newStubbedApplication patterns)
+        stub <- run (newStubbedApplication defaultPatterns)
         (json, errs) <- run $ Wai.runSession (callback assertJson endpoint) stub
         monitor $ counterexample (decodeUtf8 (Json.encode json))
         forM_ errs (monitor . counterexample . show)
@@ -534,7 +555,7 @@ sessionWith patterns specification opL path callback =
         case T.splitOn "?" path of
             _:[params] -> do
                 traverse (findQueryParam op) (T.splitOn "&" params)
-            _ ->
+            _notFound ->
                 pure []
 
     findQueryParam :: (HasCallStack, Monad f) => Operation -> Text -> f Param
@@ -544,7 +565,7 @@ sessionWith patterns specification opL path callback =
                 oops
                     ("Definition for query parameter '" <> key <> "' not found")
                     (paramAt key (op ^. parameters))
-            _ ->
+            _malformedParam ->
                 error "guardQueryParam: malformed param"
 
     paramAt :: Text -> [Referenced Param] -> Maybe Param

--- a/test/Test/Kupo/App/MailboxSpec.hs
+++ b/test/Test/Kupo/App/MailboxSpec.hs
@@ -11,7 +11,10 @@ module Test.Kupo.App.MailboxSpec
 import Kupo.Prelude
 
 import Control.Monad.IOSim
-    ( pattern SimTrace, pattern TraceMainReturn, runSimTrace )
+    ( pattern SimTrace
+    , pattern TraceMainReturn
+    , runSimTrace
+    )
 import Kupo.App.Mailbox
     ( Mailbox
     , flushMailbox
@@ -20,13 +23,19 @@ import Kupo.App.Mailbox
     , putIntermittentMessage
     )
 import Kupo.Control.MonadAsync
-    ( MonadAsync (..) )
+    ( MonadAsync (..)
+    )
 import Kupo.Control.MonadDelay
-    ( MonadDelay (..) )
+    ( MonadDelay (..)
+    )
 import Kupo.Control.MonadSTM
-    ( MonadSTM (..) )
+    ( MonadSTM (..)
+    )
 import Kupo.Control.MonadTime
-    ( DiffTime, Time (..), secondsToDiffTime )
+    ( DiffTime
+    , Time (..)
+    , secondsToDiffTime
+    )
 import Test.Hspec
     ( Spec
     , context
@@ -37,7 +46,11 @@ import Test.Hspec
     , specify
     )
 import Test.QuickCheck
-    ( arbitrary, frequency, generate, vectorOf )
+    ( arbitrary
+    , frequency
+    , generate
+    , vectorOf
+    )
 
 spec :: Spec
 spec = parallel $ context "Mailbox" $ do
@@ -68,8 +81,8 @@ spec = parallel $ context "Mailbox" $ do
                     let maxTime = n' * (producerWorkTime + consumerWorkTime)
                     t `shouldSatisfy` (<= Time maxTime)
                     msgs' `shouldBe` flatten msgs
-                SimTrace _time _threadId _label _event next ->
-                    analyze next
+                SimTrace _time _threadId _label _event step ->
+                    analyze step
                 e ->
                     expectationFailure ("Simulation failed: " <> show e)
         analyze simulation

--- a/test/Test/Kupo/Data/CardanoSpec.hs
+++ b/test/Test/Kupo/Data/CardanoSpec.hs
@@ -12,7 +12,6 @@ import Kupo.Prelude
 
 import Kupo.Data.Cardano
     ( Blake2b_224
-    , pattern GenesisPoint
     , assetNameFromText
     , assetNameToText
     , datumHashFromText
@@ -22,6 +21,7 @@ import Kupo.Data.Cardano
     , headerHashFromText
     , outputReferenceFromText
     , outputReferenceToText
+    , pattern GenesisPoint
     , pointFromText
     , policyIdFromText
     , policyIdToText
@@ -33,17 +33,36 @@ import Kupo.Data.Cardano
     , scriptToBytes
     , slotNoFromText
     , slotNoToText
-    , unsafeScriptHashFromBytes
     , unsafeAssetNameFromBytes
+    , unsafeScriptHashFromBytes
     )
 import Test.Hspec
-    ( Spec, context, parallel, shouldBe, specify )
+    ( Spec
+    , context
+    , parallel
+    , shouldBe
+    , specify
+    )
 import Test.Hspec.QuickCheck
-    ( prop )
+    ( prop
+    )
 import Test.Kupo.Data.Generators
-    ( genDatumHash, genOutputReference, genScript, genScriptHash, genSlotNo, genPolicyId, genAssetName )
+    ( genAssetName
+    , genDatumHash
+    , genOutputReference
+    , genPolicyId
+    , genScript
+    , genScriptHash
+    , genSlotNo
+    )
 import Test.QuickCheck
-    ( Gen, arbitrary, forAll, property, vectorOf, (===) )
+    ( Gen
+    , arbitrary
+    , forAll
+    , property
+    , vectorOf
+    , (===)
+    )
 
 import qualified Data.ByteString as BS
 

--- a/test/Test/Kupo/Data/CardanoSpec.hs
+++ b/test/Test/Kupo/Data/CardanoSpec.hs
@@ -13,6 +13,8 @@ import Kupo.Prelude
 import Kupo.Data.Cardano
     ( Blake2b_224
     , pattern GenesisPoint
+    , assetNameFromText
+    , assetNameToText
     , datumHashFromText
     , datumHashToText
     , digest
@@ -21,6 +23,8 @@ import Kupo.Data.Cardano
     , outputReferenceFromText
     , outputReferenceToText
     , pointFromText
+    , policyIdFromText
+    , policyIdToText
     , scriptFromBytes
     , scriptHashFromBytes
     , scriptHashFromText
@@ -30,13 +34,14 @@ import Kupo.Data.Cardano
     , slotNoFromText
     , slotNoToText
     , unsafeScriptHashFromBytes
+    , unsafeAssetNameFromBytes
     )
 import Test.Hspec
     ( Spec, context, parallel, shouldBe, specify )
 import Test.Hspec.QuickCheck
     ( prop )
 import Test.Kupo.Data.Generators
-    ( genDatumHash, genOutputReference, genScript, genScriptHash, genSlotNo )
+    ( genDatumHash, genOutputReference, genScript, genScriptHash, genSlotNo, genPolicyId, genAssetName )
 import Test.QuickCheck
     ( Gen, arbitrary, forAll, property, vectorOf, (===) )
 
@@ -57,45 +62,59 @@ spec = parallel $ do
                             Nothing -> property False
 
     context "SlotNo" $ do
-        prop "forall (s :: SlotNo). slotNoFromText (slotNoToText s) === Just{}" $
+        prop "∀(s :: SlotNo). slotNoFromText (slotNoToText s) === Just{}" $
             forAll genSlotNo $ \s ->
                 slotNoFromText (slotNoToText s) === Just s
 
     context "DatumHash" $ do
-        prop "forall (x :: DatumHash). datumHashFromText (datumHashToText x) === x" $
+        prop "∀(x :: DatumHash). datumHashFromText (datumHashToText x) === x" $
             forAll genDatumHash $ \x ->
                 datumHashFromText (datumHashToText x) === Just x
 
     context "Script" $ do
-        prop "forall (x :: Script). scriptFromBytes (scriptToBytes x) === x" $
+        prop "∀(x :: Script). scriptFromBytes (scriptToBytes x) === x" $
             forAll genScript $ \x ->
                 scriptFromBytes (scriptToBytes x) === Just x
-        prop "forall (x :: Script). digest @Blake2b_224 x === hashScript x" $
+        prop "∀(x :: Script). digest @Blake2b_224 x === hashScript x" $
             forAll genScript $ \x ->
                 unsafeScriptHashFromBytes (digest (Proxy @Blake2b_224) (scriptToBytes x))
                     === hashScript x
 
     context "ScriptHash" $ do
-        prop "forall (x :: ScriptHash). scriptHashFromBytes (scriptHashToBytes x) === x" $
+        prop "∀(x :: ScriptHash). scriptHashFromBytes (scriptHashToBytes x) === x" $
             forAll genScriptHash $ \x ->
                 scriptHashFromBytes (scriptHashToBytes x) === Just x
-        prop "forall (x :: ScriptHash). scriptFromText (scriptToText x) === x" $
+        prop "∀(x :: ScriptHash). scriptFromText (scriptToText x) === x" $
             forAll genScriptHash $ \x ->
                 scriptHashFromText (scriptHashToText x) === Just x
 
     context "headerHashFromText" $ do
-        prop "forall (bs :: ByteString). bs .size 32 => headerHashFromText (base16 bs) === Just{}" $
+        prop "∀(bs :: ByteString). bs .size 32 ⇒ headerHashFromText (base16 bs) === Just{}" $
             forAll (genBytes 32) $ \bytes ->
                 case headerHashFromText (encodeBase16 bytes) of
                     Just{}  -> property True
                     Nothing -> property False
 
     context "OutputReference" $ do
-        prop "forall (x :: OutputReference) => outputRefFromText (outputRefToText x) == Just x" $
+        prop "∀(x :: OutputReference). outputRefFromText (outputRefToText x) == Just x" $
             forAll genOutputReference $ \x ->
                 case outputReferenceFromText (outputReferenceToText x) of
                     Just{} -> property True
                     Nothing -> property False
+
+    context "PolicyId" $ do
+        prop "∀(x :: PolicyId). policyIdFromText (policyIdToText x) == Just x" $
+            forAll genPolicyId $ \x ->
+                    case policyIdFromText (policyIdToText x) of
+                        Just{} -> property True
+                        Nothing -> property False
+
+    context "AssetName" $ do
+        prop "∀(x :: AssetName). assetNameFromText (assetNameToText x) == Just x" $
+            forAll genAssetName $ \(unsafeAssetNameFromBytes -> x) ->
+                    case assetNameFromText (assetNameToText x) of
+                        Just{} -> property True
+                        Nothing -> property False
 
 --
 -- Generators

--- a/test/Test/Kupo/Data/Generators.hs
+++ b/test/Test/Kupo/Data/Generators.hs
@@ -9,14 +9,14 @@ module Test.Kupo.Data.Generators where
 import Kupo.Prelude
 
 import Data.Bits
-    ( shiftL )
+    ( shiftL
+    )
 import Kupo.Data.Cardano
     ( Address
     , BinaryData
     , Blake2b_224
     , Blake2b_256
     , Block
-    , pattern BlockPoint
     , Datum
     , DatumHash
     , HeaderHash
@@ -38,6 +38,7 @@ import Kupo.Data.Cardano
     , mkOutput
     , mkOutputReference
     , noDatum
+    , pattern BlockPoint
     , scriptHashToBytes
     , unsafeAddressFromBytes
     , unsafeBinaryDataFromBytes
@@ -50,15 +51,24 @@ import Kupo.Data.Cardano
     , unsafeValueFromList
     )
 import Kupo.Data.Configuration
-    ( InputManagement (..) )
+    ( InputManagement (..)
+    )
 import Kupo.Data.Health
-    ( ConnectionStatus (..), Health (..) )
+    ( ConnectionStatus (..)
+    , Health (..)
+    )
 import Kupo.Data.Http.ForcedRollback
-    ( ForcedRollback (..), ForcedRollbackLimit (..) )
+    ( ForcedRollback (..)
+    , ForcedRollbackLimit (..)
+    )
 import Kupo.Data.Pattern
-    ( MatchBootstrap (..), Pattern (..), Result (..) )
+    ( MatchBootstrap (..)
+    , Pattern (..)
+    , Result (..)
+    )
 import System.IO.Unsafe
-    ( unsafePerformIO )
+    ( unsafePerformIO
+    )
 import Test.QuickCheck
     ( Arbitrary (..)
     , Gen
@@ -73,9 +83,11 @@ import Test.QuickCheck
     , vectorOf
     )
 import Test.QuickCheck.Gen
-    ( Gen (..) )
+    ( Gen (..)
+    )
 import Test.QuickCheck.Random
-    ( mkQCGen )
+    ( mkQCGen
+    )
 
 import qualified Data.ByteString as BS
 import qualified Data.Text as T

--- a/test/Test/Kupo/Data/Http/FilterMatchesBySpec.hs
+++ b/test/Test/Kupo/Data/Http/FilterMatchesBySpec.hs
@@ -19,13 +19,25 @@ import Kupo.Data.Cardano
     , unsafeAssetNameFromBytes
     )
 import Kupo.Data.Http.FilterMatchesBy
-    ( FilterMatchesBy (..), filterMatchesBy )
+    ( FilterMatchesBy (..)
+    , filterMatchesBy
+    )
 import Test.Hspec
-    ( Spec, context, parallel, shouldBe, specify )
+    ( Spec
+    , context
+    , parallel
+    , shouldBe
+    , specify
+    )
 import Test.Kupo.Data.Generators
-    ( genNonEmptyAssetName, genPolicyId, genTransactionId, generateWith )
+    ( genNonEmptyAssetName
+    , genPolicyId
+    , genTransactionId
+    , generateWith
+    )
 import Test.QuickCheck
-    ( suchThat )
+    ( suchThat
+    )
 
 import qualified Data.ByteString as BS
 import qualified Network.HTTP.Types as Http
@@ -147,6 +159,7 @@ someOtherAssetName =
 -- Helpers
 --
 
+infixr 8 .=
 (.=) :: ByteString -> Text -> (ByteString, Maybe ByteString)
 (.=) key val = (key, Just (encodeUtf8 val))
 

--- a/test/Test/Kupo/Data/OgmiosSpec.hs
+++ b/test/Test/Kupo/Data/OgmiosSpec.hs
@@ -9,23 +9,44 @@ module Test.Kupo.Data.OgmiosSpec
 import Kupo.Prelude
 
 import Data.List
-    ( (!!) )
+    ( (!!)
+    )
 import Kupo.App.ChainSync.Ogmios
-    ( intersectionNotFound )
+    ( intersectionNotFound
+    )
 import Kupo.Data.Ogmios
-    ( decodeFindIntersectResponse, decodeRequestNextResponse )
+    ( decodeFindIntersectResponse
+    , decodeRequestNextResponse
+    )
 import System.Directory
-    ( listDirectory )
+    ( listDirectory
+    )
 import System.FilePath
-    ( (</>) )
+    ( (</>)
+    )
 import Test.Hspec
-    ( Spec, SpecWith, context, parallel, runIO )
+    ( Spec
+    , SpecWith
+    , context
+    , parallel
+    , runIO
+    )
 import Test.Hspec.QuickCheck
-    ( modifyMaxSize, prop )
+    ( modifyMaxSize
+    , prop
+    )
 import Test.QuickCheck
-    ( counterexample, forAll, sized, withMaxSuccess )
+    ( counterexample
+    , forAll
+    , sized
+    , withMaxSuccess
+    )
 import Test.QuickCheck.Monadic
-    ( assert, monadicIO, monitor, run )
+    ( assert
+    , monadicIO
+    , monitor
+    , run
+    )
 
 import Data.Aeson as Json
 import Data.Aeson.Types as Json

--- a/test/Test/Kupo/Data/Pattern/Fixture.hs
+++ b/test/Test/Kupo/Data/Pattern/Fixture.hs
@@ -8,7 +8,11 @@ import Kupo.Prelude
 
 import qualified Data.ByteString as BS
 import Data.List
-    ( delete, (!!), (\\) )
+    ( delete
+    , (!!)
+    , (\\)
+    )
+import qualified Data.Set as Set
 import Kupo.Data.Cardano
     ( Address
     , Output
@@ -19,11 +23,17 @@ import Kupo.Data.Cardano
     , unsafeTransactionIdFromBytes
     )
 import Kupo.Data.Pattern
-    ( MatchBootstrap (..), Pattern (..), overlaps )
+    ( MatchBootstrap (..)
+    , Pattern (..)
+    , overlaps
+    )
 import Test.Kupo.Data.Generators
-    ( generateWith )
+    ( generateWith
+    )
 import Test.Kupo.Data.UtxoConstraint
-    ( ArbitrarySatisfying (..), UtxoConstraint (..) )
+    ( ArbitrarySatisfying (..)
+    , UtxoConstraint (..)
+    )
 
 patterns
     :: [(Text, Pattern, [(OutputReference, Output)])]
@@ -205,7 +215,7 @@ nonOverlappingFragments
 nonOverlappingFragments =
     [ str
     | (str, p) <- fragments'
-    , not (p `overlaps` ((snd <$> fragments') \\ [p]))
+    , not (p `overlaps` (Set.delete p (fromList (snd <$> fragments'))))
     ]
   where
     fragments' = filter ((`notElem` ["*", "*/*"]) . fst) fragments

--- a/test/Test/Kupo/Data/PatternSpec.hs
+++ b/test/Test/Kupo/Data/PatternSpec.hs
@@ -9,17 +9,39 @@ module Test.Kupo.Data.PatternSpec
 import Kupo.Prelude
 
 import Kupo.Data.Cardano
-    ( ComparableOutput, Output, OutputReference, toComparableOutput )
+    ( ComparableOutput
+    , Output
+    , OutputReference
+    , toComparableOutput
+    )
 import Kupo.Data.Pattern
-    ( Pattern (..), includes, matching, overlaps, patternFromText )
+    ( Pattern (..)
+    , includes
+    , matching
+    , overlaps
+    , patternFromText
+    )
 import Test.Hspec
-    ( Spec, context, parallel, shouldBe, specify )
+    ( Spec
+    , context
+    , parallel
+    , shouldBe
+    , specify
+    )
 import Test.Hspec.QuickCheck
-    ( prop )
+    ( prop
+    )
 import Test.Kupo.Data.Pattern.Fixture
-    ( matches, patterns )
+    ( matches
+    , patterns
+    )
 import Test.QuickCheck
-    ( Gen, counterexample, elements, forAll, (==>) )
+    ( Gen
+    , counterexample
+    , elements
+    , forAll
+    , (==>)
+    )
 
 import qualified Data.Set as Set
 
@@ -66,7 +88,7 @@ spec = parallel $ do
         forAll genPattern $ \p1 ->
             forAll genPattern $ \p2 ->
                 p1 `includes` p2 ==>
-                    p1 `overlaps` [p2]
+                    p1 `overlaps` (Set.singleton p2)
 
 --
 -- Helper

--- a/test/Test/Kupo/Data/UtxoConstraint.hs
+++ b/test/Test/Kupo/Data/UtxoConstraint.hs
@@ -19,13 +19,16 @@ import Test.Kupo.Data.Generators
     , genScript
     )
 import Test.QuickCheck
-    ( Gen, choose, frequency )
+    ( Gen
+    , choose
+    , frequency
+    )
 
 data UtxoConstraint
-    = MustHaveAddress Address
+    = MustHaveAddress !Address
     | MustHaveShelleyAddress
-    | MustHaveTransactionId TransactionId
-    | MustHaveOutputReference OutputReference
+    | MustHaveTransactionId !TransactionId
+    | MustHaveOutputReference !OutputReference
 
 class ArbitrarySatisfying a where
     genSatisfying :: [UtxoConstraint] -> Gen a

--- a/test/Test/Kupo/Fixture.hs
+++ b/test/Test/Kupo/Fixture.hs
@@ -11,19 +11,23 @@ import Kupo.Prelude
 import Kupo.Data.Cardano
     ( BinaryData
     , DatumHash
-    , pattern GenesisPoint
     , Point
+    , PolicyId
     , Script
     , ScriptHash
     , TransactionId
+    , pattern GenesisPoint
     , unsafeBinaryDataFromBytes
     , unsafeDatumHashFromBytes
+    , unsafePolicyIdFromBytes
     , unsafeScriptFromBytes
     , unsafeScriptHashFromBytes
     , unsafeTransactionIdFromBytes
     )
 import Kupo.Data.Database
-    ( Checkpoint (..), pointFromRow )
+    ( Checkpoint (..)
+    , pointFromRow
+    )
 
 someNonExistingPoint :: Point
 someNonExistingPoint = pointFromRow $ Checkpoint
@@ -122,6 +126,11 @@ eraBoundaries =
     , ("Alonzo", lastMaryPoint)
     , ("Babbage", lastAlonzoPoint)
     ]
+
+-- A policy id from tokens present in a transaction output in early Alonzo
+somePolicyId :: PolicyId
+somePolicyId = unsafePolicyIdFromBytes $ unsafeDecodeBase16
+    "469F9A74824555709042FB95AA2D11E3C7FA4EADA2FE97BC287687DD"
 
 -- A transaction present in the first Alonzo block.
 someTransactionId :: TransactionId

--- a/test/Test/Kupo/OptionsSpec.hs
+++ b/test/Test/Kupo/OptionsSpec.hs
@@ -17,7 +17,11 @@ import Data.List
 import Kupo.Control.MonadLog
     ( Severity (..), TracerDefinition (..), defaultTracers )
 import Kupo.Data.Cardano
-    ( mkOutputReference, unsafeTransactionIdFromBytes )
+    ( mkOutputReference
+    , unsafeAssetNameFromBytes
+    , unsafePolicyIdFromBytes
+    , unsafeTransactionIdFromBytes
+    )
 import Kupo.Data.Configuration
     ( ChainProducer (..)
     , Configuration (..)
@@ -156,6 +160,32 @@ spec = parallel $ do
                         unsafeTransactionIdFromBytes $ unsafeDecodeBase16 str
                  in
                     [ MatchTransactionId txId ]
+            }
+          )
+        , ( defaultArgs ++ [ "--match", "2e7ee124eccbc648789008f8669695486f5727cada41b2d86d1c3635.*" ]
+          , shouldParseAppConfiguration $ defaultConfiguration
+            { patterns =
+                let
+                    str =
+                        "2e7ee124eccbc648789008f8669695486f5727cada41b2d86d1c3635"
+                    policyId =
+                        unsafePolicyIdFromBytes $ unsafeDecodeBase16 str
+                 in
+                    [ MatchPolicyId policyId ]
+            }
+          )
+        , ( defaultArgs ++ [ "--match", "2e7ee124eccbc648789008f8669695486f5727cada41b2d86d1c3635.706174617465" ]
+          , shouldParseAppConfiguration $ defaultConfiguration
+            { patterns =
+                let
+                    str =
+                        "2e7ee124eccbc648789008f8669695486f5727cada41b2d86d1c3635"
+                    policyId =
+                        unsafePolicyIdFromBytes $ unsafeDecodeBase16 str
+                    assetName =
+                        unsafeAssetNameFromBytes $ unsafeDecodeBase16 "706174617465"
+                 in
+                    [ MatchAssetId (policyId, assetName) ]
             }
           )
         , ( defaultArgs ++ [ "--match", "NOT-A-PATTERN" ]

--- a/test/Test/Kupo/OptionsSpec.hs
+++ b/test/Test/Kupo/OptionsSpec.hs
@@ -13,9 +13,13 @@ module Test.Kupo.OptionsSpec
 import Kupo.Prelude
 
 import Data.List
-    ( isInfixOf )
+    ( isInfixOf
+    )
 import Kupo.Control.MonadLog
-    ( Severity (..), TracerDefinition (..), defaultTracers )
+    ( Severity (..)
+    , TracerDefinition (..)
+    , defaultTracers
+    )
 import Kupo.Data.Cardano
     ( mkOutputReference
     , unsafeAssetNameFromBytes
@@ -29,9 +33,14 @@ import Kupo.Data.Configuration
     , WorkDir (..)
     )
 import Kupo.Data.Pattern
-    ( MatchBootstrap (..), Pattern (..) )
+    ( MatchBootstrap (..)
+    , Pattern (..)
+    )
 import Kupo.Options
-    ( Command (..), Tracers (..), parseOptionsPure )
+    ( Command (..)
+    , Tracers (..)
+    , parseOptionsPure
+    )
 import Test.Hspec
     ( Expectation
     , Spec
@@ -43,7 +52,8 @@ import Test.Hspec
     , specify
     )
 import Test.Kupo.Fixture
-    ( somePoint )
+    ( somePoint
+    )
 
 spec :: Spec
 spec = parallel $ do

--- a/test/Test/KupoSpec.hs
+++ b/test/Test/KupoSpec.hs
@@ -13,29 +13,52 @@ module Test.KupoSpec
 import Kupo.Prelude
 
 import Control.Exception
-    ( try )
+    ( try
+    )
 import Data.List
-    ( maximum, (\\) )
+    ( maximum
+    , (\\)
+    )
 import GHC.IORef
-    ( atomicSwapIORef )
+    ( atomicSwapIORef
+    )
 import Kupo
-    ( kupo, newEnvironment, runWith, version, withTracers )
+    ( kupo
+    , newEnvironment
+    , runWith
+    , version
+    , withTracers
+    )
 import Kupo.App.Configuration
-    ( ConflictingOptionsException, NoStartingPointException )
+    ( ConflictingOptionsException
+    , NoStartingPointException
+    )
 import Kupo.App.Http
-    ( healthCheck )
+    ( healthCheck
+    )
 import Kupo.Control.MonadAsync
-    ( race_ )
+    ( race_
+    )
 import Kupo.Control.MonadDelay
-    ( threadDelay )
+    ( threadDelay
+    )
 import Kupo.Control.MonadLog
-    ( Severity (..), TracerDefinition (..), defaultTracers )
+    ( Severity (..)
+    , TracerDefinition (..)
+    , defaultTracers
+    )
 import Kupo.Control.MonadTime
-    ( DiffTime, timeout )
+    ( DiffTime
+    , timeout
+    )
 import Kupo.Data.Cardano
-    ( pattern GenesisPoint, getPointSlotNo, mkOutputReference )
+    ( getPointSlotNo
+    , mkOutputReference
+    , pattern GenesisPoint
+    )
 import Kupo.Data.ChainSync
-    ( IntersectionNotFoundException )
+    ( IntersectionNotFoundException
+    )
 import Kupo.Data.Configuration
     ( ChainProducer (..)
     , Configuration (..)
@@ -43,19 +66,31 @@ import Kupo.Data.Configuration
     , WorkDir (..)
     )
 import Kupo.Data.Http.GetCheckpointMode
-    ( GetCheckpointMode (..) )
+    ( GetCheckpointMode (..)
+    )
 import Kupo.Data.Http.StatusFlag
-    ( StatusFlag (..) )
+    ( StatusFlag (..)
+    )
 import Kupo.Data.Pattern
-    ( MatchBootstrap (..), Pattern (..), Result (..) )
+    ( MatchBootstrap (..)
+    , Pattern (..)
+    , Result (..)
+    )
 import Kupo.Options
-    ( Tracers (..) )
+    ( Tracers (..)
+    )
 import Network.HTTP.Client
-    ( Manager, defaultManagerSettings, newManager )
+    ( Manager
+    , defaultManagerSettings
+    , newManager
+    )
 import System.Environment
-    ( lookupEnv )
+    ( lookupEnv
+    )
 import System.IO.Temp
-    ( withSystemTempDirectory, withTempFile )
+    ( withSystemTempDirectory
+    , withTempFile
+    )
 import Test.Hspec
     ( Spec
     , SpecWith
@@ -70,7 +105,9 @@ import Test.Hspec
     , xcontext
     )
 import Test.Kupo.App.Http.Client
-    ( HttpClient (..), newHttpClientWith )
+    ( HttpClient (..)
+    , newHttpClientWith
+    )
 import Test.Kupo.Fixture
     ( eraBoundaries
     , lastAlonzoPoint
@@ -97,7 +134,10 @@ import Test.Kupo.Fixture
     , someTransactionId
     )
 import Type.Reflection
-    ( tyConName, typeRep, typeRepTyCon )
+    ( tyConName
+    , typeRep
+    , typeRepTyCon
+    )
 
 import qualified Prelude
 
@@ -269,13 +309,13 @@ spec = skippableContext "End-to-end" $ \manager -> do
                 waitSlot (> (getPointSlotNo somePointSuccessor))
                 getCheckpointBySlot strict (getPointSlotNo somePoint)
                     `shouldReturn` Just somePoint
-                getCheckpointBySlot strict (pred (getPointSlotNo somePoint))
+                getCheckpointBySlot strict (prev (getPointSlotNo somePoint))
                     `shouldReturn` Nothing
                 getCheckpointBySlot strict (getPointSlotNo somePointSuccessor)
                     `shouldReturn` Just somePointSuccessor
-                getCheckpointBySlot strict  (pred (getPointSlotNo somePointSuccessor))
+                getCheckpointBySlot strict  (prev (getPointSlotNo somePointSuccessor))
                     `shouldReturn` Nothing
-                getCheckpointBySlot flex (pred (getPointSlotNo somePointSuccessor))
+                getCheckpointBySlot flex (prev (getPointSlotNo somePointSuccessor))
                     `shouldReturn` Just somePoint
             )
 
@@ -447,7 +487,7 @@ skippableContext prefix skippableSpec = do
                     }
             context cardanoNode $ around (withTempDirectory ref defaultCfg) $
                 skippableSpec manager
-        _ ->
+        _skipOtherwise ->
             xcontext cardanoNode (pure ())
 
     let ogmios = prefix <> " (ogmios)"
@@ -467,7 +507,7 @@ skippableContext prefix skippableSpec = do
                     }
             context ogmios $ around (withTempDirectory ref defaultCfg) $
                 skippableSpec manager
-        _ ->
+        _skipOtherwise ->
             xcontext ogmios (pure ())
   where
     varCardanoNodeSocket :: String
@@ -488,7 +528,7 @@ skippableContext prefix skippableSpec = do
         -> ((FilePath, Tracers IO 'Concrete, Configuration) -> IO ())
         -> IO ()
     withTempDirectory ref cfg action = do
-        serverPort <- atomicModifyIORef' ref $ \port -> (succ port, port)
+        serverPort <- atomicModifyIORef' ref $ \port -> (next port, port)
         withSystemTempDirectory "kupo-end-to-end" $ \dir -> do
             withTempFile dir "traces" $ \_ h ->
                 withTracers h version (defaultTracers (Just Info)) $ \tr ->


### PR DESCRIPTION
Fixes #56 

- :round_pushpin: **Extend patterns to also support asset id and policy id.**
      Similarly to how it was done for output reference and transaction id. The trick however for assets is that there's no good way to pre-filter them in an SQL query given the format in which they are stored. R
ight now, values are serialized as lists of key-value pairs, which makes them non static and hard to query as such. While we _could_ think about a better format that'd enable powerful SQL queries, this commit sim
ply goes the easy path and does the filtering on-the-fly, similar to how it's done when passing query parameters.
