### PR TITLE
Health over Prometheus metrics

### DIFF
--- a/docs/api/latest.yaml
+++ b/docs/api/latest.yaml
@@ -1150,3 +1150,19 @@ paths:
             "application/json;charset=utf-8":
               schema:
                 $ref: "#/components/schemas/Health"
+
+  /metrics:
+    get:
+      operationId: getMetrics
+      tags: ["Health"]
+      summary: Get Health as Prometheus metrics
+      description: |
+        Retrieve Kupo's application health status encoded as Prometheus metrics.
+      responses:
+        200:
+          description: OK
+          headers: *default-headers
+          content:
+            "text/plain;charset=utf-8":
+              schema:
+                type: string

--- a/kupo.cabal
+++ b/kupo.cabal
@@ -163,6 +163,7 @@ library
     , ouroboros-consensus-shelley
     , ouroboros-network
     , ouroboros-network-framework
+    , prometheus
     , relude
     , safe
     , safe-exceptions

--- a/package.yaml
+++ b/package.yaml
@@ -78,6 +78,7 @@ library:
     - ouroboros-consensus-shelley
     - ouroboros-network
     - ouroboros-network-framework
+    - prometheus
     - relude
     - safe
     - safe-exceptions


### PR DESCRIPTION
This patch adds `/metrics` route which exports metrics in Prometheus format (using encoding from `prometheus` library).

Sample output:

```bash
$ curl localhost:1442/metrics
# TYPE kupo_connected gauge
kupo_connected  1.0
# TYPE kupo_most_recent_checkpoint counter
kupo_most_recent_checkpoint  294998
# TYPE kupo_most_recent_node_tip counter
kupo_most_recent_node_tip  71753381
```