### PR TITLE
Implement new 'copy' command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@
 
   → [📖 API Reference](https://cardanosolutions.github.io/kupo/#section/Patterns/Metadata-tag)
 
+- Provide a new command `copy` to conveniently clone an existing database into a smaller subset. This is particularly useful to quickly fork new instances of a parent index without having to resynchronize the entire chain. The main use case being a scenario where one maintains a global index (i.e. matching `*`) and needs to create on-demand indexes using more restrictive patterns. The `copy` commands accepts one or many patterns and copies (even large) indexes in a matter of seconds.
+
+  ```
+  Usage: kupo copy --from DIR --into DIR [--match PATTERN]
+
+    Copy from a source database into another, while applying the provided pattern
+    filters.
+
+  Available options:
+    -h,--help                Show this help text
+    --from DIR               Working directory to copy from.
+    --into DIR               Working directory to copy into.
+    --match PATTERN          A pattern to match on. Can be provided multiple times (as a logical disjunction, i.e. 'or')
+  ```
+
 #### Changed
 
 - The server now implements some basic retry mechanism for some transient errors that can occur under heavy load (e.g. failing to open a database connection). This is mostly transparent for clients but should result in less `503` errors by providing a first retryable layer directly in the server.

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -13,6 +13,9 @@ main = parseOptions >>= \case
         withTracers stdout version tracers $ \tr -> do
             env <- newEnvironment cfg
             kupo tr `runWith` env
+    Copy from into patterns -> do
+        withTracers stdout version (defaultTracers @TracersCopy (Just Info)) $ \tr -> do
+            copyDatabase (tracerCopy tr, tracerProgress tr) from into patterns
     HealthCheck host port -> do
         healthCheck host port
     Version -> do

--- a/docs/man/README.md
+++ b/docs/man/README.md
@@ -16,9 +16,14 @@ kupo - Fast, lightweight & configurable chain-index for Cardano.
     [--gc-interval *SECONDS*]\
     [<u>log-level</u>]
 
-**kupo** ((-v|--version) | **version**)
-
 **kupo** **health-check**
+
+**kupo** **copy**
+  --from DIRECTORY\
+  --into DIRECTORY\
+  --match PATTERN
+
+**kupo** ((-v|--version) | **version**)
 
 # DESCRIPTION
 **Kupo** is fast, lightweight and configurable chain-index for the **Cardano** blockchain. **Kupo** synchronizes data from the blockchain according to <u>patterns</u> matching *addresses* present in transaction outputs and builds a lookup table from matches to their associated *output references*, *values*, *datums* and *scripts*. All indexed data is made available via a local HTTP web-server.

--- a/kupo.cabal
+++ b/kupo.cabal
@@ -207,6 +207,7 @@ library
     , resource-pool
     , safe
     , safe-exceptions
+    , scientific
     , sqlite-simple
     , strict-containers
     , template-haskell

--- a/package.yaml
+++ b/package.yaml
@@ -85,6 +85,7 @@ library:
     - resource-pool
     - safe
     - safe-exceptions
+    - scientific
     - strict-containers
     - sqlite-simple
     - template-haskell

--- a/src/Kupo.hs
+++ b/src/Kupo.hs
@@ -12,6 +12,7 @@ module Kupo
       runWith
     , version
     , healthCheck
+    , copyDatabase
 
     -- * Kupo
     , Kupo (..)
@@ -27,7 +28,11 @@ module Kupo
     , parseOptions
 
     -- * Tracers
+    , Tracers(..)
+    , TracersCopy(..)
+    , Severity(..)
     , withTracers
+    , defaultTracers
     ) where
 
 import Kupo.Prelude
