### PR TITLE
Fix build of ouroboros-consensus

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -78,6 +78,9 @@ constraints:
   , plutus-tx == 1.0.0.0
   , plutus-tx-plugin == 1.0.0.0
 
+  -- XXX: for ouroboros-consensus, try a more recent CHaP index which has a revision for this
+  , unix-bytestring < 0.4
+
 source-repository-package
   type: git
   location: https://github.com/CardanoSolutions/direct-sqlite


### PR DESCRIPTION
Seems like it broke because a more recent version of unix-bytestring became available and the original package (as in the CHaP index-state provided) was not having an upper bound. Should also try more recent index states instead, but that would require quite a lot of additional constraints in kupo.cabal.