### PR TITLE
Retrieve metadata by slot-no

### DIFF
--- a/docs/api/latest.yaml
+++ b/docs/api/latest.yaml
@@ -489,7 +489,7 @@ components:
           type: string
           description: A blake2b-256 hash digest of a Plutus' datum.
           contentEncoding: base16
-          example: 309706b92ad8340cd6a5d31bf9d2e682fdab9fc8865ee3de14e09dedf9b1b635
+          example: 3097...b635
           minLength: 64
           maxLength: 64
         - title: Nothing
@@ -563,11 +563,11 @@ components:
           - unsafe_allow_beyond_safe_zone
           - within_safe_zone
 
-    HeaderHash:
+    HeaderHash: &HeaderHash
       type: string
       description: A blake2b-256 hash digest of a block header.
       contentEncoding: base16
-      example: 9d09706b92adedf9b1b632e682fdab9fc8865ee3de14e0935d8340cd6a5d31bf
+      example: 9d09...31bf
       minLength: 64
       maxLength: 64
 
@@ -860,7 +860,7 @@ components:
           description: A blake2b-224 hash digest of a Native or Plutus script.
           type: string
           contentEncoding: base16
-          example: 309706b92ad8340cd6a5d31bf9d2e682fdab9fc8865ee3de14e09ded
+          example: 3097...9ded
           minLength: 56
           maxLength: 56
         - title: Nothing
@@ -877,7 +877,7 @@ components:
       type: string
       description: A blake2b-256 hash digest of a transaction body.
       contentEncoding: base16
-      example: 35d8340cd6a5d31bf9d09706b92adedf9b1b632e682fdab9fc8865ee3de14e09
+      example: 35d8...4e09
       minLength: 64
       maxLength: 64
 
@@ -1006,7 +1006,7 @@ components:
         minLength: 64
         maxLength: 64
         pattern: ^[a-f0-9]{64}$
-        example: 309706b92ad8340cd6a5d31bf9d2e682fdab9fc8865ee3de14e09dedf9b1b635
+        example: 3097...b635
       description:
         A datum blake2b-256 hash digest.
 
@@ -1064,7 +1064,7 @@ components:
         minLength: 56
         maxLength: 56
         pattern: ^[a-f0-9]{56}$
-        example: 309706b92ad8340cd6a5d31bf9d2e682fdab9fc8865ee3de14e09ded
+        example: 3097...9ded
       description:
         A script blake2b-224 hash digest of a script.
 
@@ -1444,7 +1444,12 @@ paths:
       responses:
         200:
           description: OK
-          headers: *default-headers
+          headers:
+            <<: *default-headers
+            X-Block-Header-Hash:
+              <<: *HeaderHash
+              description: |
+                The block's header hash digest (`blake2b-256`) of the corresponding block at the provided slot. Clients are expected to control that this hash matches the one they expect, especially when fetching metadata from blocks in the unstable region (i.e. less than `k=2160` blocks from the network tip). Indeed, Cardano is a distributed system after all and data isn't guaranteed to be immediately immutable. Data present in very recent blocks may therefore be different between two successive requests.
           content:
             "application/json;charset=utf-8":
               schema:

--- a/docs/api/latest.yaml
+++ b/docs/api/latest.yaml
@@ -571,6 +571,211 @@ components:
       minLength: 64
       maxLength: 64
 
+    Metadata:
+      type: object
+      additionalProperties: false
+      required:
+        - hash
+        - schema
+        - raw
+      properties:
+        hash:
+          type: string
+          description: A blake2b-256 hash digest of the raw serialized data
+          contentEncoding: base16
+          example: cd6a5d31bf9d309706b92ad83402e682fdab9fc889b1b63565ee3de14e09dedf
+          minLength: 64
+          maxLength: 64
+
+        raw:
+          type: string
+          description: A [CBOR](https://www.rfc-editor.org/rfc/rfc8949.html)-encoded binary payload.
+          contentEncoding: base16
+
+        schema:
+          type: object
+          description: |
+            A high-level description of the raw data. The top-level object is an object where all keys are integers (possibly negative) and points to objects representing one of 5 primitives:
+
+            - int
+            - string
+            - bytes
+            - list
+            - map
+
+            This schema is meant to give a faithful representation of the underlying [CBOR](https://www.rfc-editor.org/rfc/rfc8949.html) encoding, which is slightly more expressive than pure JSON (e.g. keys of maps can be arbitrary CBOR objects).
+
+            This is why it is generally not possible to ensure a 1:1 conversion between low-level CBOR and JSON, and why this intermediate representation is necessary to safely represent **any** metadata object.
+          propertyNames:
+            type: integer
+          additionalProperties:
+            x-additionalPropertiesName: "label (integer)"
+            $ref: "#/components/schemas/Metadatum"
+          example:
+            {
+              "64": {"string": "some text"},
+              "32": {"int": 42},
+              "16": {
+                "map": [
+                  {
+                    "k": {"string": "numbers"},
+                    "v": {"list": [{"int": 1}, {"int": 2}, {"int": 4}, {"int": 8}]}
+                  },
+                  {
+                    "k": {"string": "alphabet"},
+                    "v": {
+                      "map": [
+                        {"k": {"string": "A"}, "v": {"int": 65}},
+                        {"k": {"string": "B"}, "v": {"int": 66}},
+                        {"k": {"string": "C"}, "v": {"int": 67}}
+                      ]
+                    }
+                  }
+                ]
+              },
+              "-8": { "bytes": "48656c6c6f2c2043617264616e6f21" }
+            }
+
+    Metadatum:
+      oneOf:
+        - $ref: "#/components/schemas/Metadatum_Int"
+        - $ref: "#/components/schemas/Metadatum_String"
+        - $ref: "#/components/schemas/Metadatum_Bytes"
+        - $ref: "#/components/schemas/Metadatum_List"
+        - $ref: "#/components/schemas/Metadatum_Map"
+
+    Metadatum_Int:
+      title: int
+      type: object
+      additionalProperties: false
+      required:
+        - int
+      properties:
+        int:
+          type: integer
+          description: |
+            An integer or arbitrary size.
+
+            Example:
+
+            ```json
+            { "int": 42 }
+            ```
+
+    Metadatum_String:
+      title: string
+      type: object
+      additionalProperties: false
+      required:
+        - string
+      properties:
+        string:
+          type: string
+          contentEncoding: utf-8
+          maxLength: 64
+          description: |
+            A text string, which is at most 64 bytes.
+
+            Example:
+
+            ```json
+            { "string": "kupo!" }
+            ```
+
+    Metadatum_Bytes:
+      title: bytes
+      type: object
+      additionalProperties: false
+      required:
+        - bytes
+      properties:
+        bytes:
+          type: string
+          contentEncoding: base16
+          maxLength: 128
+          description: |
+            A base16 byte string, which is at most 64 bytes
+
+            Example:
+
+            ```json
+            { "bytes": "6b75706f21" }
+            ```
+
+    Metadatum_List:
+      title: list
+      type: object
+      additionalProperties: false
+      required:
+        - list
+      properties:
+        list:
+          type: array
+          additionalItems: false
+          items:
+            $ref: "#/components/schemas/Metadatum"
+          description: |
+            A (possibly heterogeneous) list of metadatum
+
+            Example:
+
+            ```json
+            {
+              "list": [
+                {
+                  "int": 14
+                },
+                {
+                  "list": [
+                    { "string": "kupo!" },
+                    { "bytes": "6b75706f21" }
+                  ]
+                }
+              ]
+            }
+            ```
+
+    Metadatum_Map:
+      title: map
+      type: object
+      additionalProperties: false
+      required:
+        - map
+      properties:
+        map:
+          type: array
+          items:
+            type: object
+            additionalItems: false
+            required:
+              - k
+              - v
+            properties:
+              k:
+                $ref: "#/components/schemas/Metadatum"
+              v:
+                $ref: "#/components/schemas/Metadatum"
+          description: |
+            A list of key:value objects. Both keys and values can be any sort metadatum.
+
+            Example:
+
+            ```json
+            {
+              "map": [
+                {
+                  "k": { "int": 14 },
+                  "v": {
+                    "list": [
+                      { "string": "kupo!" },
+                      { "bytes": "6b75706f21" }
+                    ]
+                  }
+                }
+              ]
+            }
+            ```
+
     OutputIndex:
       type: integer
       description: The index of the output within the transaction carrying it.
@@ -887,6 +1092,15 @@ components:
       description: |
         A query flag (i.e. `?strict`) to only look for checkpoints that strictly match the provided slot. The behavior otherwise is to look for the largest nearest slot smaller or equal to the one provided.
 
+    transaction-id:
+      name: transaction_id
+      in: query
+      required: false
+      description: |
+        An optional transaction id to retrieve items associated with the transaction only.
+      schema:
+        $ref: "#/components/schemas/TransactionId"
+
     unspent:
       name: unspent
       in: query
@@ -897,14 +1111,33 @@ components:
 
 tags:
   - name: Matches
+    description: |
+      Accessing results matched by a certain configuration. Results can be retrieve using **any** pattern (and not only those defined in configuration). So it is possible for example to
+      index data using quite wide patterns (e.g. `*`) but only query a single address later on.
   - name: Checkpoints
     description: |
       An API for inspecting checkpoints known of the database. A checkpoint really is a point on-chain that directly references a block. They are comprised of an absolute slot
       number and a block header hash. Kupo records all such points as it processes blocks. In particular, they are also used to resume synchronization upon restart.
   - name: Datums
+    description: |
+      Accessing datums indexed by the server. By default, the engine indexes **every** datum present in transaction witnesses and inline datums present in **matched** transaction outputs. However,
+      a periodic garbage collector will automatically remove datums that aren't associated to any matched output. Said differently, any datum hash present in a matched output can be queried (so long
+      as its datum has been seen on-chain one way or another). Other hashes _may_ work but aren't guaranteed.
   - name: Scripts
+    description: |
+      Accessing scripts indexed by the server. By default, the engine indexes **every** script present in transaction witnesses and inline scripts present in **matched** transaction outputs. However,
+      a periodic garbage collector will automatically remove scripts that aren't associated to any matched output. Said differently, any script hash present in a matched output can be queried (so long
+      as its script has been seen on-chain one way or another). Other hashes _may_ work but aren't guaranteed.
+  - name: Metadata
+    description: |
+      Accessing metadata present in blocks/transactions. Unlike most other resources, metadata are **not** indexed by the server and are retrieved on-the-fly directly from the node. This is generally quite fast but likely not suitable for fetching large batches of metadata.
   - name: Patterns
