### PR TITLE
Authorize indexing outputs by metadata tag.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+### [2.4.0] - UNRELEASED
+
+#### Added
+
+- [📌 #108](https://github.com/CardanoSolutions/kupo/issues/108) Introduce a new indexing pattern by transaction metadata tag. This pattern will only index outputs of a transaction that (a) has metadata, (b) has one metadatum labelled with the provided tag. This pattern is however (at least for now) only usable for indexing, not querying.
+
+  → [📖 API Reference](https://cardanosolutions.github.io/kupo/#section/Patterns/Metadata-tag)
+
+#### Changed
+
+N/A
+
+#### Removed
+
+N/A
+
 ### [2.3.3] - 2022-01-23
 
 #### Added

--- a/docs/api/latest.yaml
+++ b/docs/api/latest.yaml
@@ -279,8 +279,11 @@ info:
          ├─┫ POLICY_ID ┣────┤ . ├─┫ ASSET_NAME ┣─────┤
          │ ┗━━━━━━━━━━━┛    ╰───╯ ┗━━━━━━━━━━━━┛     │
          │ ┏━━━━━━━━━━━━━━┓ ╭───╮ ┏━━━━━━━━━━━━━━━━┓ │
-         └─┫ OUTPUT_INDEX ┣─┤ @ ├─┫ TRANSACTION_ID ┣─┘
-           ┗━━━━━━━━━━━━━━┛ ╰───╯ ┗━━━━━━━━━━━━━━━━┛
+         ├─┫ OUTPUT_INDEX ┣─┤ @ ├─┫ TRANSACTION_ID ┣─┤
+         │ ┗━━━━━━━━━━━━━━┛ ╰───╯ ┗━━━━━━━━━━━━━━━━┛ │
+         │ ┏━━━━━━━━━━━━━━┓                          │
+         └─┫ METADATA_TAG ┣──────────────────────────┘
+           ┗━━━━━━━━━━━━━━┛
     ```
 
     ## Address
@@ -381,12 +384,26 @@ info:
     HEXDIG = %x30–39 / %x41-%46
     ```
 
+    ## Metadata tag
+
+    > <sup><strong>WARNING</strong></sup> <br/>
+    >
+    > This pattern can only be used for indexing, not for querying.
+
+    ```
+    METADATA_TAG =
+
+          ╭───╮  ┏━━━━━━━━━━━━━━┓  ╭───╮
+        ╾─┤ { ├──┫ METADATA TAG ┣──┤ } ├─╼
+          ╰───╯  ┗━━━━━━━━━━━━━━┛  ╰───╯
+    ```
+
     ### Examples
 
-    | Pattern                                                              | Description                                              |
-    | ---                                                                  | ---                                                      |
-    | `*@dca1e44765b9f80c8b18105e17de90d4a07e4d5a83de533e53fee32e0502d17e` | Outputs from a specific transaction                      |
-    | `3@dca1e44765b9f80c8b18105e17de90d4a07e4d5a83de533e53fee32e0502d17e` | The 4th output (0-based indexing) of a given transaction |
+    | Pattern | Description                                                |
+    | ---     | ---                                                        |
+    | `{25}`  | Outputs of any transaction that has metadata with label 25 |
+    | `{42}`  | Outputs of any transaction that has metadata with label 42 |
 
     # Accessing results
 

--- a/src/Kupo/Data/Database.hs
+++ b/src/Kupo/Data/Database.hs
@@ -644,8 +644,10 @@ addressFromRow =
 -- Filters
 --
 
+-- Invariant: cannot be called with 'MatchMetadataTag'; this pattern is only for indexing.
 patternToSql
-    :: App.Pattern
+    :: HasCallStack
+    => App.Pattern
     -> (Text, Maybe Text)
 patternToSql = \case
     App.MatchAny App.IncludingBootstrap ->
@@ -693,6 +695,8 @@ patternToSql = \case
         )
     App.MatchAssetId (pid, _) ->
         patternToSql (App.MatchPolicyId pid)
+    App.MatchMetadataTag{} ->
+        error "patternToSql: called for 'MatchMetadataTag'"
   where
     x = encodeBase16
 

--- a/src/Kupo/Data/Http/Error.hs
+++ b/src/Kupo/Data/Http/Error.hs
@@ -56,6 +56,18 @@ invalidPattern =
         , details = Nothing
         }
 
+invalidQueryPattern :: Response
+invalidQueryPattern =
+    responseJson status400 Default.headers $ HttpError
+        { hint = "Invalid query pattern! It isn't possible to query results via this pattern. \
+                 \This is an index-only pattern. You may want to fetch all results in a paginated \
+                 \fashion instead; or use another pattern for filtering. If you do strongly believe \
+                 \that it should be possible to query results using this pattern, please open a \
+                 \Github discussion: <https://github.com/CardanoSolutions/kupo/discussions/new?category=ideas> \
+                 \or contribute to an existing one regarding this matter."
+        , details = Nothing
+        }
+
 invalidPatterns :: [Text] -> Response
 invalidPatterns validPatterns =
     responseJson status400 Default.headers $ HttpError

