### PR TITLE
Support pagination for /matches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ node_modules
 
 ## Cabal
 dist-newstyle
+.dist-production
 
 ## Dist
 /dist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@
 
 - Support for [ETag/If-None-Match](https://developer.mozilla.org/en-US/docs/Web/HTTP/Caching#etagif-none-match) standard HTTP caching. `ETag` in kupo matches the most recent block header hash. This allows clients to perform efficient polling and caching on their end. This also comes as an additional protection for rollbacks as one can control the `ETag` between two requests and assess whether a rollback happened.
 
+- [📌 #96](https://github.com/CardanoSolutions/kupo/issues/96) Matches can now be fetched in a paginated fashion, using slot ranges. Ranges can be made on either `created_at` or `spent_at` fields, and are inclusive. Besides, clients have two ways to define ranges:
+
+  - by absolute slot number;
+  - by point (slot number + block header hash).
+
+  The latter performs an extra check and will fail should the provided point not exist. This is handy to fetch collections over multiple pages while ensuring that the underlying data doesn't change due to a new fork of the chain being adopted behind the scene. Here are some examples of queries with (valid) ranges:
+
+  ```
+  /matches?created_after=1234
+  ```
+
+  ```
+  /matches?created_after=1234&created_before=5678
+  ```
+
+  ```
+  /matches?spent&spent_before=1234
+  ```
+
+  ```
+  /matches?spent&created_after=1234.4675360c80235b60b127222702b6e9b2b5c20dee7115acfc46eb6f3e9fd97ff0&spent_before=5678
+  ```
+
+  See:
+    - `GET /matches` → [📖 API Reference](https://cardanosolutions.github.io/kupo/#operation/getAllMatches)
+    - `GET /matches/{pattern}` → [📖 API Reference](https://cardanosolutions.github.io/kupo/#operation/getMatches)
+
 #### Changed
 
 - [📌 #94](https://github.com/CardanoSolutions/kupo/issues/94) Improved user-experience on start-up when providing invalid or missing working directory. Kupo will now recursively create the working directory if it's missing and otherwise provide a more informative error if it can't (e.g. because the directory already exists and is a file or because of a lack of permissions).

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ $(OUT)/share/kupo/LICENSE:
 $(OUT)/bin/kupo:
 	@mkdir -p $(@D)
 ifeq ($(OS),Darwin)
-	cabal install kupo:exe:kupo --flags +production --installdir=$(@D) --install-method=copy
+	cabal install --builddir=.dist-production kupo:exe:kupo --flags +production --installdir=$(@D) --install-method=copy
 	@echo "Build successful."
 	@echo ""
 	@echo "    ╔═══ NOTE ═════════════════════════════════════════════════════════════╗"

--- a/docs/api/latest.yaml
+++ b/docs/api/latest.yaml
@@ -1277,6 +1277,102 @@ components:
         Filters results to only those containing assets of a specific asset id. This parameter can't
         be used alone and must be provided alongside a `policy_id`.
 
+    created-after:
+      name: created_after
+      in: query
+      required: false
+      allowEmptyValue: false
+      description: |
+        Fetch only results created after (inclusive) some point.
+
+        > <sup><strong>NOTE</strong></sup> <br/>
+        >
+        > This can be combined with an upper bound (e.g. `{created, spent}_before`)
+        > but cannot be combined with another lower bound.
+      schema:
+        oneOf:
+          - title: By Slot
+            type: integer
+            minimum: 1
+            description: |
+              Only fetch results that were created at and after the given slot.
+          - title: By Point
+            type: string
+            pattern: "[0-9]+.[0-9a-f]{64}"
+            description: |
+              Only fetch results that were created at and after the given
+              point. This fails if the provided point doesn't exist. It is
+              handy to fetch a collection of results by pages while ensuring
+              that the collection isn't being altered to due alternative chain
+              forks being adopted. The last known fetch point can be used as
+              starting point for the next range.
+
+              Points are defined in the usual format (same as the command-line):
+
+              ```
+                        ┏━━━━━━━━━━━━━┓ ╭───╮ ┏━━━━━━━━━━━━━┓
+              POINT = ╾─┫ SLOT-NUMBER ┣─┤ . ├─┫ HEADER-HASH ┣─╼
+                        ┗━━━━━━━━━━━━━┛ ╰───╯ ┗━━━━━━━━━━━━━┛
+                              ┏━━━━━━━━━━━┓
+              HEADER-HASH = ╾─┫ 64 HEXDIG ┣───────────────────╼
+                              ┗━━━━━━━━━━━┛
+                              ┏━━━━━━━━━━┓
+              SLOT-NUMBER = ╾─┫ 1* DIGIT ┣────────────────────╼
+                              ┗━━━━━━━━━━┛
+              ```
+
+              For example:
+
+              `5999990.dca1e44765b9f80c8b18105e17de90d4a07e4d5a83de533e53fee32e0502d17e`
+
+    created-before:
+      name: created_before
+      in: query
+      required: false
+      allowEmptyValue: false
+      description: |
+        Fetch only results created before (inclusive) some point.
+
+        > <sup><strong>NOTE</strong></sup> <br/>
+        >
+        > This can be combined with a lower bound (e.g. `{created, spent}_after`)
+        > but cannot be combined with another upper bound.
+      schema:
+        oneOf:
+          - title: By Slot
+            type: integer
+            minimum: 1
+            description: |
+              Only fetch results that were created at and before the given slot.
+          - title: By Point
+            type: string
+            pattern: "[0-9]+.[0-9a-f]{64}"
+            description: |
+              Only fetch results that were created at and before the given
+              point. This fails if the provided point doesn't exist. It is
+              handy to fetch a collection of results by pages while ensuring
+              that the collection isn't being altered to due alternative chain
+              forks being adopted. The last known fetch point can be used as
+              starting point for the next range.
+
+              Points are defined in the usual format (same as the command-line):
+
+              ```
+                        ┏━━━━━━━━━━━━━┓ ╭───╮ ┏━━━━━━━━━━━━━┓
+              POINT = ╾─┫ SLOT-NUMBER ┣─┤ . ├─┫ HEADER-HASH ┣─╼
+                        ┗━━━━━━━━━━━━━┛ ╰───╯ ┗━━━━━━━━━━━━━┛
+                              ┏━━━━━━━━━━━┓
+              HEADER-HASH = ╾─┫ 64 HEXDIG ┣───────────────────╼
+                              ┗━━━━━━━━━━━┛
+                              ┏━━━━━━━━━━┓
+              SLOT-NUMBER = ╾─┫ 1* DIGIT ┣────────────────────╼
+                              ┗━━━━━━━━━━┛
+              ```
+
+              For example:
+
+              `5999990.dca1e44765b9f80c8b18105e17de90d4a07e4d5a83de533e53fee32e0502d17e`
+
     datum-hash:
       name: datum_hash
       in: path
@@ -1380,6 +1476,102 @@ components:
       description: |
         A query flag (i.e. `?spent`) to filter matches by status, to get only 'spent' matches.  Note that, when running kupo with `--prune-utxo`, this will always return an empty list of results.
 
+    spent-after:
+      name: spent_after
+      in: query
+      required: false
+      allowEmptyValue: false
+      description: |
+        Fetch only results spent after (inclusive) some point.
+
+        > <sup><strong>NOTE</strong></sup> <br/>
+        >
+        > This can be combined with an upper bound (e.g. `{created, spent}_before`)
+        > but cannot be combined with another lower bound.
+      schema:
+        oneOf:
+          - title: By Slot
+            type: integer
+            minimum: 1
+            description: |
+              Only fetch results that were spent at and after the given slot.
+          - title: By Point
+            type: string
+            pattern: "[0-9]+.[0-9a-f]{64}"
+            description: |
+              Only fetch results that were spent at and after the given
+              point. This fails if the provided point doesn't exist. It is
+              handy to fetch a collection of results by pages while ensuring
+              that the collection isn't being altered to due alternative chain
+              forks being adopted. The last known fetch point can be used as
+              starting point for the next range.
+
+              Points are defined in the usual format (same as the command-line):
+
+              ```
+                        ┏━━━━━━━━━━━━━┓ ╭───╮ ┏━━━━━━━━━━━━━┓
+              POINT = ╾─┫ SLOT-NUMBER ┣─┤ . ├─┫ HEADER-HASH ┣─╼
+                        ┗━━━━━━━━━━━━━┛ ╰───╯ ┗━━━━━━━━━━━━━┛
+                              ┏━━━━━━━━━━━┓
+              HEADER-HASH = ╾─┫ 64 HEXDIG ┣───────────────────╼
+                              ┗━━━━━━━━━━━┛
+                              ┏━━━━━━━━━━┓
+              SLOT-NUMBER = ╾─┫ 1* DIGIT ┣────────────────────╼
+                              ┗━━━━━━━━━━┛
+              ```
+
+              For example:
+
+              `5999990.dca1e44765b9f80c8b18105e17de90d4a07e4d5a83de533e53fee32e0502d17e`
+
+    spent-before:
+      name: spent_before
+      in: query
+      required: false
+      allowEmptyValue: false
+      description: |
+        Fetch only results spent before (inclusive) some point.
+
+        > <sup><strong>NOTE</strong></sup> <br/>
+        >
+        > This can be combined with a lower bound (e.g. `{created, spent}_after`)
+        > but cannot be combined with another upper bound.
+      schema:
+        oneOf:
+          - title: By Slot
+            type: integer
+            minimum: 1
+            description: |
+              Only fetch results that were spent at and before the given slot.
+          - title: By Point
+            type: string
+            pattern: "[0-9]+.[0-9a-f]{64}"
+            description: |
+              Only fetch results that were spent at and before the given
+              point. This fails if the provided point doesn't exist. It is
+              handy to fetch a collection of results by pages while ensuring
+              that the collection isn't being altered to due alternative chain
+              forks being adopted. The last known fetch point can be used as
+              starting point for the next range.
+
+              Points are defined in the usual format (same as the command-line):
+
+              ```
+                        ┏━━━━━━━━━━━━━┓ ╭───╮ ┏━━━━━━━━━━━━━┓
+              POINT = ╾─┫ SLOT-NUMBER ┣─┤ . ├─┫ HEADER-HASH ┣─╼
+                        ┗━━━━━━━━━━━━━┛ ╰───╯ ┗━━━━━━━━━━━━━┛
+                              ┏━━━━━━━━━━━┓
+              HEADER-HASH = ╾─┫ 64 HEXDIG ┣───────────────────╼
+                              ┗━━━━━━━━━━━┛
+                              ┏━━━━━━━━━━┓
+              SLOT-NUMBER = ╾─┫ 1* DIGIT ┣────────────────────╼
+                              ┗━━━━━━━━━━┛
+              ```
+
+              For example:
+
+              `5999990.dca1e44765b9f80c8b18105e17de90d4a07e4d5a83de533e53fee32e0502d17e`
+
     strict:
       name: strict
       in: query
@@ -1454,6 +1646,10 @@ paths:
         - $ref: "#/components/parameters/spent"
         - $ref: "#/components/parameters/unspent"
         - $ref: "#/components/parameters/order"
+        - $ref: "#/components/parameters/created-after"
+        - $ref: "#/components/parameters/spent-after"
+        - $ref: "#/components/parameters/created-before"
+        - $ref: "#/components/parameters/spent-before"
         - $ref: "#/components/parameters/policy-id"
         - $ref: "#/components/parameters/asset-name"
         - $ref: "#/components/parameters/transaction-id"
@@ -1484,6 +1680,10 @@ paths:
         - $ref: "#/components/parameters/spent"
         - $ref: "#/components/parameters/unspent"
         - $ref: "#/components/parameters/order"
+        - $ref: "#/components/parameters/created-after"
+        - $ref: "#/components/parameters/spent-after"
+        - $ref: "#/components/parameters/created-before"
+        - $ref: "#/components/parameters/spent-before"
         - $ref: "#/components/parameters/policy-id"
         - $ref: "#/components/parameters/asset-name"
         - $ref: "#/components/parameters/transaction-id"

--- a/kupo.cabal
+++ b/kupo.cabal
@@ -107,6 +107,7 @@ library
       Kupo.Data.Http.GetCheckpointMode
       Kupo.Data.Http.OrderMatchesBy
       Kupo.Data.Http.Response
+      Kupo.Data.Http.SlotRange
       Kupo.Data.Http.Status
       Kupo.Data.Http.StatusFlag
       Kupo.Data.Ogmios
@@ -291,6 +292,7 @@ test-suite unit
       Test.Kupo.Data.Http.ForcedRollbackSpec
       Test.Kupo.Data.Http.Helpers
       Test.Kupo.Data.Http.OrderMatchesBySpec
+      Test.Kupo.Data.Http.SlotRangeSpec
       Test.Kupo.Data.OgmiosSpec
       Test.Kupo.Data.Pattern.Fixture
       Test.Kupo.Data.PatternSpec

--- a/src/Kupo/App/Http.hs
+++ b/src/Kupo/App/Http.hs
@@ -24,6 +24,7 @@ import Data.Aeson
     )
 import Kupo.App.Database
     ( ConnectionType (..)
+    , DBTransaction
     , Database (..)
     )
 import Kupo.App.Http.HealthCheck
@@ -40,6 +41,9 @@ import Kupo.Control.MonadLog
     )
 import Kupo.Control.MonadSTM
     ( MonadSTM (..)
+    )
+import Kupo.Control.MonadThrow
+    ( throwIO
     )
 import Kupo.Data.Cardano
     ( DatumHash
@@ -105,7 +109,8 @@ import Kupo.Data.Http.Response
     , responseStreamJson
     )
 import Kupo.Data.Http.SlotRange
-    ( slotRangeFromQueryParams
+    ( intoSlotRange
+    , slotRangeFromQueryParams
     )
 import Kupo.Data.Http.Status
     ( Status (..)
@@ -189,10 +194,16 @@ httpServer tr withDatabase forceRollback fetchBlock patternsVar readHealth host 
         & Warp.setBeforeMainLoop (logWith tr HttpServerListening{host,port})
 
     withDatabaseWrapped send connectionType action = do
-        (withDatabase connectionType action `catch` onServerError) >>= \case
+        handle onServerError (handle onAssertPointException (withDatabase connectionType action)) >>= \case
             Nothing -> onServiceUnavailable
             Just r  -> return r
       where
+        onAssertPointException = \case
+            ErrPointNotFound{} ->
+                Just <$> send Errors.nonExistingPoint
+            ErrPointMismatch{requested, found} ->
+                Just <$> send (Errors.pointMismatch requested found)
+
         onServerError (hint :: SomeException) = do
             logWith tr $ HttpUnexpectedError (toText $ displayException hint)
             Just <$> send Errors.serverError
@@ -495,7 +506,7 @@ handleGetMatches headers patternQuery queryParams Database{..} = handleRequest $
     pattern_ <- (patternQuery >>= patternFromText)
         `orAbort` Errors.invalidPattern
 
-    slotRange <- slotRangeFromQueryParams queryParams
+    pointRange <- slotRangeFromQueryParams queryParams
         `orAbort` Errors.invalidSlotRange
 
     statusFlag <- statusFlagFromQueryParams queryParams
@@ -508,7 +519,20 @@ handleGetMatches headers patternQuery queryParams Database{..} = handleRequest $
         `orAbort` Errors.invalidSortDirection
 
     pure $ responseStreamJson headers resultToJson $ \yield done -> do
-        runTransaction $ foldInputs pattern_ slotRange statusFlag sortDirection (yieldIf yield)
+        let assertPointExists :: Point -> DBTransaction IO ()
+            assertPointExists requested = do
+                let nextSlot = next (getPointSlotNo requested)
+                points <- listAncestorsDesc nextSlot 1
+                case points of
+                    [found] | found == requested ->
+                        pure ()
+                    [found] ->
+                        throwIO ErrPointMismatch{requested, found}
+                    _pointNotFound ->
+                        throwIO ErrPointNotFound{requested}
+        runTransaction $ do
+            slotRange <- intoSlotRange pointRange assertPointExists assertPointExists
+            foldInputs pattern_ slotRange statusFlag sortDirection (yieldIf yield)
         done
   where
     -- NOTE: kupo does support two different ways for fetching results, via query parameters or via
@@ -783,6 +807,18 @@ handlePutPatterns headers readHealth forceRollback patternsVar mPointOrSlot quer
                 atomically (putTMVar response Errors.failedToRollback)
             }
         atomically (takeTMVar response)
+
+--
+-- AssertPointException
+--
+
+-- | Thrown by some handlers when performing extra sanity checks on provided points.
+data AssertPointException
+    = ErrPointNotFound { requested :: !Point }
+    | ErrPointMismatch { requested :: !Point, found :: !Point }
+    deriving (Generic, Show)
+
+instance Exception AssertPointException
 
 --
 -- Helpers

--- a/src/Kupo/App/Http.hs
+++ b/src/Kupo/App/Http.hs
@@ -531,7 +531,7 @@ handleGetMatches headers patternQuery queryParams Database{..} = handleRequest $
                     _pointNotFound ->
                         throwIO ErrPointNotFound{requested}
         runTransaction $ do
-            slotRange <- intoSlotRange pointRange assertPointExists assertPointExists
+            slotRange <- intoSlotRange assertPointExists assertPointExists pointRange
             foldInputs pattern_ slotRange statusFlag sortDirection (yieldIf yield)
         done
   where

--- a/src/Kupo/App/Http.hs
+++ b/src/Kupo/App/Http.hs
@@ -104,6 +104,9 @@ import Kupo.Data.Http.Response
     , responseJsonEncoding
     , responseStreamJson
     )
+import Kupo.Data.Http.SlotRange
+    ( slotRangeFromQueryParams
+    )
 import Kupo.Data.Http.Status
     ( Status (..)
     , mkStatus
@@ -492,6 +495,9 @@ handleGetMatches headers patternQuery queryParams Database{..} = handleRequest $
     pattern_ <- (patternQuery >>= patternFromText)
         `orAbort` Errors.invalidPattern
 
+    slotRange <- slotRangeFromQueryParams queryParams
+        `orAbort` Errors.invalidSlotRange
+
     statusFlag <- statusFlagFromQueryParams queryParams
         `orAbort` Errors.invalidStatusFlag
 
@@ -502,7 +508,7 @@ handleGetMatches headers patternQuery queryParams Database{..} = handleRequest $
         `orAbort` Errors.invalidSortDirection
 
     pure $ responseStreamJson headers resultToJson $ \yield done -> do
-        runTransaction $ foldInputs pattern_ statusFlag sortDirection (yieldIf yield)
+        runTransaction $ foldInputs pattern_ slotRange statusFlag sortDirection (yieldIf yield)
         done
   where
     -- NOTE: kupo does support two different ways for fetching results, via query parameters or via

--- a/src/Kupo/Data/Cardano/Point.hs
+++ b/src/Kupo/Data/Cardano/Point.hs
@@ -19,11 +19,13 @@ import Kupo.Data.Cardano.Block
 import Kupo.Data.Cardano.HeaderHash
     ( headerHashFromText
     , headerHashToJson
+    , headerHashToText
     )
 import Kupo.Data.Cardano.SlotNo
     ( SlotNo (..)
     , slotNoFromText
     , slotNoToJson
+    , slotNoToText
     )
 import Ouroboros.Network.Block
     ( HeaderHash
@@ -62,6 +64,17 @@ pointFromText txt =
         <*> headerHashFromText (T.drop 1 headerHash)
       where
         (slotNo, headerHash) = T.breakOn "." (T.strip txt)
+
+pointToText :: Point -> Text
+pointToText = \case
+    GenesisPoint ->
+        "origin"
+    BlockPoint sl h ->
+        mconcat
+            [ slotNoToText sl
+            , "."
+            , headerHashToText h
+            ]
 
 getPointSlotNo :: Point -> SlotNo
 getPointSlotNo pt =

--- a/src/Kupo/Data/Http/Error.hs
+++ b/src/Kupo/Data/Http/Error.hs
@@ -55,7 +55,16 @@ invalidStatusFlag =
         { hint = "Invalid filter query! Matches can be filtered by status using \
                  \HTTP query flags. Provide either '?spent' or '?unspent' to \
                  \filter accordingly. Anything else is an error. In case of \
-                 \doubts, check the documentation at: <https://cardanosolutions.github.io/kupo>!"
+                 \doubts, check the documentation at: <https://cardanosolutions.github.io/kupo#operation/getAllMatches>!"
+        }
+
+invalidSlotRange :: Response
+invalidSlotRange =
+    responseJson status400 Default.headers $ HttpError
+        { hint = "Unprocessable slot range! Slot ranges can be specified in the form of \
+                 \lower and upper bound, in absolute slots. Either bound is optional and \
+                 \you can only provide each bound once. Anything else is an error. In case \
+                 \of doubts, check the documentation at: <https://cardanosolutions.github.io/kupo#operation/getAllMatches>!"
         }
 
 invalidMatchFilter :: Response

--- a/src/Kupo/Data/Http/SlotRange.hs
+++ b/src/Kupo/Data/Http/SlotRange.hs
@@ -4,32 +4,71 @@
 
 module Kupo.Data.Http.SlotRange
     ( Range
+    , intoSlotRange
     , slotRangeFromQueryParams
     ) where
 
 import Kupo.Prelude
 
-import Kupo.Data.Cardano
+import Kupo.Data.Cardano.Point
+    ( Point
+    , getPointSlotNo
+    , pointFromText
+    )
+import Kupo.Data.Cardano.SlotNo
     ( SlotNo (..)
     , slotNoFromText
     )
+
 import qualified Network.HTTP.Types.URI as Http
 
+-- | A basic range/closed interval with optional bounds.
 type Range a = (Maybe a, Maybe a)
 
+-- | Convert a range of SlotNo/Point to a mere 'Range SlotNo', but performs action with points when
+-- they're provided. This allows, for example, running extra checks on full points but then fallback
+-- on an more homogeneous range for downstream manipulation.
+intoSlotRange
+    :: forall m. (Applicative m)
+    => Range (Either SlotNo Point)
+        -- ^ A flexible range
+    -> (Point -> m ())
+        -- ^ Action to perform when lower-bound is a 'Point'
+    -> (Point -> m ())
+        -- ^ Action to perform when upper-bound is a 'Point'
+    -> m (Range SlotNo)
+intoSlotRange (lower, upper) withLowerPoint withUpperPoint = (,)
+    <$> traverse (intoSlotBound withLowerPoint) lower
+    <*> traverse (intoSlotBound withUpperPoint) upper
+  where
+    intoSlotBound :: (Point -> m ()) -> Either SlotNo Point -> m SlotNo
+    intoSlotBound withPoint = \case
+        Left slot ->
+            pure slot
+        Right point ->
+            withPoint point $> getPointSlotNo point
+
+-- | Parse a 'Range' from query parameters; the range can be specified as either full points or just
+-- slot numbers; or a mix of both.
 slotRangeFromQueryParams
     :: Http.Query
-    -> Maybe (Range SlotNo)
+    -> Maybe (Range (Either SlotNo Point))
 slotRangeFromQueryParams = \case
     ("created_before", param):rest -> do
         (lower, upper') <- slotRangeFromQueryParams rest
         guard (isNothing upper')
-        upper <- slotNoFromText . decodeUtf8 =<< param
+        upper <- asum
+            [ fmap Left . slotNoFromText . decodeUtf8 =<< param
+            , fmap Right . pointFromText . decodeUtf8 =<< param
+            ]
         pure (lower, Just upper)
     ("created_after", param):rest -> do
         (lower', upper) <- slotRangeFromQueryParams rest
         guard (isNothing lower')
-        lower <- slotNoFromText . decodeUtf8 =<< param
+        lower <- asum
+            [ fmap Left . slotNoFromText . decodeUtf8 =<< param
+            , fmap Right . pointFromText . decodeUtf8 =<< param
+            ]
         pure (Just lower, upper)
     [] ->
         pure (Nothing, Nothing)

--- a/src/Kupo/Data/Http/SlotRange.hs
+++ b/src/Kupo/Data/Http/SlotRange.hs
@@ -3,7 +3,8 @@
 --  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 module Kupo.Data.Http.SlotRange
-    ( Range
+    ( Range (..)
+    , RangeField (..)
     , intoSlotRange
     , slotRangeFromQueryParams
     ) where
@@ -23,23 +24,71 @@ import Kupo.Data.Cardano.SlotNo
 import qualified Network.HTTP.Types.URI as Http
 
 -- | A basic range/closed interval with optional bounds.
-type Range a = (Maybe a, Maybe a)
+data Range a
+    = Whole
+    | After RangeField a
+    | Before RangeField a
+    | Between (RangeField, a) (RangeField, a)
+    deriving (Generic, Show, Eq)
+
+-- | What field is the range on.
+data RangeField = CreatedAt | SpentAt
+    deriving (Generic, Show, Eq, Ord)
+
+setLowerBound
+    :: MonadFail m
+    => RangeField
+    -> Range a
+    -> a
+    -> m (Range a)
+setLowerBound lowerField range lowerBound =
+    case range of
+        Whole ->
+            pure (After lowerField lowerBound)
+        Before upperField upperBound ->
+            pure (Between (lowerField, lowerBound) (upperField, upperBound))
+        _ -> fail "lower bound already set"
+
+setUpperBound
+    :: MonadFail m
+    => RangeField
+    -> Range a
+    -> a
+    -> m (Range a)
+setUpperBound upperField range upperBound =
+    case range of
+        Whole ->
+            pure (Before upperField upperBound)
+        After lowerField lowerBound ->
+            pure (Between (lowerField, lowerBound) (upperField, upperBound))
+        _ -> fail "upper bound already set"
 
 -- | Convert a range of SlotNo/Point to a mere 'Range SlotNo', but performs action with points when
 -- they're provided. This allows, for example, running extra checks on full points but then fallback
 -- on an more homogeneous range for downstream manipulation.
 intoSlotRange
-    :: forall m. (Applicative m)
-    => Range (Either SlotNo Point)
-        -- ^ A flexible range
-    -> (Point -> m ())
+    :: forall m. (Monad m)
+    => (Point -> m ())
         -- ^ Action to perform when lower-bound is a 'Point'
     -> (Point -> m ())
         -- ^ Action to perform when upper-bound is a 'Point'
+    -> Range (Either SlotNo Point)
+        -- ^ A flexible range
     -> m (Range SlotNo)
-intoSlotRange (lower, upper) withLowerPoint withUpperPoint = (,)
-    <$> traverse (intoSlotBound withLowerPoint) lower
-    <*> traverse (intoSlotBound withUpperPoint) upper
+intoSlotRange withLowerPoint withUpperPoint = \case
+    Whole ->
+        pure Whole
+
+    After lowerField lowerBound ->
+        After lowerField <$> intoSlotBound withLowerPoint lowerBound
+
+    Before upperField upperBound ->
+        Before upperField <$> intoSlotBound withUpperPoint upperBound
+
+    Between (lowerField, lowerBound) (upperField, upperBound) -> do
+        lowerBoundSlot <- intoSlotBound withLowerPoint lowerBound
+        upperBoundSlot <- intoSlotBound withUpperPoint upperBound
+        pure $ Between (lowerField, lowerBoundSlot) (upperField, upperBoundSlot)
   where
     intoSlotBound :: (Point -> m ()) -> Either SlotNo Point -> m SlotNo
     intoSlotBound withPoint = \case
@@ -54,23 +103,30 @@ slotRangeFromQueryParams
     :: Http.Query
     -> Maybe (Range (Either SlotNo Point))
 slotRangeFromQueryParams = \case
-    ("created_before", param):rest -> do
-        (lower, upper') <- slotRangeFromQueryParams rest
-        guard (isNothing upper')
-        upper <- asum
-            [ fmap Left . slotNoFromText . decodeUtf8 =<< param
-            , fmap Right . pointFromText . decodeUtf8 =<< param
-            ]
-        pure (lower, Just upper)
     ("created_after", param):rest -> do
-        (lower', upper) <- slotRangeFromQueryParams rest
-        guard (isNothing lower')
-        lower <- asum
-            [ fmap Left . slotNoFromText . decodeUtf8 =<< param
-            , fmap Right . pointFromText . decodeUtf8 =<< param
-            ]
-        pure (Just lower, upper)
+        range <- slotRangeFromQueryParams rest
+        setLowerBound CreatedAt range =<< slotOrPoint param
+
+    ("created_before", param):rest -> do
+        range <- slotRangeFromQueryParams rest
+        setUpperBound CreatedAt range =<< slotOrPoint param
+
+    ("spent_after", param):rest -> do
+        range <- slotRangeFromQueryParams rest
+        setLowerBound SpentAt range =<< slotOrPoint param
+
+    ("spent_before", param):rest -> do
+        range <- slotRangeFromQueryParams rest
+        setUpperBound SpentAt range =<< slotOrPoint param
+
     [] ->
-        pure (Nothing, Nothing)
+        pure Whole
+
     _:rest ->
         slotRangeFromQueryParams rest
+  where
+    slotOrPoint param =
+      asum
+          [ fmap Left . slotNoFromText . decodeUtf8 =<< param
+          , fmap Right . pointFromText . decodeUtf8 =<< param
+          ]

--- a/src/Kupo/Data/Http/SlotRange.hs
+++ b/src/Kupo/Data/Http/SlotRange.hs
@@ -1,0 +1,37 @@
+--  This Source Code Form is subject to the terms of the Mozilla Public
+--  License, v. 2.0. If a copy of the MPL was not distributed with this
+--  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+module Kupo.Data.Http.SlotRange
+    ( Range
+    , slotRangeFromQueryParams
+    ) where
+
+import Kupo.Prelude
+
+import Kupo.Data.Cardano
+    ( SlotNo (..)
+    , slotNoFromText
+    )
+import qualified Network.HTTP.Types.URI as Http
+
+type Range a = (Maybe a, Maybe a)
+
+slotRangeFromQueryParams
+    :: Http.Query
+    -> Maybe (Range SlotNo)
+slotRangeFromQueryParams = \case
+    ("created_before", param):rest -> do
+        (lower, upper') <- slotRangeFromQueryParams rest
+        guard (isNothing upper')
+        upper <- slotNoFromText . decodeUtf8 =<< param
+        pure (lower, Just upper)
+    ("created_after", param):rest -> do
+        (lower', upper) <- slotRangeFromQueryParams rest
+        guard (isNothing lower')
+        lower <- slotNoFromText . decodeUtf8 =<< param
+        pure (Just lower, upper)
+    [] ->
+        pure (Nothing, Nothing)
+    _:rest ->
+        slotRangeFromQueryParams rest

--- a/src/Kupo/Data/Http/StatusFlag.hs
+++ b/src/Kupo/Data/Http/StatusFlag.hs
@@ -5,15 +5,11 @@
 module Kupo.Data.Http.StatusFlag
     ( StatusFlag (..)
     , isNoStatusFlag
-    , hideTransientGhostInputs
     , statusFlagFromQueryParams
     ) where
 
 import Kupo.Prelude
 
-import Kupo.Data.Configuration
-    ( InputManagement (..)
-    )
 import qualified Network.HTTP.Types.URI as Http
 
 data StatusFlag
@@ -27,23 +23,6 @@ isNoStatusFlag = \case
     NoStatusFlag -> True
     OnlyUnspent -> False
     OnlySpent -> False
-
--- | Because the chain is only eventually immutable, kupo does not remove recent
--- data right away. Thus, it is possible that, even though the configuration
--- asked to prune all spent inputs, some remains present in the database and
--- marked as 'spent'. Yet, this is an implementation detail and we therefore
--- gives clients the illusion that there's no 'spent' inputs in the database if
--- they're running with the 'RemoveSpentInputs' option enabled.
-hideTransientGhostInputs
-    :: InputManagement
-    -> StatusFlag
-    -> StatusFlag
-hideTransientGhostInputs inputManagement statusFlag =
-    case inputManagement of
-        MarkSpentInputs ->
-           statusFlag
-        RemoveSpentInputs ->
-            OnlyUnspent
 
 statusFlagFromQueryParams
     :: Http.Query

--- a/src/Kupo/Prelude.hs
+++ b/src/Kupo/Prelude.hs
@@ -11,6 +11,7 @@ module Kupo.Prelude
       -- * JSON
     , FromJSON (..)
     , ToJSON (..)
+    , encodingToValue
     , eitherDecodeJson
     , defaultGenericToEncoding
     , encodeBytes
@@ -222,6 +223,12 @@ import qualified Data.Map as Map
 defaultGenericToEncoding :: (Generic a, GToJSON' Encoding Zero (Rep a)) => a -> Json.Encoding
 defaultGenericToEncoding =
     genericToEncoding Json.defaultOptions
+
+encodingToValue :: Json.Encoding -> Json.Value
+encodingToValue =
+    maybe (error "encodingToValue: failed?") identity
+    . Json.decode
+    . Json.encodingToLazyByteString
 
 eitherDecodeJson
     :: (Json.Value -> Json.Parser a)

--- a/test/Test/Kupo/App/HttpSpec.hs
+++ b/test/Test/Kupo/App/HttpSpec.hs
@@ -523,7 +523,7 @@ databaseStub = Database
         return ()
     , insertInputs =
         \_ -> return ()
-    , foldInputs = \_ _ _ callback -> lift $ do
+    , foldInputs = \_ _ _ _ callback -> lift $ do
         rows <- generate (listOf1 genResult)
         mapM_ callback rows
     , deleteInputs =

--- a/test/Test/Kupo/Data/CardanoSpec.hs
+++ b/test/Test/Kupo/Data/CardanoSpec.hs
@@ -27,6 +27,7 @@ import Kupo.Data.Cardano
     , outputReferenceToText
     , pattern GenesisPoint
     , pointFromText
+    , pointToText
     , policyIdFromText
     , policyIdToText
     , scriptFromBytes
@@ -54,6 +55,7 @@ import Test.Kupo.Data.Generators
     ( genAssetName
     , genDatumHash
     , genMetadata
+    , genNonGenesisPoint
     , genOutputReference
     , genPolicyId
     , genScript
@@ -78,17 +80,14 @@ import qualified Data.ByteString.Lazy.Char8 as BL8
 
 spec :: Spec
 spec = parallel $ do
-    context "pointFromText" $ do
+    context "Point" $ do
         specify "origin" $ do
             pointFromText "origin" `shouldBe` Just GenesisPoint
+            pointToText GenesisPoint `shouldBe` "origin"
 
         prop "{slotNo}.{blockHeaderHash}" $
-            forAll genSlotNo $ \s ->
-                forAll (genBytes 32) $ \bytes ->
-                    let txt = slotNoToText s <> "." <> encodeBase16 bytes
-                     in case pointFromText txt of
-                            Just{}  -> property True
-                            Nothing -> property False
+            forAll genNonGenesisPoint $ \pt ->
+                pointFromText (pointToText pt) == Just pt
 
     context "SlotNo" $ do
         prop "∀(s :: SlotNo). slotNoFromText (slotNoToText s) === Just{}" $

--- a/test/Test/Kupo/Data/Http/SlotRangeSpec.hs
+++ b/test/Test/Kupo/Data/Http/SlotRangeSpec.hs
@@ -1,0 +1,64 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this
+-- file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+module Test.Kupo.Data.Http.SlotRangeSpec
+    ( spec
+    ) where
+
+import Kupo.Prelude
+
+import Kupo.Data.Http.SlotRange
+    ( slotRangeFromQueryParams
+    )
+import Test.Hspec
+    ( Spec
+    , context
+    , parallel
+    , shouldBe
+    , specify
+    )
+import Test.Kupo.Data.Http.Helpers
+    ( renderQueryParams
+    , (.=)
+    )
+
+spec :: Spec
+spec = parallel $ do
+    context "slotRangeFromQueryParams" $ do
+        forM_ matrix $ \(queryParams, expectation) -> do
+            specify (renderQueryParams queryParams expectation) $ do
+                slotRangeFromQueryParams queryParams `shouldBe` expectation
+          where
+            matrix =
+                [ ( []
+                  , Just (Nothing, Nothing)
+                  )
+                , ( [ "created_after" .= "14" ]
+                  , Just (Just 14, Nothing)
+                  )
+                , ( [ "created_before" .= "42" ]
+                  , Just (Nothing, Just 42)
+                  )
+                , ( [ "created_after" .= "14", "created_before" .= "42" ]
+                  , Just (Just 14, Just 42)
+                  )
+                , ( [ "created_before" .= "42", "created_after" .= "14" ]
+                  , Just (Just 14, Just 42)
+                  )
+                , ( [ "created_before" .= "42", "foo" .= "bar" ]
+                  , Just (Nothing, Just 42)
+                  )
+                , ( [ "foo" .= "bar", "created_after" .= "14" ]
+                  , Just (Just 14, Nothing)
+                  )
+                , ( [ "created_after" .= "14", "created_after" .= "42" ]
+                  , Nothing
+                  )
+                , ( [ "created_after" .= "foo" ]
+                  , Nothing
+                  )
+                , ( [ "created_before" .= "-57" ]
+                  , Nothing
+                  )
+                ]

--- a/test/Test/Kupo/Data/Http/SlotRangeSpec.hs
+++ b/test/Test/Kupo/Data/Http/SlotRangeSpec.hs
@@ -12,7 +12,9 @@ import Kupo.Data.Cardano
     ( pointFromText
     )
 import Kupo.Data.Http.SlotRange
-    ( slotRangeFromQueryParams
+    ( Range (..)
+    , RangeField (..)
+    , slotRangeFromQueryParams
     )
 import Test.Hspec
     ( Spec
@@ -35,25 +37,64 @@ spec = parallel $ do
           where
             matrix =
                 [ ( []
-                  , Just (Nothing, Nothing)
+                  , Just Whole
+                  )
+                , ( [ "foo" .= "bar" ]
+                  , Just Whole
                   )
                 , ( [ "created_after" .= "14" ]
-                  , Just (Just (Left 14), Nothing)
+                  , Just (After CreatedAt (Left 14))
                   )
                 , ( [ "created_before" .= "42" ]
-                  , Just (Nothing, Just (Left 42))
+                  , Just (Before CreatedAt (Left 42))
                   )
                 , ( [ "created_after" .= "14", "created_before" .= "42" ]
-                  , Just (Just (Left 14), Just (Left 42))
+                  , Just (Between (CreatedAt, Left 14) (CreatedAt, Left 42))
                   )
                 , ( [ "created_before" .= "42", "created_after" .= "14" ]
-                  , Just (Just (Left 14), Just (Left 42))
+                  , Just (Between (CreatedAt, Left 14) (CreatedAt, Left 42))
                   )
                 , ( [ "created_before" .= "42", "foo" .= "bar" ]
-                  , Just (Nothing, Just (Left 42))
+                  , Just (Before CreatedAt (Left 42))
                   )
                 , ( [ "foo" .= "bar", "created_after" .= "14" ]
-                  , Just (Just (Left 14), Nothing)
+                  , Just (After CreatedAt (Left 14))
+                  )
+                , ( [ "created_after" .=
+                        "14.0000000000000000000000000000000000000000000000000000000000000000"
+                    ]
+                  ,  (After CreatedAt . Right) <$> pointFromText
+                        "14.0000000000000000000000000000000000000000000000000000000000000000"
+                  )
+                , ( [ "spent_after" .= "14" ]
+                  , Just (After SpentAt (Left 14))
+                  )
+                , ( [ "spent_before" .= "42" ]
+                  , Just (Before SpentAt (Left 42))
+                  )
+                , ( [ "spent_after" .= "14", "spent_before" .= "42" ]
+                  , Just (Between (SpentAt, Left 14) (SpentAt, Left 42))
+                  )
+                , ( [ "spent_before" .= "42", "spent_after" .= "14" ]
+                  , Just (Between (SpentAt, Left 14) (SpentAt, Left 42))
+                  )
+                , ( [ "spent_before" .= "42", "foo" .= "bar" ]
+                  , Just (Before SpentAt (Left 42))
+                  )
+                , ( [ "foo" .= "bar", "spent_after" .= "14" ]
+                  , Just (After SpentAt (Left 14))
+                  )
+                , ( [ "spent_after" .=
+                        "14.0000000000000000000000000000000000000000000000000000000000000000"
+                    ]
+                  ,  (After SpentAt . Right) <$> pointFromText
+                        "14.0000000000000000000000000000000000000000000000000000000000000000"
+                  )
+                , ( [ "created_after" .= "14", "spent_before" .= "42" ]
+                  , Just (Between (CreatedAt, Left 14) (SpentAt, Left 42))
+                  )
+                , ( [ "spent_after" .= "14", "created_before" .= "42" ]
+                  , Just (Between (SpentAt, Left 14) (CreatedAt, Left 42))
                   )
                 , ( [ "created_after" .= "14", "created_after" .= "42" ]
                   , Nothing
@@ -64,13 +105,19 @@ spec = parallel $ do
                 , ( [ "created_before" .= "-57" ]
                   , Nothing
                   )
-                , ( [ "created_after" .=
-                        "14.0000000000000000000000000000000000000000000000000000000000000000"
-                    ]
-                  , Just
-                      ( Right <$> pointFromText
-                          "14.0000000000000000000000000000000000000000000000000000000000000000"
-                      , Nothing
-                      )
+                , ( [ "spent_after" .= "14", "spent_after" .= "42" ]
+                  , Nothing
+                  )
+                , ( [ "spent_after" .= "foo" ]
+                  , Nothing
+                  )
+                , ( [ "spent_before" .= "-57" ]
+                  , Nothing
+                  )
+                , ( [ "created_after" .= "14", "spent_after" .= "42" ]
+                  , Nothing
+                  )
+                , ( [ "created_before" .= "14", "spent_before" .= "42" ]
+                  , Nothing
                   )
                 ]

--- a/test/Test/Kupo/Data/Http/SlotRangeSpec.hs
+++ b/test/Test/Kupo/Data/Http/SlotRangeSpec.hs
@@ -8,6 +8,9 @@ module Test.Kupo.Data.Http.SlotRangeSpec
 
 import Kupo.Prelude
 
+import Kupo.Data.Cardano
+    ( pointFromText
+    )
 import Kupo.Data.Http.SlotRange
     ( slotRangeFromQueryParams
     )
@@ -35,22 +38,22 @@ spec = parallel $ do
                   , Just (Nothing, Nothing)
                   )
                 , ( [ "created_after" .= "14" ]
-                  , Just (Just 14, Nothing)
+                  , Just (Just (Left 14), Nothing)
                   )
                 , ( [ "created_before" .= "42" ]
-                  , Just (Nothing, Just 42)
+                  , Just (Nothing, Just (Left 42))
                   )
                 , ( [ "created_after" .= "14", "created_before" .= "42" ]
-                  , Just (Just 14, Just 42)
+                  , Just (Just (Left 14), Just (Left 42))
                   )
                 , ( [ "created_before" .= "42", "created_after" .= "14" ]
-                  , Just (Just 14, Just 42)
+                  , Just (Just (Left 14), Just (Left 42))
                   )
                 , ( [ "created_before" .= "42", "foo" .= "bar" ]
-                  , Just (Nothing, Just 42)
+                  , Just (Nothing, Just (Left 42))
                   )
                 , ( [ "foo" .= "bar", "created_after" .= "14" ]
-                  , Just (Just 14, Nothing)
+                  , Just (Just (Left 14), Nothing)
                   )
                 , ( [ "created_after" .= "14", "created_after" .= "42" ]
                   , Nothing
@@ -60,5 +63,14 @@ spec = parallel $ do
                   )
                 , ( [ "created_before" .= "-57" ]
                   , Nothing
+                  )
+                , ( [ "created_after" .=
+                        "14.0000000000000000000000000000000000000000000000000000000000000000"
+                    ]
+                  , Just
+                      ( Right <$> pointFromText
+                          "14.0000000000000000000000000000000000000000000000000000000000000000"
+                      , Nothing
+                      )
                   )
                 ]


### PR DESCRIPTION
- :round_pushpin: **Enable querying with slot-range**
    The goal is to allow client fetching smaller response, but not
  necessarily to use the range to make query faster.

  We gain some performance improvement from the fact that the database
  will yield less results, but the queries are extended in a way that
  the slot range has no effect whatsoever on the query planner.

  This is because, we generally want to keep searching by address,
  payment credential, output reference and so on, and not drop those
  indexes for a dumb query on the created_at index. Indeed, imagine we
  query a specific output reference from the database, but only after
  slot 5M; now there might still be millions of results after that slot,
  so we don't want the database to only filter results by slot and then,
  scan what's left to find the output. We'd rather find the candidate
  outputs, and then, discard those that aren't within the given slot
  range.

  Fixes #96

- :round_pushpin: **Allow passing full points as slot ranges.**
    When passing full points (i.e. with block header hash), Kupo performs
  an additional checks to verify whether the point exists, and fail
  otherwise.

  This is useful when fetching a data-collection in a paginated fashion,
  making sure that we are fetching collections on a continuous chain.
  One can provide the last known point as a lower bound for a next
  range; if the chain adopts a conflicting fork the target point will no
  longer exists and the range request will raise an appropriate error.

- :round_pushpin: **use separate directory for building production release**
    So that cache isn't constantly invalidated between dev and production builds.

- :round_pushpin: **Allow query by ranges on 'spent_at' field too.**
    We also allow mixed ranges, like anything created after slot X but
  spent before slot Y. Yet, we don't allow multiple conditions on the
  same bound. So one can't ask for matches that have been created after
  some slot and spent after some other slot.

- :round_pushpin: **Fix state-machine flaky port binding**
    This slightly increases the entropy regarding what TCP ports gets picked for running the state-machine tests; in principle, connections are dropped between tests but sometimes the test runner gets faster than the OS kernel when it comes to freeing port and the next test ends up trying to bind port on an already taken location. Now, each test should use different ports which hopefully do not conflict with processes from the host machine :grimacing:

- :round_pushpin: **Document new created-at-before and created-at-after query params.**
  
- :round_pushpin: **Complete CHANGELOG for pagination.**
  