+    description: |
+      Dynamically managing the server's configuration. Note that modifying patterns after the server has started indexing may break the server's data integrity -- or more exactly, data completeness.
+      The server does not re-synchronize past blocks unless explicitly told so.
   - name: Health
+    description: |
+      Monitoring endpoints to assess the server's health.
 
 paths:
   /matches:
@@ -1196,6 +1429,28 @@ paths:
                 oneOf:
                   - $ref: "#/components/schemas/Point"
                   - type: "null"
+
+  /metadata/{slot-no}:
+    get:
+      operationId: getMetadataBySlot
+      tags: ["Metadata"]
+      summary: Get Metadata By Slot
+      description: |
+        Retrieve all metadata data seen in a block at the given slot, possibly filtered by transaction id.
+
+        Metadata are ordered according to their respective transaction's order in the block.
+      parameters:
+        - $ref: "#/components/parameters/transaction-id"
+      responses:
+        200:
+          description: OK
+          headers: *default-headers
+          content:
+            "application/json;charset=utf-8":
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Metadata"
 
   /health:
     get:

--- a/kupo.cabal
+++ b/kupo.cabal
@@ -45,10 +45,11 @@ library
       Kupo
       Kupo.App
       Kupo.App.ChainSync
-      Kupo.App.ChainSync.Direct
+      Kupo.App.ChainSync.Node
       Kupo.App.ChainSync.Ogmios
       Kupo.App.Configuration
       Kupo.App.Database
+      Kupo.App.FetchBlock.Node
       Kupo.App.Health
       Kupo.App.Http
       Kupo.App.Http.HealthCheck

--- a/kupo.cabal
+++ b/kupo.cabal
@@ -50,6 +50,7 @@ library
       Kupo.App.Configuration
       Kupo.App.Database
       Kupo.App.FetchBlock.Node
+      Kupo.App.FetchBlock.Ogmios
       Kupo.App.Health
       Kupo.App.Http
       Kupo.App.Http.HealthCheck

--- a/kupo.cabal
+++ b/kupo.cabal
@@ -66,6 +66,7 @@ library
       Kupo.Data.ChainSync
       Kupo.Data.Configuration
       Kupo.Data.Database
+      Kupo.Data.FetchBlock
       Kupo.Data.Health
       Kupo.Data.Http.Default
       Kupo.Data.Http.Error
@@ -324,6 +325,7 @@ test-suite unit
     , quickcheck-state-machine
     , relude
     , sqlite-simple
+    , stm
     , temporary
     , text
     , wai

--- a/package.yaml
+++ b/package.yaml
@@ -121,6 +121,7 @@ tests:
     - quickcheck-state-machine
     - relude
     - sqlite-simple
+    - stm
     - temporary
     - text
     - wai

--- a/src/Kupo/App.hs
+++ b/src/Kupo/App.hs
@@ -111,6 +111,7 @@ import qualified Data.Set as Set
 import qualified Kupo.App.ChainSync.Node as Node
 import qualified Kupo.App.ChainSync.Ogmios as Ogmios
 import qualified Kupo.App.FetchBlock.Node as Node
+import qualified Kupo.App.FetchBlock.Ogmios as Ogmios
 
 --
 -- Producer
@@ -186,8 +187,8 @@ withFetchBlockClient
     -> IO ()
 withFetchBlockClient chainProducer callback = do
     case chainProducer of