@@ -57,6 +62,7 @@ import Kupo.App.Configuration
 import Kupo.App.Database
     ( ConnectionType (..)
     , Database (..)
+    , copyDatabase
     , createShortLivedConnection
     , newDatabaseFile
     , newLock
@@ -79,7 +85,9 @@ import Kupo.Control.MonadAsync
     ( concurrently4
     )
 import Kupo.Control.MonadLog
-    ( TracerDefinition (..)
+    ( Severity (..)
+    , TracerDefinition (..)
+    , defaultTracers
     , withTracers
     )
 import Kupo.Control.MonadSTM
@@ -109,6 +117,7 @@ import Kupo.Data.Health
 import Kupo.Options
     ( Command (..)
     , Tracers (..)
+    , TracersCopy (..)
     , parseOptions
     )
 import Kupo.Version
@@ -222,6 +231,7 @@ kupoWith tr withProducer withFetchBlock =
                         (\case
                             ReadOnly  -> tryWithResource readOnlyPool
                             ReadWrite -> tryWithResource readWritePool
+                            WriteOnly -> const (fail "impossible: tried to acquire WriteOnly database?")
                         )
                         forceRollback
                         fetchBlock

--- a/src/Kupo/Data/Database.hs
+++ b/src/Kupo/Data/Database.hs
@@ -675,7 +675,7 @@ patternToSql = \case
         , Nothing
         )
     App.MatchOutputReference ref ->
-        ( "output_reference = x'" <> x (outputReferenceToRow ref) <> "'"
+        ( "inputs.output_reference = x'" <> x (outputReferenceToRow ref) <> "'"
         , Nothing
         )
     App.MatchTransactionId txId ->
@@ -683,7 +683,7 @@ patternToSql = \case
             lowerBound = outputReferenceToRow (mkOutputReference txId minBound)
             upperBound = outputReferenceToRow (mkOutputReference txId maxBound)
         in
-        ( "output_reference BETWEEN "
+        ( "inputs.output_reference BETWEEN "
             <> "x'" <> x lowerBound <> "'"
             <> " AND "
             <> "x'" <> x upperBound <> "'"

--- a/src/Kupo/Prelude.hs
+++ b/src/Kupo/Prelude.hs
@@ -72,6 +72,8 @@ module Kupo.Prelude
     , noConnectionStatusToggle
     , hijackSigTerm
     , hSupportsANSI
+    , hSetCursorColumn
+    , hClearLine
     ) where
 
 import Cardano.Binary
@@ -195,6 +197,7 @@ import System.Environment
     )
 import System.IO
     ( hIsTerminalDevice
+    , hPutStr
     )
 import System.Posix.Signals
     ( Handler (..)
@@ -346,3 +349,14 @@ hSupportsANSI :: Handle -> IO Bool
 hSupportsANSI h = (&&) <$> hIsTerminalDevice h <*> isNotDumb
   where
     isNotDumb = (/= Just "dumb") <$> lookupEnv "TERM"
+
+-- | Set the cursor to the given (0-based) column. Useful to override the terminal output.
+hSetCursorColumn :: Handle -> Int -> IO ()
+hSetCursorColumn h col = hPutStr h (csi [col + 1] "G")
+
+-- | Clear the current line on screen.
+hClearLine :: Handle -> IO ()
+hClearLine h = hPutStr h (csi [2] "K")
+
+csi :: [Int] -> [Char] -> [Char]
+csi args code = "\ESC[" ++ intercalate ";" (map show args) ++ code

--- a/test/Test/Kupo/App/HttpSpec.hs
+++ b/test/Test/Kupo/App/HttpSpec.hs
@@ -56,6 +56,9 @@ import Kupo.Data.Cardano
 import Kupo.Data.ChainSync
     ( ForcedRollbackHandler (..)
     )
+import Kupo.Data.Database
+    ( policyToRow
+    )
 import Kupo.Data.Health
     ( ConnectionStatus (..)
     , Health (..)
@@ -98,7 +101,9 @@ import Test.Kupo.Data.Generators
     , genHeaderHash
     , genMetadata
     , genNonGenesisPoint
+    , genOutputReference
     , genPattern
+    , genPolicyId
     , genResult
     , genScript
     , genTransactionId
@@ -521,6 +526,8 @@ databaseStub = Database
         return ()
     , close =
         return ()
+    , countInputs =
+        \_ -> lift (generate arbitrary)
     , insertInputs =
         \_ -> return ()
     , foldInputs = \_ _ _ _ callback -> lift $ do
@@ -532,8 +539,13 @@ databaseStub = Database
         \_ _ -> lift (generate arbitrary)
     , pruneInputs =
         liftIO (generate arbitrary)
+    , countPolicies =
+        \_ -> lift (generate arbitrary)
     , insertPolicies =
         \_ -> return ()
+    , foldPolicies = \_ callback -> lift $ do
+        rows <- generate (listOf1 $ policyToRow <$> genOutputReference <*> genPolicyId)
+        mapM_ callback rows
     , insertCheckpoints =
         \_ -> return ()
     , listCheckpointsDesc = lift $ do

--- a/test/Test/Kupo/OptionsSpec.hs
+++ b/test/Test/Kupo/OptionsSpec.hs
@@ -283,6 +283,26 @@ spec = parallel $ do
             ]
           , shouldFail
           )
+        , ( [ "copy", "--from", "foo", "--into", "bar" ]
+          , flip shouldBe $ Right $ Copy "foo" "bar" $ fromList []
+          )
+        , ( [ "copy", "--from", "foo", "--into", "bar", "--match", "*" ]
+          , flip shouldBe $ Right $ Copy "foo" "bar" $ fromList
+                [ MatchAny IncludingBootstrap
+                ]
+          )
+        , ( [ "copy", "--from", "foo", "--into", "bar", "--match", "*", "--match", "*/*" ]
+          , flip shouldBe $ Right $ Copy "foo" "bar" $ fromList
+                [ MatchAny IncludingBootstrap
+                , MatchAny OnlyShelley
+                ]
+          )
+        , ( [ "copy", "--into", "bar" ]
+          , shouldFail
+          )
+        , ( [ "copy", "--from", "foo" ]
+          , shouldFail
+          )
         , ( [ "version" ], flip shouldBe $ Right Version )
         , ( [ "-v" ], flip shouldBe $ Right Version )
         , ( [ "--version" ], flip shouldBe $ Right Version )


### PR DESCRIPTION
Allow cloning an existing database into a new location, while applying
filtering patterns. This is useful to quickly spawn new indexes from
a more generic one, without awaiting a full re-synchronization.

![2023-01-09 01 18 53](https://user-images.githubusercontent.com/5680256/211226255-49aaf472-2669-4017-9cb0-034e6f8e7b25.gif)