### PR TITLE
Add nix flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,93 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1681202837,
+        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "iohk-nix": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1680659925,
+        "narHash": "sha256-2MW2IEYCe6uE55ljxQ4I2KP9JGtEKd6OPCHiHrEJQbQ=",
+        "owner": "input-output-hk",
+        "repo": "iohk-nix",
+        "rev": "335752283302344536e09095d09e4ac7538067b2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "iohk-nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1677021523,
+        "narHash": "sha256-0EhZjJ3rq8ZTTJ6Trrf/9hYtnIry0OsyY2NKoQoOS5Q=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "5a5adc2ad7009851d7d0fc26311e42a93b171d2e",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1681759395,
+        "narHash": "sha256-7aaRtLxLAy8qFVIA26ulB+Q5nDVzuQ71qi0s0wMjAws=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "cd749f58ba83f7155b7062dd49d08e5e47e44d50",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-22.11",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "iohk-nix": "iohk-nix",
+        "nixpkgs": "nixpkgs_2"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -57,9 +57,11 @@
 
   nixConfig = {
     extra-substituters = [
+      "https://kupo.cachix.org"
       "https://cache.iog.io"
     ];
     extra-trusted-public-keys = [
+      "kupo.cachix.org-1:RzYQ8KVjRJdPNt/Bhq/UqdyGYWFM8ShjEMNG8wzHBQ4="
       "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ="
     ];
   };

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,57 @@
+{
+  inputs = {
+    nixpkgs.url = "nixpkgs/nixos-22.11";
+    flake-utils.url = "github:numtide/flake-utils";
+    iohk-nix.url = "github:input-output-hk/iohk-nix";
+  };
+
+  outputs =
+    { self
+    , nixpkgs
+    , flake-utils
+    , iohk-nix
+    , ...
+    } @ inputs:
+    flake-utils.lib.eachSystem [
+      "x86_64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ]
+      (system:
+      let
+        pkgs = import inputs.nixpkgs {
+          inherit system;
+          overlays = [
+            # patched libsodium
+            iohk-nix.overlays.crypto
+          ];
+        };
+        compiler = "ghc8107";
+      in
+      rec {
+        devShells.default = pkgs.mkShell {
+          name = "kupo-dev-shell";
+
+          buildInputs = [
+            pkgs.glibcLocales
+            pkgs.libsodium-vrf # from iohk-nix overlay
+            pkgs.lzma
+            pkgs.secp256k1
+            pkgs.zlib
+            pkgs.git
+            pkgs.pkgconfig
+            pkgs.haskell.compiler.${compiler}
+            pkgs.cabal-install
+          ];
+        };
+      });
+
+  nixConfig = {
+    extra-substituters = [
+      "https://cache.iog.io"
+    ];
+    extra-trusted-public-keys = [
+      "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ="
+    ];
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -27,21 +27,30 @@
           ];
         };
         compiler = "ghc8107";
+
+        haskell-language-server = pkgs.haskell.packages.${compiler}.haskell-language-server.overrideAttrs (attrs:
+          { doCheck = false; }
+        );
       in
       rec {
         devShells.default = pkgs.mkShell {
           name = "kupo-dev-shell";
 
           buildInputs = [
+            # libraries
             pkgs.glibcLocales
             pkgs.libsodium-vrf # from iohk-nix overlay
             pkgs.lzma
             pkgs.secp256k1
             pkgs.zlib
+            # build tools
             pkgs.git
             pkgs.pkgconfig
             pkgs.haskell.compiler.${compiler}
             pkgs.cabal-install
+            # development tools
+            pkgs.stylish-haskell
+            haskell-language-server
           ];
         };
       });


### PR DESCRIPTION
This allows users to do a 'nix develop' and are put in a shell with cabal, ghc and libraries installed such that the project can be compiled.

No caching of dependencies included in this basic flake.

Happy to expand / reduce this into a shape which is addressing https://github.com/CardanoSolutions/kupo/discussions/113