-        Ogmios{} -> do
-            error "withFetchBlockClient^ogmios: TODO"
+        Ogmios{ogmiosHost, ogmiosPort} ->
+            Ogmios.withFetchBlockClient ogmiosHost ogmiosPort callback
         CardanoNode{nodeSocket, nodeConfig} -> do
             NetworkParameters
                 { networkMagic

--- a/src/Kupo/App.hs
+++ b/src/Kupo/App.hs
@@ -99,7 +99,7 @@ import Kupo.Data.Pattern
 
 import qualified Data.Map as Map
 import qualified Data.Set as Set
-import qualified Kupo.App.ChainSync.Direct as Direct
+import qualified Kupo.App.ChainSync.Node as Node
 import qualified Kupo.App.ChainSync.Ogmios as Ogmios
 
 --
@@ -150,7 +150,7 @@ newProducer tr chainProducer callback = do
                   networkMagic
                   slotsPerEpoch
                   nodeSocket
-                  (Direct.mkChainSyncClient forcedRollbackVar mailbox checkpoints)
+                  (Node.mkChainSyncClient forcedRollbackVar mailbox checkpoints)
                   & handle
                     (\case
                         e@IntersectionNotFound{requestedPoints = points} -> do

--- a/src/Kupo/App.hs
+++ b/src/Kupo/App.hs
@@ -28,6 +28,7 @@ import Control.Monad.Class.MonadTimer
     )
 import Kupo.App.ChainSync
     ( TraceChainSync (..)
+    , withChainSyncExceptionHandler
     )
 import Kupo.App.Configuration
     ( TraceConfiguration (..)
@@ -53,6 +54,7 @@ import Kupo.Control.MonadLog
     , MonadLog (..)
     , Severity (..)
     , Tracer
+    , nullTracer
     )
 import Kupo.Control.MonadOuroboros
     ( MonadOuroboros (..)
@@ -194,13 +196,14 @@ withFetchBlockClient chainProducer callback = do
             (chainSyncClient, fetchBlockClient) <- Node.newFetchBlockClient
             race_
                 (callback fetchBlockClient)
-                (withChainSyncServer
-                  noConnectionStatusToggle
-                  [ NodeToClientV_9 .. maxBound ]
-                  networkMagic
-                  slotsPerEpoch
-                  nodeSocket
-                  chainSyncClient
+                (withChainSyncExceptionHandler nullTracer noConnectionStatusToggle $
+                    withChainSyncServer
+                        noConnectionStatusToggle
+                        [ NodeToClientV_9 .. maxBound ]
+                        networkMagic
+                        slotsPerEpoch
+                        nodeSocket
+                        chainSyncClient
                 )
 
 -- | Consumer process that is reading messages from the 'Mailbox'. Messages are

--- a/src/Kupo/App/ChainSync/Node.hs
+++ b/src/Kupo/App/ChainSync/Node.hs
@@ -2,7 +2,7 @@
 --  License, v. 2.0. If a copy of the MPL was not distributed with this
 --  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-module Kupo.App.ChainSync.Direct
+module Kupo.App.ChainSync.Node
     ( mkChainSyncClient
     ) where
 
@@ -66,6 +66,10 @@ mkChainSyncClient var0 mailbox pts =
         -- functions that do not get garbage-collected somehow. As a results,
         -- the heap just keep growing. Inlining the TMVar nicely fixes the
         -- problem.
+        --
+        -- Compiling with `-fno-full-laziness` fixes the issue which suggests that
+        -- some thunks are being created somewhere when used as a top-level binding.
+        --
         -- Interestingly, there's no issue with the 'mailbox'.
         SendMsgFindIntersect pts (clientStIntersect var0 Nothing)
   where

--- a/src/Kupo/App/ChainSync/Ogmios.hs
+++ b/src/Kupo/App/ChainSync/Ogmios.hs
@@ -124,10 +124,3 @@ connect ConnectionStatusToggle{toggleConnected} host port action =
         --
         -- [("Sec-WebSocket-Protocol", "ogmios.v1:compact")]
         WS.defaultConnectionOptions [] (\ws -> toggleConnected >> action ws)
-
-data CannotResolveAddressException = CannotResolveAddress
-    { host :: !String
-    , port :: !Int
-    } deriving (Show)
-
-instance Exception CannotResolveAddressException

--- a/src/Kupo/App/FetchBlock/Node.hs
+++ b/src/Kupo/App/FetchBlock/Node.hs
@@ -54,7 +54,7 @@ newFetchBlockClient = do
         ( ChainSyncClientPipelined $ pure $ SendMsgFindIntersect [GenesisPoint] $
                 ClientPipelinedStIntersect
                 { recvMsgIntersectFound = \_point _tip -> do
-                    clientStIdle $ atomically (readTMVar reqVar)
+                    clientStIdle $ atomically (takeTMVar reqVar)
                 , recvMsgIntersectNotFound = \_tip -> do
                     error "mkFetchBlockClient.recvMsgIntersectNotFound: absurd; \
                           \it's always possible to find an intersection against the origin."

--- a/src/Kupo/App/FetchBlock/Node.hs
+++ b/src/Kupo/App/FetchBlock/Node.hs
@@ -1,0 +1,109 @@
+--  This Source Code Form is subject to the terms of the Mozilla Public
+--  License, v. 2.0. If a copy of the MPL was not distributed with this
+--  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+{-# LANGUAGE PatternSynonyms #-}
+
+module Kupo.App.FetchBlock.Node
+    ( FetchBlockClient
+    , newFetchBlockClient
+    ) where
+
+import Kupo.Prelude
+
+import Control.Monad.Class.MonadSTM
+    ( MonadSTM (..)
+    )
+import Kupo.Data.Cardano
+    ( Point
+    , Tip
+    , pattern GenesisPoint
+    )
+import Kupo.Data.FetchBlock
+    ( FetchBlockClient
+    )
+import Network.TypedProtocol.Pipelined
+    ( N (..)
+    )
+import Ouroboros.Network.Protocol.ChainSync.ClientPipelined
+    ( ChainSyncClientPipelined (..)
+    , ClientPipelinedStIdle (..)
+    , ClientPipelinedStIntersect (..)
+    , ClientStNext (..)
+    )
+
+-- | Callback given to intermediate client states to ease signature / handling.
+type BlockFetchHandler (m :: Type -> Type) block =
+    Maybe block -> m (ClientPipelinedStIdle Z block Point Tip m ())
+
+-- | A chain-sync client tailored to retrieving specific blocks, identified by their point on chain.
+--
+-- The client is idle most of the time, waiting for requests from an external actor, and provide
+-- requested block in a timely manner as callback.
+--
+-- Note that the client fetches the block immediately *following* the given point. It is therefore up
+-- to the caller to figure out what the previous point on chain of the block they're after is.
+newFetchBlockClient
+    :: forall m block.
+        ( MonadSTM m
+        )
+    => m (ChainSyncClientPipelined block Point Tip m (), FetchBlockClient m block)
+newFetchBlockClient = do
+    reqVar <- newEmptyTMVarIO
+    pure
+        ( ChainSyncClientPipelined $ pure $ SendMsgFindIntersect [GenesisPoint] $
+                ClientPipelinedStIntersect
+                { recvMsgIntersectFound = \_point _tip -> do
+                    clientStIdle $ atomically (readTMVar reqVar)
+                , recvMsgIntersectNotFound = \_tip -> do
+                    error "mkFetchBlockClient.recvMsgIntersectNotFound: absurd; \
+                          \it's always possible to find an intersection against the origin."
+                }
+        , \point reply -> do
+            atomically $ putTMVar reqVar (point, reply)
+        )
+  where
+    clientStIdle
+            :: m (Point, Maybe block -> m ())
+            -> m (ClientPipelinedStIdle Z block Point Tip m ())
+    clientStIdle await =
+        await <&> \(point, reply) ->
+            SendMsgFindIntersect [point] $ clientStIntersect $ \block -> do
+                reply block
+                clientStIdle await
+
+    clientStIntersect
+        :: BlockFetchHandler m block
+        -> ClientPipelinedStIntersect block Point Tip m ()
+    clientStIntersect reply =
+        ClientPipelinedStIntersect
+        { recvMsgIntersectFound = \_point _tip ->
+            let st = clientStNextRollback reply
+             in pure $ SendMsgRequestNext st (pure st)
+        , recvMsgIntersectNotFound = \_tip ->
+            reply Nothing
+        }
+
+    clientStNextRollback
+        :: BlockFetchHandler m block
+        -> ClientStNext Z block Point Tip m ()
+    clientStNextRollback reply =
+        ClientStNext
+        { recvMsgRollForward = \_block _tip ->
+            error "clientStNextRollback.recvMsgRollForward: absurd; \
+                  \After a successful intersection, the node always sends a 'RollBackward' message."
+        , recvMsgRollBackward = \_point _tip ->
+            let st = clientStNextRollForward reply
+             in pure $ SendMsgRequestNext st (pure st)
+        }
+
+    clientStNextRollForward
+        :: BlockFetchHandler m block
+        -> ClientStNext Z block Point Tip m ()
+    clientStNextRollForward reply =
+        ClientStNext
+        { recvMsgRollForward = \block _tip ->
+            reply (Just block)
+        , recvMsgRollBackward = \_point _tip ->
+            reply Nothing
+        }

--- a/src/Kupo/App/FetchBlock/Ogmios.hs
+++ b/src/Kupo/App/FetchBlock/Ogmios.hs
@@ -1,0 +1,44 @@
+--  This Source Code Form is subject to the terms of the Mozilla Public
+--  License, v. 2.0. If a copy of the MPL was not distributed with this
+--  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+module Kupo.App.FetchBlock.Ogmios
+    ( withFetchBlockClient
+    ) where
+
+import Kupo.Prelude
+
+import Kupo.Data.FetchBlock
+    ( FetchBlockClient
+    )
+import Kupo.Data.Ogmios
+    ( PartialBlock
+    , RequestNextResponse (..)
+    , decodeFindIntersectResponse
+    , decodeRequestNextResponse
+    , encodeFindIntersect
+    , encodeRequestNext
+    )
+
+import qualified Network.WebSockets as WS
+import qualified Network.WebSockets.Json as WS
+
+withFetchBlockClient
+    :: String
+    -> Int
+    -> (FetchBlockClient IO PartialBlock -> IO ())
+    -> IO ()
+withFetchBlockClient host port action =
+    action $ \point reply -> WS.runClient host port "/" $ \ws -> do
+        WS.sendJson ws (encodeFindIntersect [point])
+        WS.receiveJson ws (decodeFindIntersectResponse identity) >>= \case
+            Left _notFound -> reply Nothing
+            Right () -> do
+                replicateM_ 2 (WS.sendJson ws encodeRequestNext)
+                -- NOTE: The first reply is always a 'Roll-Backward' to the requested point. Ignore.
+                void (WS.receiveJson ws decodeRequestNextResponse)
+                WS.receiveJson ws decodeRequestNextResponse >>= \case
+                    RollBackward _tip _point -> do
+                        reply Nothing
+                    RollForward _tip block -> do
+                        reply (Just block)

--- a/src/Kupo/App/Http.hs
+++ b/src/Kupo/App/Http.hs
@@ -50,6 +50,7 @@ import Kupo.Data.Cardano
     , hasAssetId
     , hasPolicyId
     , headerHashToBytes
+    , headerHashToText
     , metadataToJson'
     , pattern GenesisPoint
     , pointToJson
@@ -602,7 +603,7 @@ handleGetMetadata baseHeaders slotArg Database{..} fetchBlock =
                 let headers =
                         ( "X-Block-Header-Hash"
                         -- NOTE: Safe because it can't be origin (it has an ancestor)
-                        , headerHashToBytes (unsafeGetPointHeaderHash (getPoint blk))
+                        , encodeUtf8 $ headerHashToText $ unsafeGetPointHeaderHash $ getPoint blk
                         ) : baseHeaders
                 atomically $ putTMVar response $ responseStreamJson headers metadataToJson' $
                     \yield done -> do

--- a/src/Kupo/Data/Cardano.hs
+++ b/src/Kupo/Data/Cardano.hs
@@ -31,6 +31,7 @@ module Kupo.Data.Cardano
     , metadataToText
     , metadataFromText
     , metadataToJson
+    , metadataFromJson
     , metadataToJson'
 
       -- * MetadataHash
@@ -278,6 +279,9 @@ import Cardano.Slotting.Slot
 import Control.Arrow
     ( left
     )
+import Data.Aeson
+    ( (.:)
+    )
 import Data.Binary.Put
     ( runPut
     )
@@ -372,8 +376,12 @@ import qualified Cardano.Ledger.ShelleyMA.Timelocks as Ledger.MaryAllegra
 import qualified Cardano.Ledger.ShelleyMA.TxBody as Ledger.MaryAllegra
 import qualified Cardano.Ledger.TxIn as Ledger
 import qualified Codec.CBOR.Read as Cbor
+import qualified Data.Aeson as Json
 import qualified Data.Aeson.Encoding as Json
 import qualified Data.Aeson.Key as Json
+import qualified Data.Aeson.Key as Json.Key
+import qualified Data.Aeson.KeyMap as Json.KeyMap
+import qualified Data.Aeson.Types as Json
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Short as SBS
 import qualified Data.Map as Map
@@ -448,10 +456,10 @@ metadataToJson (Ledger.Metadata meta) =
     encodeMetadatum = \case
         Ledger.I n ->
             encodeObject [("int", Json.integer n)]
-        Ledger.B bytes ->
-            encodeObject [("bytes", Json.text $ encodeBase16 bytes)]
         Ledger.S txt ->
             encodeObject [("string", Json.text txt)]
+        Ledger.B bytes ->
+            encodeObject [("bytes", Json.text $ encodeBase16 bytes)]
         Ledger.List xs ->
             encodeObject [("list", Json.list encodeMetadatum xs)]
         Ledger.Map xs ->
@@ -463,6 +471,63 @@ metadataToJson (Ledger.Metadata meta) =
             [ ( "k", encodeMetadatum k )
             , ( "v", encodeMetadatum v )
             ]
+
+metadataFromJson :: Json.Value -> Json.Parser (MetadataHash, Metadata)
+metadataFromJson = fmap mkMetadata . Json.withObject "Metadata"
+    (Json.KeyMap.foldrWithKey
+        (\k v accum -> Map.insert
+            <$> metadatumLabelFromJson k
+            <*> metadatumFromJson v
+            <*> accum
+        )
+        (pure Map.empty)
+    )
+  where
+    metadatumLabelFromJson :: Json.Key -> Json.Parser Word64
+    metadatumLabelFromJson key = do
+        (lbl, remLbl) <- either fail pure (T.decimal $ Json.Key.toText key)
+        guard (T.null remLbl)
+        pure lbl
+
+    metadatumFromJson :: Json.Value -> Json.Parser Metadatum
+    metadatumFromJson = Json.withObject "Metadatum" $ \o -> asum
+        [ metadatumIntFromJson o
+        , metadatumStringFromJson o
+        , metadatumBytesFromJson o
+        , metadatumListFromJson o
+        , metadatumMapFromJson o
+        ]
+      where
+        metadatumIntFromJson :: Json.Object -> Json.Parser Metadatum
+        metadatumIntFromJson o = do
+            i <- o .: "int"
+            pure (Ledger.I i)
+
+        metadatumStringFromJson :: Json.Object -> Json.Parser Metadatum
+        metadatumStringFromJson o = do
+            s <- o .: "string"
+            pure (Ledger.S s)
+
+        metadatumBytesFromJson :: Json.Object -> Json.Parser Metadatum
+        metadatumBytesFromJson o = do
+            b <- (o .: "bytes")
+              >>= either (fail . toString) pure . decodeBase16 . encodeUtf8 @Text
+            pure (Ledger.B b)
+
+        metadatumListFromJson :: Json.Object -> Json.Parser Metadatum
+        metadatumListFromJson o = do
+            xs <- (o .: "list") >>= traverse metadatumFromJson
+            pure (Ledger.List xs)
+
+        metadatumMapFromJson :: Json.Object -> Json.Parser Metadatum
+        metadatumMapFromJson o = do
+            xs <- (o .: "map") >>= traverse
+                (Json.withObject "map" $ \m -> do
+                    k <- m .: "k"
+                    v <- m .: "v"
+                    (,) <$> metadatumFromJson k <*> metadatumFromJson v
+                )
+            pure (Ledger.Map xs)
 
 metadataToJson' :: (MetadataHash, Metadata) -> Json.Encoding
 metadataToJson' (hash, meta) =

--- a/src/Kupo/Data/Cardano.hs
+++ b/src/Kupo/Data/Cardano.hs
@@ -39,6 +39,7 @@ module Kupo.Data.Cardano
     , metadataHashToJson
     , metadataHashToText
     , metadataHashFromText
+    , unsafeMetadataHashFromBytes
 
       -- * TransactionId
     , TransactionId
@@ -200,9 +201,10 @@ module Kupo.Data.Cardano
 
       -- * HeaderHash
     , HeaderHash
-    , headerHashToBytes
+    , headerHashToText
     , headerHashFromText
     , headerHashToJson
+    , headerHashToBytes
     , unsafeHeaderHashFromBytes
 
       -- * Point
@@ -478,6 +480,13 @@ type MetadataHash =
 hashMetadata :: Metadata -> MetadataHash
 hashMetadata = Ledger.hashMetadata
 {-# INLINABLE hashMetadata #-}
+
+unsafeMetadataHashFromBytes :: HasCallStack => ByteString -> MetadataHash
+unsafeMetadataHashFromBytes =
+    Ledger.unsafeMakeSafeHash
+    . fromMaybe (error "unsafeMetadataHashFromBytes")
+    . hashFromBytes @Blake2b_256
+{-# INLINABLE unsafeMetadataHashFromBytes #-}
 
 metadataHashToText :: MetadataHash -> Text
 metadataHashToText =
@@ -1597,6 +1606,13 @@ headerHashFromText
 headerHashFromText =
     fmap (OneEraHash . hashToBytesShort) . hashFromTextAsHex @Blake2b_256
 {-# INLINABLE headerHashFromText #-}
+
+headerHashToText
+    :: HeaderHash Block
+    -> Text
+headerHashToText =
+    encodeBase16 . headerHashToBytes
+{-# INLINABLE headerHashToText #-}
 
 headerHashToBytes
     :: HeaderHash Block

--- a/src/Kupo/Data/FetchBlock.hs
+++ b/src/Kupo/Data/FetchBlock.hs
@@ -1,0 +1,15 @@
+--  This Source Code Form is subject to the terms of the Mozilla Public
+--  License, v. 2.0. If a copy of the MPL was not distributed with this
+--  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+module Kupo.Data.FetchBlock where
+
+import Kupo.Prelude
+
+import Kupo.Data.Cardano
+    ( Point
+    )
+
+--  | A simple block fetch client, that retrieves blocks from a given point.
+type FetchBlockClient m block =
+    Point -> (Maybe block -> m ()) -> m ()

--- a/src/Kupo/Data/Http/Error.hs
+++ b/src/Kupo/Data/Http/Error.hs
@@ -82,6 +82,16 @@ invalidSlotNo =
                  \number. That is, an non-negative integer."
         }
 
+noAncestor :: Response
+noAncestor =
+    responseJson status400 Default.headers $ HttpError
+        { hint = "There's no known-ancestor to the point you've provided! \
+                 \No worries, if you're querying a very recent point, it may \
+                \just be the case that your request arrived in between a \
+                \rollback. Note also that there's (obviously) no ancesto to \
+                \the slot number `0`."
+        }
+
 malformedDatumHash :: Response
 malformedDatumHash =
     responseJson status400 Default.headers $ HttpError

--- a/src/Kupo/Data/Http/Error.hs
+++ b/src/Kupo/Data/Http/Error.hs
@@ -56,6 +56,14 @@ invalidMatchFilter =
                  \In case of doubts, check the documentation at: <https://cardanosolutions.github.io/kupo>!"
         }
 
+invalidMetadataFilter :: Response
+invalidMetadataFilter =
+    responseJson status400 Default.headers $ HttpError
+        { hint = "Invalid or incomplete filter query parameters! You can (optionally) filter \
+                 \metadata by 'transaction_id', which must be a valid text string encoded in base16. \
+                 \In case of doubts, check the documentation at: <https://cardanosolutions.github.io/kupo#operation/getMetadataBySlot>!"
+        }
+
 stillActivePattern :: Response
 stillActivePattern =
     responseJson status400 Default.headers $ HttpError

--- a/src/Kupo/Data/Http/FilterMatchesBy.hs
+++ b/src/Kupo/Data/Http/FilterMatchesBy.hs
@@ -80,7 +80,7 @@ filterMatchesBy = search Nothing Nothing
             policyId <- case search byPolicyId byTransactionId rest of
                 Just (FilterByPolicyId policyId) ->
                     Just policyId
-                _ ->
+                _noPolicyId ->
                     Nothing
             assetName <- assetNameFromText str
             pure $ FilterByAssetId (policyId, assetName)
@@ -89,7 +89,7 @@ filterMatchesBy = search Nothing Nothing
             txId <- case search byPolicyId byTransactionId rest of
                 Just (FilterByTransactionId tId) ->
                     Just tId
-                _ ->
+                _noTransactionId ->
                     Nothing
             outputIndex <- outputIndexFromText str
             pure $ FilterByOutputReference (mkOutputReference txId outputIndex)

--- a/src/Kupo/Data/Ogmios.hs
+++ b/src/Kupo/Data/Ogmios.hs
@@ -56,6 +56,7 @@ import Kupo.Data.Cardano
     , fromNativeScript
     , hashScript
     , headerHashToJson
+    , metadataFromJson
     , mkOutput
     , mkOutputReference
     , noDatum
@@ -414,7 +415,9 @@ decodePartialTransaction = Json.withObject "PartialTransaction" $ \o -> do
     scripts <- case scriptsInAuxiliaryData of
         Just xs -> decodeScripts' scriptsInWitness xs
         Nothing -> pure scriptsInWitness
-    let metadata = undefined
+    metadata <- auxiliaryData .:? "blob" >>= \case
+        Nothing -> pure Nothing
+        Just v  -> Just <$> metadataFromJson v
     case inputSource of
         Just ("collaterals" :: Text) -> do
             inputs <- traverse decodeInput =<< (o .: "body" >>= (.: "collaterals"))

--- a/src/Kupo/Data/PartialBlock.hs
+++ b/src/Kupo/Data/PartialBlock.hs
@@ -12,6 +12,7 @@ import Kupo.Prelude
 import Kupo.Data.Cardano
     ( BinaryData
     , DatumHash
+    , HasTransactionId (..)
     , Input
     , IsBlock (..)
     , Metadata
@@ -21,6 +22,8 @@ import Kupo.Data.Cardano
     , Point
     , Script
     , ScriptHash
+    , StandardCrypto
+    , TransactionId
     )
 
 import qualified Data.Set as Set
@@ -35,12 +38,16 @@ data PartialBlock = PartialBlock
 -- | A partial transaction, analogous to 'PartialBlock', trimmed down to the
 -- minimum.
 data PartialTransaction = PartialTransaction
-    { inputs :: ![Input]
+    { id :: !TransactionId
+    , inputs :: ![Input]
     , outputs :: ![(OutputReference, Output)]
     , datums :: !(Map DatumHash BinaryData)
     , scripts :: !(Map ScriptHash Script)
     , metadata :: !(Maybe (MetadataHash, Metadata))
     } deriving (Eq, Show)
+
+instance HasTransactionId PartialTransaction StandardCrypto where
+    getTransactionId = id
 
 instance IsBlock PartialBlock where
     type BlockBody PartialBlock = PartialTransaction

--- a/src/Kupo/Data/PartialBlock.hs
+++ b/src/Kupo/Data/PartialBlock.hs
@@ -14,6 +14,8 @@ import Kupo.Data.Cardano
     , DatumHash
     , Input
     , IsBlock (..)
+    , Metadata
+    , MetadataHash
     , Output
     , OutputReference
     , Point
@@ -27,16 +29,17 @@ import qualified Data.Set as Set
 -- are relevant to kupo. Rest isn't indexed.
 data PartialBlock = PartialBlock
     { blockPoint :: !Point
-    , blockBody :: ![ PartialTransaction ]
+    , blockBody :: ![PartialTransaction]
     } deriving (Eq, Show)
 
 -- | A partial transaction, analogous to 'PartialBlock', trimmed down to the
 -- minimum.
 data PartialTransaction = PartialTransaction
-    { inputs :: ![ Input ]
-    , outputs :: ![ (OutputReference, Output) ]
+    { inputs :: ![Input]
+    , outputs :: ![(OutputReference, Output)]
     , datums :: !(Map DatumHash BinaryData)
     , scripts :: !(Map ScriptHash Script)
+    , metadata :: !(Maybe (MetadataHash, Metadata))
     } deriving (Eq, Show)
 
 instance IsBlock PartialBlock where
@@ -59,3 +62,6 @@ instance IsBlock PartialBlock where
 
     witnessedScripts =
         scripts
+
+    userDefinedMetadata =
+        metadata

--- a/src/Kupo/Prelude.hs
+++ b/src/Kupo/Prelude.hs
@@ -9,8 +9,11 @@ module Kupo.Prelude
       -- * JSON
     , FromJSON (..)
     , ToJSON (..)
-    , byteStringToJson
+    , eitherDecodeJson
     , defaultGenericToEncoding
+    , encodeBytes
+    , encodeObject
+    , encodeMap
 
       -- * Lenses
     , Lens'
@@ -39,11 +42,6 @@ module Kupo.Prelude
     , serialize'
     , decodeFull'
     , unsafeDeserialize'
-
-      -- * JSON
-    , eitherDecodeJson
-    , encodeObject
-    , encodeMap
 
       -- * System
     , hijackSigTerm
@@ -202,11 +200,6 @@ encodeBase58 :: ByteString -> Text
 encodeBase58 =
     decodeUtf8 . Base58.encodeBase58 Base58.bitcoinAlphabet
 
--- | Encode a ByteString to JSON as a base16 text
-byteStringToJson :: ByteString -> Json.Encoding
-byteStringToJson =
-    Json.text . encodeBase16
-
 -- | Generic JSON encoding, with pre-defined default options.
 defaultGenericToEncoding :: (Generic a, GToJSON' Encoding Zero (Rep a)) => a -> Json.Encoding
 defaultGenericToEncoding =
@@ -243,3 +236,8 @@ encodeMap encodeKey encodeValue =
 encodeObject :: [(Text, Json.Encoding)] -> Json.Encoding
 encodeObject =
     Json.pairs . foldr (\(Json.fromText -> k, v) -> (<>) (Json.pair k v)) mempty
+
+-- | Encode a ByteString to JSON as a base16 text
+encodeBytes :: ByteString -> Json.Encoding
+encodeBytes =
+    Json.text . encodeBase16

--- a/src/Kupo/Prelude.hs
+++ b/src/Kupo/Prelude.hs
@@ -104,6 +104,7 @@ import Relude hiding
     , TVar
     , atomically
     , catchSTM
+    , id
     , isEmptyTMVar
     , mkWeakTMVar
     , modifyTVar'

--- a/test/Test/Kupo/App/Http/Client.hs
+++ b/test/Test/Kupo/App/Http/Client.hs
@@ -39,6 +39,8 @@ import Kupo.Data.Cardano
     , Datum
     , DatumHash
     , ExtendedOutputReference
+    , Metadata
+    , MetadataHash
     , Point
     , Script
     , ScriptHash
@@ -51,6 +53,8 @@ import Kupo.Data.Cardano
     , datumHashToText
     , fromDatumHash
     , getPointSlotNo
+    , metadataFromText
+    , metadataHashFromText
     , mkOutputReference
     , noDatum
     , pointFromText
@@ -99,6 +103,7 @@ import qualified Data.Aeson as Json
 import qualified Data.Aeson.Encoding as Json
 import qualified Data.Aeson.KeyMap as Json
 import qualified Data.Aeson.Types as Json
+import qualified Data.ByteString.Lazy.Char8 as BL8
 import qualified Data.Map as Map
 import qualified Data.Text as T
 
@@ -115,6 +120,8 @@ data HttpClient (m :: Type -> Type) = HttpClient
         :: ScriptHash -> m (Maybe Script)
     , waitScript
         :: ScriptHash -> m Script
+    , lookupMetadataBySlotNo
+        :: SlotNo -> m [(MetadataHash, Metadata)]
     , listCheckpoints
         :: m [Point]
     , getCheckpointBySlot
@@ -151,6 +158,8 @@ newHttpClientWith manager (serverHost, serverPort) logs =
             \a0 -> waitForServer >> _lookupScriptByHash a0
         , waitScript =
             \a0 -> waitForServer >> _waitScript a0
+        , lookupMetadataBySlotNo =
+            \a0 -> waitForServer >> _lookupMetadataBySlotNo a0
         , listCheckpoints =
             waitForServer >> _listCheckpoints
         , getCheckpointBySlot =
@@ -299,6 +308,23 @@ newHttpClientWith manager (serverHost, serverPort) logs =
                 log $ "waitScript (" <> scriptStr <> "): found"
                 pure script
 
+    _lookupMetadataBySlotNo :: SlotNo -> IO [(MetadataHash, Metadata)]
+    _lookupMetadataBySlotNo slotNo = do
+        let fragment = toString (slotNoToText slotNo)
+        req <- parseRequest (baseUrl <> "/metadata/" <> fragment)
+        res <- httpLbs req manager
+        let body = responseBody res
+        if | responseStatus res == status200 ->
+                case eitherDecodeJson (Json.listParser decodeMetadata) body of
+                    Left e ->
+                        fail (show e)
+                    Right xs ->
+                        pure xs
+           | responseStatus res == status400 && "no known-ancestor" `T.isInfixOf` (decodeUtf8 body) ->
+                return []
+           | otherwise ->
+                fail ("Unexpected response from the server: " <> BL8.unpack body)
+
     _putPatternSince :: Pattern -> Either SlotNo Point -> IO Bool
     _putPatternSince p pt = do
         let fragment = toString (patternToText p)
@@ -444,6 +470,16 @@ decodeHash
     -> Json.Parser (Hash alg a)
 decodeHash =
     maybe empty pure . hashFromTextAsHex
+
+decodeMetadata
+    :: Json.Value
+    -> Json.Parser (MetadataHash, Metadata)
+decodeMetadata = Json.withObject "Metadata" $ \o -> do
+    hash <- (o .: "hash")
+        >>= maybe (fail "failed to decode metadata hash") pure . metadataHashFromText
+    meta <- (o .: "raw")
+        >>= maybe (fail "failed to decode metadata payload") pure . metadataFromText
+    pure (hash, meta)
 
 decodeResult
     :: Json.Value

--- a/test/Test/Kupo/App/HttpSpec.hs
+++ b/test/Test/Kupo/App/HttpSpec.hs
@@ -48,7 +48,8 @@ import Kupo.Control.MonadSTM
     ( MonadSTM (..)
     )
 import Kupo.Data.Cardano
-    ( SlotNo (..)
+    ( Block
+    , SlotNo (..)
     , pattern BlockPoint
     , unsafeHeaderHashFromBytes
     )
@@ -420,6 +421,7 @@ newStubbedApplication defaultPatterns = do
     pure $ app
         (\callback -> callback databaseStub)
         (\_point ForcedRollbackHandler{onSuccess} -> onSuccess)
+        (\_point reply -> reply (Nothing @Block))
         patternsVar
         healthStub
 

--- a/test/Test/Kupo/Data/CardanoSpec.hs
+++ b/test/Test/Kupo/Data/CardanoSpec.hs
@@ -19,6 +19,10 @@ import Kupo.Data.Cardano
     , digest
     , hashScript
     , headerHashFromText
+    , metadataFromText
+    , metadataHashFromText
+    , metadataHashToText
+    , metadataToText
     , outputReferenceFromText
     , outputReferenceToText
     , pattern GenesisPoint
@@ -49,6 +53,7 @@ import Test.Hspec.QuickCheck
 import Test.Kupo.Data.Generators
     ( genAssetName
     , genDatumHash
+    , genMetadata
     , genOutputReference
     , genPolicyId
     , genScript
@@ -107,12 +112,22 @@ spec = parallel $ do
             forAll genScriptHash $ \x ->
                 scriptHashFromText (scriptHashToText x) === Just x
 
-    context "headerHashFromText" $ do
+    context "HeaderHash" $ do
         prop "∀(bs :: ByteString). bs .size 32 ⇒ headerHashFromText (base16 bs) === Just{}" $
             forAll (genBytes 32) $ \bytes ->
                 case headerHashFromText (encodeBase16 bytes) of
                     Just{}  -> property True
                     Nothing -> property False
+
+    context "Metadata" $ do
+        prop "∀(x :: Metadata). metadataFromText (metadataToText x) === x" $
+            forAll genMetadata $ \(_, x) ->
+                metadataFromText (metadataToText x) === Just x
+
+    context "MetadataHash" $ do
+        prop "∀(x :: MetadataHash). metadataHashFromText (metadataHashToText x) === x" $
+            forAll genMetadata $ \(x, _) ->
+                metadataHashFromText (metadataHashToText x) === Just x
 
     context "OutputReference" $ do
         prop "∀(x :: OutputReference). outputRefFromText (outputRefToText x) == Just x" $

--- a/test/Test/Kupo/Data/Generators.hs
+++ b/test/Test/Kupo/Data/Generators.hs
@@ -21,6 +21,9 @@ import Kupo.Data.Cardano
     , DatumHash
     , ExtendedOutputReference
     , HeaderHash
+    , Metadata
+    , MetadataHash
+    , Metadatum (..)
     , Output
     , OutputIndex
     , OutputReference
@@ -37,6 +40,7 @@ import Kupo.Data.Cardano
     , digestSize
     , fromBinaryData
     , fromDatumHash
+    , mkMetadata
     , mkOutput
     , mkOutputReference
     , noDatum
@@ -92,6 +96,7 @@ import Test.QuickCheck.Random
     )
 
 import qualified Data.ByteString as BS
+import qualified Data.Map as Map
 import qualified Data.Text as T
 
 genAddress :: Gen Address
@@ -254,7 +259,6 @@ genResultWith genPoint = Result
     <*> genPoint
     <*> frequency [(1, pure Nothing), (5, Just <$> genPoint)]
 
-
 genOutput :: Gen Output
 genOutput = mkOutput
     <$> genAddress
@@ -302,6 +306,18 @@ genForcedRollback =
     ForcedRollback
         <$> oneof [Left <$> genSlotNo, Right <$> genNonGenesisPoint]
         <*> genForcedRollbackLimit
+
+genMetadata :: Gen (MetadataHash, Metadata)
+genMetadata = do
+    n <- choose (1, 3)
+    mkMetadata . Map.fromList <$> liftA2 zip (vector n) (vectorOf n genMetadatum)
+  where
+    -- TODO: Generate more complicated metadatum ?
+    genMetadatum :: Gen Metadatum
+    genMetadatum = oneof
+        [ I <$> arbitrary
+        , B <$> (genBytes =<< choose (0, 16))
+        ]
 
 --
 -- Helpers

--- a/test/Test/Kupo/Fixture.hs
+++ b/test/Test/Kupo/Fixture.hs
@@ -220,3 +220,8 @@ someMetadata = unsafeMetadataHashFromBytes . unsafeDecodeBase16 <$>
     [ "A1AE526C1A228CE730E223C8AB56543F865BA8C2C991CA87D509783D4B002C35"
     , "0C7C650D6992E292A8EAFE206CE87469AC27F0B929DE414370DDDC38993A5C14"
     ]
+
+-- | The transaction associated with the first metadata of 'someMetadata'
+someTransactionIdWithMetadata :: TransactionId
+someTransactionIdWithMetadata = unsafeTransactionIdFromBytes $ unsafeDecodeBase16
+    "4DC5093D26FDD8D82BA30615EDA72D96B80ED28D3750D916AB1D3AB6FEE4B4B3"

--- a/test/Test/Kupo/Fixture.hs
+++ b/test/Test/Kupo/Fixture.hs
@@ -11,14 +11,17 @@ import Kupo.Prelude
 import Kupo.Data.Cardano
     ( BinaryData
     , DatumHash
+    , MetadataHash
     , Point
     , PolicyId
     , Script
     , ScriptHash
+    , SlotNo
     , TransactionId
     , pattern GenesisPoint
     , unsafeBinaryDataFromBytes
     , unsafeDatumHashFromBytes
+    , unsafeMetadataHashFromBytes
     , unsafePolicyIdFromBytes
     , unsafeScriptFromBytes
     , unsafeScriptHashFromBytes
@@ -206,3 +209,14 @@ someStakeKey = unsafeDecodeBase16
 someOtherStakeKey :: ByteString
 someOtherStakeKey = unsafeDecodeBase16
     "8c19e0c753136fd37f7bdd0ad6e24b6faa8d4ab0cb1cf8b20439b63c"
+
+-- | Some slot shortly after the start of Allegra which contains transactions with metadata.
+someSlotWithMetadata :: SlotNo
+someSlotWithMetadata = 18_014_527
+
+-- | The metadata associated with 'someSlotWithMetadata'
+someMetadata :: [MetadataHash]
+someMetadata = unsafeMetadataHashFromBytes . unsafeDecodeBase16 <$>
+    [ "A1AE526C1A228CE730E223C8AB56543F865BA8C2C991CA87D509783D4B002C35"
+    , "0C7C650D6992E292A8EAFE206CE87469AC27F0B929DE414370DDDC38993A5C14"
+    ]

--- a/test/Test/KupoSpec.hs
+++ b/test/Test/KupoSpec.hs
@@ -134,6 +134,7 @@ import Test.Kupo.Fixture
     , someStakeKey
     , someThirdTransactionId
     , someTransactionId
+    , someTransactionIdWithMetadata
     )
 import Type.Reflection
     ( tyConName
@@ -503,11 +504,11 @@ spec = skippableContext "End-to-end" $ \manager -> do
             (kupo tr `runWith` env)
             (do
                 waitSlot (> someSlotWithMetadata)
-                xs <- lookupMetadataBySlotNo someSlotWithMetadata
+                xs <- lookupMetadataBySlotNo someSlotWithMetadata Nothing
                 [ hash | (hash, _meta) <- xs ] `shouldBe` someMetadata
-                -- NOTE: Ensure we can fetch again, as a regression test. It was observed that only
-                -- the first fetch would work and subsequent one would block indefinitely.
-                void (lookupMetadataBySlotNo someSlotWithMetadata)
+
+                xs' <- lookupMetadataBySlotNo someSlotWithMetadata (Just someTransactionIdWithMetadata)
+                [ hash | (hash, _meta) <- xs' ] `shouldBe` take 1 someMetadata
             )
 
 type EndToEndSpec

--- a/test/Test/KupoSpec.hs
+++ b/test/Test/KupoSpec.hs
@@ -107,6 +107,7 @@ import Test.Kupo.App.Http.Client
     )
 import Test.Kupo.Fixture
     ( eraBoundaries
+    , lastAllegraPoint
     , lastAlonzoPoint
     , lastByronPoint
     , lastMaryPoint
@@ -114,6 +115,7 @@ import Test.Kupo.Fixture
     , someDatumHashInWitness
     , someDatumInOutput
     , someDatumInWitness
+    , someMetadata
     , someNonExistingPoint
     , someOtherPoint
     , someOtherStakeKey
@@ -128,6 +130,7 @@ import Test.Kupo.Fixture
     , someScriptInMetadata
     , someScriptInOutput
     , someScriptInWitness
+    , someSlotWithMetadata
     , someStakeKey
     , someThirdTransactionId
     , someTransactionId
@@ -487,6 +490,24 @@ spec = skippableContext "End-to-end" $ \manager -> do
                 waitUntilM $ do
                     values <- fmap value <$> getAllMatches NoStatusFlag
                     return $ all (`hasPolicyId` somePolicyId) values
+            )
+
+    specify "Fetch metadata by slot" $ \(tmp, tr, cfg, httpLogs) -> do
+        let HttpClient{..} = newHttpClientWith manager (serverHost cfg, serverPort cfg) httpLogs
+        env <- newEnvironment $ cfg
+            { workDir = Dir tmp
+            , since = Just lastAllegraPoint
+            , patterns = [MatchAny OnlyShelley]
+            }
+        timeoutOrThrow 10 (debug httpLogs) $ race_
+            (kupo tr `runWith` env)
+            (do
+                waitSlot (> someSlotWithMetadata)
+                xs <- lookupMetadataBySlotNo someSlotWithMetadata
+                [ hash | (hash, _meta) <- xs ] `shouldBe` someMetadata
+                -- NOTE: Ensure we can fetch again, as a regression test. It was observed that only
+                -- the first fetch would work and subsequent one would block indefinitely.
+                void (lookupMetadataBySlotNo someSlotWithMetadata)
             )
 
 type EndToEndSpec


### PR DESCRIPTION
Fixes #51

---

- :round_pushpin: **Define a new ouroboros local client for fetching blocks by *previous* point.**
    This is pretty rudimentary but _works_. This assumes that the caller has ways to retrieve any checkpoint necessary for them to find blocks.

  In the case of kupo, this is now trivially done since every on-chain point is stored in the database, with proper indexing allowing to navigate backward from any point.

  The Ogmios client is still to be written but will be done in a similar fashion.

- :round_pushpin: **Define the API extension for metadata.**
    Going for something simple, allowing to retrieve metadata behind

  GET /metadata/{slot-no}

  Possibly, authorizing a filter by transaction-id. Note that I am tempted to change the response already to move the 'created_at' point to the top-level of the response -- since it'll be identical for all items in the array in case where there are multiple metadata object.

  Plus, it'll make it easier for clients to verify that the points they're getting is indeed matching whatever they expect (and we should encourage them to do in the documentation!) because fetching by slot is "unsafe" for blocks that aren't at least k=2160 blocks deep in the chain.

- :round_pushpin: **Move few common JSON encoding helpers to the Prelude.**
  
- :round_pushpin: **Define supporting code for Metadata/ MetadataHash**
    Retrieving these from Ogmios isn't implemented yet. It isn't trivial as it requires to parse the detailed JSON metadata description. It't not essential to move on with testing and the rest of the implementation so I'll leave it for later.

- :round_pushpin: **Implement HTTP server logic for retrieving metadata and wire the fetch-block client.**
     This was a bit more involved than I originally envisionned, because of the state-machine testing mainly which obliges the application logic to somewhat abstract the fetch-block client too. This is fortunately relatively easy to do, and has the nice benefits of making it testable too through the state-machine machinery. I am starting off a simple generator for metadata (though I'll make it more stuffed as soon as I begin looking into testing serialization roundtrips when implementing the Ogmios' part).

   So far, everything compiles (without +production) and tests pass; so this isn't breaking any existing functionalities. I can now extend the test-suite to demonstrate that the new functionality work properly. Eventually, an end-to-end scenario will confirm that the integration with actual chain producers also work (since the state-machine tests mocks them away).

- :round_pushpin: **Incude metadata to state-machine & http test benchs.**
    And fix various little things accordingly, including the missing chain-sync exception handler around the fetch-block client.

- :round_pushpin: **Add end-to-end scenario illustrating fetching metadata by slot-no.**
    ```console
  $ time curl -v http://localhost:1442/metadata/70146054 | jq
  > GET /metadata/70146054 HTTP/1.1
  > Host: localhost:1442
  > User-Agent: curl/7.77.0
  > Accept: */*

  < HTTP/1.1 200 OK
  < Transfer-Encoding: chunked
  < Date: Sat, 01 Oct 2022 12:15:25 GMT
  < Server: kupo
  < X-Block-Header-Hash: 6c735d4883068bb7d3c5b22b1b8166490317480bab3454e2fe227a351448bdb8
  < X-Most-Recent-Checkpoint: 70257131
  < Content-Type: application/json;charset=utf-8
  <
  [
    {
      "hash": "04e6464091d5b8b5555fc4c3e2240c8676ece51ebd7c090115013f8fe74f07dd",
      "raw": "a11902a2a1636d736781687465737420313233",
      "schema": {
        "674": {
          "map": [
            {
              "k": {
                "string": "msg"
              },
              "v": {
                "list": [
                  {
                    "string": "test 123"
                  }
                ]
              }
            }
          ]
        }
      }
    }
  ]
  0.00s user 0.01s system 57% cpu 0.022 total
  ```

- :round_pushpin: **Write more elaborate Metadata generator, going through all primitives.**

- :round_pushpin: **Implement JSON parser for metadata detailed JSON**
    And roundtrip test the heck out of it. This is THE missing piece for the Ogmios' implementation. Now that this is done, rest should be a piece of cake.

- :round_pushpin: **Implement FetchBlockClient for Ogmios.**
    Effectively enabling metadata retrieving through Ogmios as well.

- :round_pushpin: **Add optional filter by transaction id on metadata retrieving.**