### PR TITLE
Recover from node disconnection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 - [📌 #98](https://github.com/CardanoSolutions/kupo/issues/98) Logs are now shown in a human-friendly way when `stdout` is an ANSI-capable terminal. When sent to a file or to a non-terminal, the behaviour is unchanged (i.e. structured JSON).
 
+- Kupo will no longer crash when loosing connection with the underlying cardano-node or Ogmios server. Instead, it'll recover from the issue and try to reconnect automatically.
+
 #### Removed
 
 - The `/patterns` family of endpoints no longer return a `X-Most-Recent-Checkpoint` for it doesn't make much sense for these endpoints. Indeed, they may change regardless of what is processed by the indexer.

--- a/Makefile
+++ b/Makefile
@@ -118,10 +118,16 @@ man: $(OUT)/share/man/man1/kupo.1 # Build man page
 doc: # Serve the rendered documentation on \033[0;33m<http://localhost:8000>\033[00m
 	@cd docs && python -m SimpleHTTPServer
 
-dev: # Starts Kupo against the preview network, with the provided options
+dev-cardano-node: # Connects Kupo to a local cardano-node on the preview network, with the provided options
 	cabal run kupo:exe:kupo -- \
 		--node-config $(CONFIG)/cardano-node/config.json \
 		--node-socket /tmp/node.socket \
+		$(filter-out $@,$(MAKECMDGOALS))
+
+dev-ogmios: # Connects Kupo to a local ogmios bridge on the preview network, with the provided options
+	cabal run kupo:exe:kupo -- \
+		--ogmios-host 127.0.0.1 \
+		--ogmios-port 1337 \
 		$(filter-out $@,$(MAKECMDGOALS))
 
 clean: # Remove build artifacts

--- a/src/Kupo/App/ChainSync.hs
+++ b/src/Kupo/App/ChainSync.hs
@@ -84,33 +84,6 @@ withChainSyncExceptionHandler tr ConnectionStatusToggle{toggleDisconnected} io =
         . handle (onRetryableException 0 isRetryableIntersectionNotFoundException)
         . (`onException` toggleDisconnected)
 
-    onHandshakeException :: HandshakeProtocolError NodeToClientVersion -> IO a
-    onHandshakeException = \case
-        HandshakeError (Handshake.Refused _version reason) -> do
-            let hint = case T.splitOn "/=" reason of
-                    [T.filter isDigit -> remoteConfig, T.filter isDigit -> localConfig] ->
-                        unwords
-                            [ "Kupo is configured for", prettyNetwork localConfig
-                            , "but cardano-node is running on", prettyNetwork remoteConfig <> "."
-                            , "You probably want to use a different configuration."
-                            ]
-                    _unexpectedReasonMessage ->
-                        ""
-            throwIO $ HandshakeException $ unwords
-                [ "Unable to establish the connection with the cardano-node:"
-                , "it runs on a different network!"
-                , hint
-                ]
-        e ->
-            throwIO e
-      where
-        prettyNetwork = \case
-            "764824073" -> "'mainnet'"
-            "1097911063" -> "'testnet'"
-            "1" -> "'preview'"
-            "2" -> "'preprod'"
-            unknownMagic -> "'network-magic=" <> unknownMagic <> "'"
-
     onRetryableException :: Exception e => DiffTime -> (e -> Bool) -> e -> IO DiffTime
     onRetryableException retryingIn isRetryable e
         | isRetryable e = do
@@ -120,18 +93,12 @@ withChainSyncExceptionHandler tr ConnectionStatusToggle{toggleDisconnected} io =
             throwIO e
 
     isRetryableIOException :: IOException -> Bool
-    isRetryableIOException e =
-        isResourceVanishedError e || isDoesNotExistError e || isTryAgainError e || isInvalidArgumentOnSocket e
-      where
-        isTryAgainError :: IOException -> Bool
-        isTryAgainError = isInfixOf "resource exhausted" . show
-
-        isResourceVanishedError :: IOException -> Bool
-        isResourceVanishedError = isInfixOf "resource vanished" . show
-
-        -- NOTE: MacOS
-        isInvalidArgumentOnSocket :: IOException -> Bool
-        isInvalidArgumentOnSocket = isInfixOf "invalid argument (Socket operation on non-socket)" . show
+    isRetryableIOException e
+        | isResourceVanishedError e = True
+        | isDoesNotExistError e = True
+        | isResourceExhaustedError e = True
+        | isInvalidArgumentOnSocket e = True
+        | otherwise = False
 
     isRetryableConnectionException :: ConnectionException -> Bool
     isRetryableConnectionException = \case
@@ -144,6 +111,54 @@ withChainSyncExceptionHandler tr ConnectionStatusToggle{toggleDisconnected} io =
     isRetryableIntersectionNotFoundException = \case
         ForcedIntersectionNotFound{} -> True
         IntersectionNotFound{} -> False
+
+--
+-- Helpers
+--
+
+-- | Show better errors when failing to handshake with the cardano-node. This is generally
+-- because users have misconfigured their instance.
+onHandshakeException :: HandshakeProtocolError NodeToClientVersion -> IO a
+onHandshakeException = \case
+    HandshakeError (Handshake.Refused _version reason) -> do
+        let hint = case T.splitOn "/=" reason of
+                [T.filter isDigit -> remoteConfig, T.filter isDigit -> localConfig] ->
+                    unwords
+                        [ "Kupo is configured for", prettyNetwork localConfig
+                        , "but cardano-node is running on", prettyNetwork remoteConfig <> "."
+                        , "You probably want to use a different configuration."
+                        ]
+                _unexpectedReasonMessage ->
+                    ""
+        throwIO $ HandshakeException $ unwords
+            [ "Unable to establish the connection with the cardano-node:"
+            , "it runs on a different network!"
+            , hint
+            ]
+    e ->
+        throwIO e
+
+-- | Show a named version of the network magic when we recognize it for better UX.
+prettyNetwork :: Text -> Text
+prettyNetwork = \case
+    "764824073" -> "'mainnet'"
+    "1097911063" -> "'testnet'"
+    "1" -> "'preview'"
+    "2" -> "'preprod'"
+    unknownMagic -> "'network-magic=" <> unknownMagic <> "'"
+
+isResourceExhaustedError :: IOException -> Bool
+isResourceExhaustedError =
+    isInfixOf "resource exhausted" . show
+
+isResourceVanishedError :: IOException -> Bool
+isResourceVanishedError =
+    isInfixOf "resource vanished" . show
+
+-- NOTE: MacOS
+isInvalidArgumentOnSocket :: IOException -> Bool
+isInvalidArgumentOnSocket =
+    isInfixOf "invalid argument (Socket operation on non-socket)" . show
 
 --
 -- Tracer


### PR DESCRIPTION
- :round_pushpin: **Refactor chain-sync exception handlers.**
  
- :round_pushpin: **Stay up on retryable MuxError, reconnect within 5s.**
  
- :round_pushpin: **Split 'make dev' into 'make dev-{cardano-node, ogmios}'**
  