--- a/src/Kupo/Data/PartialBlock.hs
+++ b/src/Kupo/Data/PartialBlock.hs
@@ -23,6 +23,7 @@ import Kupo.Data.Cardano
     , Script
     , ScriptHash
     , TransactionId
+    , emptyMetadata
     )
 
 import qualified Data.Set as Set
@@ -60,8 +61,9 @@ instance IsBlock PartialBlock where
     foldBlock fn result =
         foldrWithIndex fn result . blockBody
 
-    mapMaybeOutputs fn  =
-        mapMaybe (uncurry fn) . outputs
+    mapMaybeOutputs fn tx =
+        let meta = maybe emptyMetadata snd (metadata tx)
+         in mapMaybe (\outs -> uncurry fn outs meta) (outputs tx)
 
     witnessedDatums =
         datums

--- a/test/Test/Kupo/Data/DatabaseSpec.hs
+++ b/test/Test/Kupo/Data/DatabaseSpec.hs
@@ -146,6 +146,7 @@ import Test.Kupo.Data.Generators
     , genPattern
     , genPointsBetween
     , genPolicyId
+    , genQueryablePattern
     , genResult
     , genResultWith
     , genScriptReference
@@ -1099,7 +1100,7 @@ shortLivedWorker fp mode lock = do
                     pure $ void $ runTransaction listCheckpointsDesc
                   )
                 , (2, do
-                    pattern_ <- genPattern
+                    pattern_ <- genQueryablePattern
                     status <- elements [NoStatusFlag, OnlySpent, OnlyUnspent]
                     sortDir <- elements [Asc, Desc]
                     pure $ runTransaction $ foldInputs pattern_ Whole status sortDir (\_ -> pure ())
@@ -1110,7 +1111,7 @@ shortLivedWorker fp mode lock = do
                     ReadOnly -> []
                     ReadWrite ->
                         [ (1, do
-                            pattern_ <- genPattern
+                            pattern_ <- genQueryablePattern
                             pure $ void $ runTransaction $ deleteInputs (Set.singleton pattern_)
                           )
                         , (1, do

--- a/test/Test/Kupo/Data/Generators.hs
+++ b/test/Test/Kupo/Data/Generators.hs
@@ -249,9 +249,17 @@ genPattern = oneof
     , MatchPaymentAndDelegation <$> genBytes sz <*> genBytes sz
     , MatchTransactionId <$> genTransactionId
     , MatchOutputReference <$> genOutputReference
+    , MatchMetadataTag <$> arbitrary
     ]
   where
     sz = digestSize @Blake2b_224
+
+genQueryablePattern :: Gen Pattern
+genQueryablePattern =
+    genPattern `suchThat` (\case
+        MatchMetadataTag{} -> False
+        _ -> True
+    )
 
 genResult :: Gen Result
 genResult =

--- a/test/Test/Kupo/Data/PatternSpec.hs
+++ b/test/Test/Kupo/Data/PatternSpec.hs
@@ -12,6 +12,7 @@ import Kupo.Data.Cardano
     ( ComparableOutput
     , ExtendedOutputReference
     , Output
+    , emptyMetadata
     , toComparableOutput
     )
 import Kupo.Data.Pattern
@@ -101,7 +102,7 @@ matchAll
 matchAll p xs =
     [ (outRef, toComparableOutput out)
     | (outRef, out) <- xs
-    , isJust (matching (fst outRef) out p)
+    , isJust (matching (fst outRef) out emptyMetadata p)
     ]
 
 genPattern :: Gen Pattern

--- a/test/Test/Kupo/OptionsSpec.hs
+++ b/test/Test/Kupo/OptionsSpec.hs
@@ -213,6 +213,11 @@ spec = parallel $ do
                     fromList [ MatchAssetId (policyId, assetName) ]
             }
           )
+        , ( defaultArgs ++ [ "--match", "{1234}" ]
+          , shouldParseAppConfiguration $ defaultConfiguration
+            { patterns = fromList [ MatchMetadataTag 1234 ]
+            }
+          )
         , ( defaultArgs ++ [ "--match", "NOT-A-PATTERN" ]
           , shouldFail
           )


### PR DESCRIPTION
  This is a first iteration on this feature, which provides a handy way
  to fetch results by metadata tag (match _all outputs_ in a matching
  transaction).

  Metadata can then be retrieved directly from `/metadata` by slot no
  and transaction id.

  Note that we do not however allow to explicitly query by metadata tag.
  In order to do so, we would need to store associated metadata tags
  with the output, or in a side table. For now, this isn't a compelling
  use case.

  Fixes #108