### PR TITLE
Kupo x Hydra

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ dist-newstyle
 ## Dist
 /dist
 *.tar.gz
+/cabal.project.local

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "test/ogmios"]
 	path = test/vectors/ogmios
 	url = git@github.com:cardanosolutions/ogmios.git
+[submodule "test/vectors/hydra"]
+	path = test/vectors/hydra
+	url = git@github.com/input-output-hk/hydra.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -6,4 +6,4 @@
 	url = git@github.com:cardanosolutions/ogmios.git
 [submodule "test/vectors/hydra"]
 	path = test/vectors/hydra
-	url = git@github.com/input-output-hk/hydra.git
+	url = git@github.com:input-output-hk/hydra.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+### [2.7.0] - UNRELEASED
+
+#### Added
+
+- Support for indexing a Hydra head. Use `--hydra-host` and `--hydra-port` to
+  connect `kupo` to a `hydra-node`.
+
 ### [2.6.1] - 2023-08-30
 
 #### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,30 @@
-### [2.7.0] - UNRELEASED
+### [2.7.0] - 2023-10-13
 
 #### Added
 
-- Support for indexing a Hydra head. Use `--hydra-host` and `--hydra-port` to
-  connect `kupo` to a `hydra-node`.
+- Support for indexing a Hydra head.
+
+  Use `--hydra-host` and `--hydra-port` to connect `kupo` to a `hydra-node`.
+
+  > **Note**:
+  >
+  > Hydra heads do not actually form a 'chain'; Hydra doesn't have blocks, but
+  > snapshots which are akin to blocks so we treat them as such. The block
+  > header hash we opted for is arbitrary and is a hash of all the transaction
+  > id present in the snapshot.
+  >
+  > It also comes with diminished capabilities since Hydra doesn't have any
+  > protocol to query metadata for example and Kupo does not store them. So
+  > unlike Ogmios or Cardano-node, metadata cannot be retrieved when Hydra is
+  > used as a chain producer.
+
+#### Changed
+
+- N/A
+
+#### Removed
+
+- N/A
 
 ### [2.6.1] - 2023-08-30
 

--- a/cabal.project
+++ b/cabal.project
@@ -23,7 +23,6 @@ test-show-details: direct
 
 package kupo
   tests: true
-  flags: +production
 
 package websockets-json
   tests: false

--- a/docs/api/latest.yaml
+++ b/docs/api/latest.yaml
@@ -224,6 +224,25 @@ info:
 
     Kupo will synchronize data directly from Ogmios! Neat isn't it?
 
+    ## --hydra-host {hostname} / --hydra-port {port-number}
+
+    Kupo can also be used to index the layer two ledger available in a
+    [Hydra](https://github.com/input-output-hk/hydra/#readme) head. For this, we
+    need to use `--hydra-host` and `--hydra-port` to point to a machine running
+    a `hydra-node` of a head you want to index and the port of the websocket
+    API.
+
+    For example:
+
+    ```console
+    $ kupo \
+      --hydra-host 0.0.0.0 \
+      --hydra-port 4001 \
+      --since origin \
+      --match * \
+      --workdir ./db
+    ```
+
     ## --help
 
     In case you're lost, don't forget that a summary of this manual is available by running:

--- a/docs/man/README.md
+++ b/docs/man/README.md
@@ -32,22 +32,32 @@ kupo - Fast, lightweight & configurable chain-index for Cardano.
 **--node-socket**
 :   Path to the Cardano node domain socket file.
 
-    (**NOTE**: Unused when connecting to Ogmios)
+    (**NOTE**: Unused when connecting to Ogmios or Hydra)
 
 **--node-config**
 :   Path to the Cardano node configuration file.
 
-    (**NOTE**: Unused when connecting to Ogmios)
+    (**NOTE**: Unused when connecting to Ogmios or Hydra)
 
 **--ogmios-host**
 :   Ogmios' host address.
 
-    (**NOTE**: Unused when connecting to a Cardano node)
+    (**NOTE**: Unused when connecting to a Cardano node or Hydra)
 
 **--ogmios-port**
 :   Ogmios' port.
 
-    (**NOTE**: Unused when connecting to a Cardano node)
+    (**NOTE**: Unused when connecting to a Cardano node or Hydra)
+
+**--hydra-host**
+:   Hydra-node host address.
+
+    (**NOTE**: Unused when connecting to a Cardano node or Ogmios)
+
+**--hydra-port**
+:   Hydra-node port.
+
+    (**NOTE**: Unused when connecting to a Cardano node or Ogmios)
 
 **--workdir**
 :   Path to a working directory, where the SQLite database files are stored. By convention, the database is called <u>kupo.sqlite</u>.
@@ -255,6 +265,13 @@ kupo - Fast, lightweight & configurable chain-index for Cardano.
   --in-memory\
   --since 16588737.4e9bbbb67e3ae262133d94c3da5bffce7b1127fc436e7433b87668dba34c354a\
   --match addr1vyc29pvl2uyzqt8nwxrcxnf558ffm27u3d9calxn8tdudjgz4xq9p\
+
+**kupo**\
+  --hydra-host 0.0.0.0\
+  --hydra-port 4001\
+  --in-memory\
+  --since origin\
+  --match *
 
 # SEE ALSO
 Online documentation and API reference: <https://cardanosolutions.github.io/kupo/>

--- a/kupo.cabal
+++ b/kupo.cabal
@@ -47,6 +47,7 @@ library
       Kupo
       Kupo.App
       Kupo.App.ChainSync
+      Kupo.App.ChainSync.Hydra
       Kupo.App.ChainSync.Node
       Kupo.App.ChainSync.Ogmios
       Kupo.App.Configuration
@@ -107,6 +108,7 @@ library
       Kupo.Data.Http.SlotRange
       Kupo.Data.Http.Status
       Kupo.Data.Http.StatusFlag
+      Kupo.Data.Hydra
       Kupo.Data.Ogmios
       Kupo.Data.PartialBlock
       Kupo.Data.Pattern

--- a/kupo.cabal
+++ b/kupo.cabal
@@ -40,7 +40,7 @@ source-repository head
 flag production
   description: Compile executables for production.
   manual: True
-  default: False
+  default: True
 
 library
   exposed-modules:

--- a/kupo.cabal
+++ b/kupo.cabal
@@ -297,6 +297,7 @@ test-suite unit
       Test.Kupo.Data.Http.OrderMatchesBySpec
       Test.Kupo.Data.Http.SlotRangeSpec
       Test.Kupo.Data.OgmiosSpec
+      Test.Kupo.Data.HydraSpec
       Test.Kupo.Data.Pattern.Fixture
       Test.Kupo.Data.PatternSpec
       Test.Kupo.Data.UtxoConstraint

--- a/modules/websockets-json/package.yaml
+++ b/modules/websockets-json/package.yaml
@@ -28,5 +28,6 @@ library:
     - bytestring
     - connection
     - exceptions
+    - io-classes
     - websockets
     - wuss

--- a/modules/websockets-json/src/Network/WebSockets/Json.hs
+++ b/modules/websockets-json/src/Network/WebSockets/Json.hs
@@ -13,7 +13,7 @@ import Prelude
 import Control.Exception
     ( Exception
     )
-import Control.Monad.Catch
+import Control.Monad.Class.MonadThrow
     ( MonadThrow (..)
     )
 import Control.Monad.IO.Class
@@ -54,7 +54,7 @@ receiveJson
 receiveJson ws decoder =  do
     bytes <- liftIO (WS.receiveData ws)
     either
-        (\(path, err) -> throwM $ MalformedOrUnexpectedResponse bytes path err)
+        (\(path, err) -> throwIO $ MalformedOrUnexpectedResponse bytes path err)
         pure
         (Json.eitherDecodeWith Json.jsonEOF (Json.iparse decoder) bytes)
 

--- a/modules/websockets-json/websockets-json.cabal
+++ b/modules/websockets-json/websockets-json.cabal
@@ -77,6 +77,7 @@ library
     , bytestring
     , connection
     , exceptions
+    , io-classes
     , websockets
     , wuss
   default-language: Haskell2010

--- a/src/Kupo/App.hs
+++ b/src/Kupo/App.hs
@@ -100,6 +100,9 @@ import Kupo.Data.Database
 import Kupo.Data.FetchBlock
     ( FetchBlockClient
     )
+import Kupo.Data.PartialBlock
+    ( PartialBlock
+    )
 import Kupo.Data.Pattern
     ( Codecs (..)
     , Match (..)
@@ -234,6 +237,8 @@ withFetchBlockClient chainProducer callback = do
     case chainProducer of
         Ogmios{ogmiosHost, ogmiosPort} ->
             Ogmios.withFetchBlockClient ogmiosHost ogmiosPort callback
+        Hydra{} ->
+            callback @PartialBlock (\_point respond -> respond Nothing)
         CardanoNode{nodeSocket, nodeConfig} -> do
             NetworkParameters
                 { networkMagic

--- a/src/Kupo/App/ChainSync/Hydra.hs
+++ b/src/Kupo/App/ChainSync/Hydra.hs
@@ -34,6 +34,10 @@ import Kupo.Data.Ogmios
     ( PartialBlock
     )
 
+import Kupo.Data.Hydra
+    ( HydraMessage (..)
+    , decodeHydraMessage
+    )
 import qualified Network.WebSockets as WS
 import qualified Network.WebSockets.Json as WS
 
@@ -49,7 +53,11 @@ runChainSyncClient
     -> WS.Connection
     -> m IntersectionNotFoundException
 runChainSyncClient mailbox beforeMainLoop pts ws = do
-    undefined
+    beforeMainLoop
+    forever $ do
+        WS.receiveJson ws decodeHydraMessage >>= \case
+            SnapshotConfirmed{} -> pure ()
+            SomethingElse -> pure ()
 
 connect
     :: ConnectionStatusToggle IO

--- a/src/Kupo/App/ChainSync/Hydra.hs
+++ b/src/Kupo/App/ChainSync/Hydra.hs
@@ -1,0 +1,62 @@
+--  This Source Code Form is subject to the terms of the Mozilla Public
+--  License, v. 2.0. If a copy of the MPL was not distributed with this
+--  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+module Kupo.App.ChainSync.Hydra
+    ( connect
+    , runChainSyncClient
+    ) where
+
+import Kupo.Prelude
+
+import Control.Exception.Safe
+    ( MonadThrow
+    )
+import Kupo.App.Mailbox
+    ( Mailbox
+    , putHighFrequencyMessage
+    , putIntermittentMessage
+    )
+import Kupo.Control.MonadSTM
+    ( MonadSTM (..)
+    )
+import Kupo.Data.Cardano
+    ( Point
+    , SlotNo
+    , Tip
+    , WithOrigin
+    , pointSlot
+    )
+import Kupo.Data.ChainSync
+    ( IntersectionNotFoundException (..)
+    )
+import Kupo.Data.Ogmios
+    ( PartialBlock
+    )
+
+import qualified Network.WebSockets as WS
+import qualified Network.WebSockets.Json as WS
+
+runChainSyncClient
+    :: forall m.
+        ( MonadIO m
+        , MonadSTM m
+        , MonadThrow m
+        )
+    => Mailbox m (Tip, PartialBlock) (Tip, Point)
+    -> m () -- An action to run before the main loop starts.
+    -> [Point]
+    -> WS.Connection
+    -> m IntersectionNotFoundException
+runChainSyncClient mailbox beforeMainLoop pts ws = do
+    undefined
+
+connect
+    :: ConnectionStatusToggle IO
+    -> String
+    -> Int
+    -> (WS.Connection -> IO a)
+    -> IO a
+connect ConnectionStatusToggle{toggleConnected} host port action =
+    WS.runClientWith host port "/"
+        WS.defaultConnectionOptions [] (\ws -> toggleConnected >> action ws)

--- a/src/Kupo/App/ChainSync/Hydra.hs
+++ b/src/Kupo/App/ChainSync/Hydra.hs
@@ -2,6 +2,7 @@
 --  License, v. 2.0. If a copy of the MPL was not distributed with this
 --  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+{-# LANGUAGE PatternSynonyms #-}
 module Kupo.App.ChainSync.Hydra
     ( connect
     , runChainSyncClient
@@ -34,9 +35,22 @@ import Kupo.Data.Ogmios
     ( PartialBlock
     )
 
+import qualified Data.ByteString as BS
+import Kupo.Data.Cardano.HeaderHash
+    ( unsafeHeaderHashFromBytes
+    )
+import Kupo.Data.Cardano.Point
+    ( pattern BlockPoint
+    )
+import Kupo.Data.Cardano.Tip
+    ( pattern Tip
+    )
 import Kupo.Data.Hydra
     ( HydraMessage (..)
     , decodeHydraMessage
+    )
+import Kupo.Data.PartialBlock
+    ( PartialBlock (..)
     )
 import qualified Network.WebSockets as WS
 import qualified Network.WebSockets.Json as WS
@@ -56,7 +70,17 @@ runChainSyncClient mailbox beforeMainLoop pts ws = do
     beforeMainLoop
     forever $ do
         WS.receiveJson ws decodeHydraMessage >>= \case
-            SnapshotConfirmed{} -> pure ()
+            SnapshotConfirmed{} -> do
+                let headerHash = unsafeHeaderHashFromBytes $ BS.replicate 32 0
+                let slotNo = 1 -- TODO: decode snapshot number as slot
+                let blockNo = 1
+                let tip = Tip slotNo headerHash blockNo
+                let block =
+                        PartialBlock
+                            { blockPoint = BlockPoint slotNo headerHash
+                            , blockBody  = []
+                            }
+                atomically (putHighFrequencyMessage mailbox (tip, block))
             SomethingElse -> pure ()
 
 connect

--- a/src/Kupo/App/ChainSync/Hydra.hs
+++ b/src/Kupo/App/ChainSync/Hydra.hs
@@ -60,8 +60,8 @@ runChainSyncClient mailbox beforeMainLoop _pts ws = do
     TransactionStore{pushTx, popTxById} <- newTransactionStore
     forever $ do
         WS.receiveJson ws decodeHydraMessage >>= \case
-            HeadIsOpen ->
-                atomically (putHighFrequencyMessage mailbox (mkHydraBlock 0 []))
+            HeadIsOpen{genesisTxs} ->
+                atomically (putHighFrequencyMessage mailbox (mkHydraBlock 0 genesisTxs))
             TxValid{tx} ->
                 pushTx tx
             SnapshotConfirmed{ snapshot = Snapshot { number, confirmedTransactionIds }} -> do

--- a/src/Kupo/App/ChainSync/Hydra.hs
+++ b/src/Kupo/App/ChainSync/Hydra.hs
@@ -32,8 +32,9 @@ import Kupo.Data.Ogmios
 
 import Kupo.Data.Hydra
     ( HydraMessage (..)
+    , Snapshot (..)
     , decodeHydraMessage
-    , fromSnapshot
+    , fromSnapshotNumber
     )
 import qualified Network.WebSockets as WS
 import qualified Network.WebSockets.Json as WS
@@ -53,8 +54,10 @@ runChainSyncClient mailbox beforeMainLoop _pts ws = do
     beforeMainLoop
     forever $ do
         WS.receiveJson ws decodeHydraMessage >>= \case
-            SnapshotConfirmed{ snapshot } -> do
-                atomically (putHighFrequencyMessage mailbox (fromSnapshot snapshot))
+            HeadIsOpen -> do
+                atomically (putHighFrequencyMessage mailbox (fromSnapshotNumber 0))
+            SnapshotConfirmed{ snapshot = Snapshot { number }} -> do
+                atomically (putHighFrequencyMessage mailbox (fromSnapshotNumber number))
             SomethingElse -> pure ()
 
 connect

--- a/src/Kupo/App/ChainSync/Hydra.hs
+++ b/src/Kupo/App/ChainSync/Hydra.hs
@@ -12,10 +12,6 @@ module Kupo.App.ChainSync.Hydra
 
 import Kupo.Prelude
 
-import Control.Exception.Safe
-    ( MonadThrow
-    , throwM
-    )
 import Kupo.App.Mailbox
     ( Mailbox
     , putHighFrequencyMessage
@@ -23,10 +19,16 @@ import Kupo.App.Mailbox
 import Kupo.Control.MonadSTM
     ( MonadSTM (..)
     )
+import Kupo.Control.MonadThrow
+    ( MonadThrow (..)
+    )
 import Kupo.Data.Cardano
     ( Point
     , Tip
     , TransactionId
+    , WithOrigin (..)
+    , getPointSlotNo
+    , getTipSlotNo
     )
 import Kupo.Data.ChainSync
     ( IntersectionNotFoundException (..)
@@ -38,7 +40,7 @@ import Kupo.Data.Hydra
     , mkHydraBlock
     )
 import Kupo.Data.PartialBlock
-    ( PartialBlock
+    ( PartialBlock (..)
     , PartialTransaction (..)
     )
 
@@ -50,26 +52,112 @@ runChainSyncClient
     :: forall m.
         ( MonadIO m
         , MonadSTM m
-        , MonadThrow m, MonadThrow (STM m))
+        , MonadThrow m
+        , MonadThrow (STM m)
+        )
     => Mailbox m (Tip, PartialBlock) (Tip, Point)
     -> m () -- An action to run before the main loop starts.
     -> [Point]
     -> WS.Connection
     -> m IntersectionNotFoundException
-runChainSyncClient mailbox beforeMainLoop _pts ws = do
+runChainSyncClient mailbox beforeMainLoop pts ws = do
     beforeMainLoop
     TransactionStore{push, pop} <- newTransactionStore
-    forever $ do
-        WS.receiveJson ws decodeHydraMessage >>= \case
+    flip evalStateT (sortOn getPointSlotNo pts) $ forever $ do
+       lift (WS.receiveJson ws decodeHydraMessage) >>= \case
             HeadIsOpen{genesisTxs} -> do
-                atomically (putHighFrequencyMessage mailbox (mkHydraBlock 0 genesisTxs))
+                handleBlock $ mkHydraBlock 0 genesisTxs
             TxValid{tx} -> do
-                push tx
+                lift $ push tx
             SnapshotConfirmed{ snapshot = Snapshot { number, confirmedTransactionIds }} -> do
-                txs <- pop confirmedTransactionIds
-                atomically (putHighFrequencyMessage mailbox (mkHydraBlock number txs))
+                txs <- lift $ pop confirmedTransactionIds
+                handleBlock $ mkHydraBlock number txs
             SomethingElse -> do
                 pure ()
+  where
+    -- Hydra doesn't provide any mechanism to negotiate an intersection point and receive snapshots
+    -- only from a certain point. So we 'fake' it by skippping blocks until we have caught up with our
+    -- state.
+    --
+    -- - We start from a (possibly empty) ascending list of checkpoints that we have already processed.
+    -- - For each 'block' received from the Hydra head, we have one of three situation.
+    --
+    --   1. Its slot number is lower than the current cursor (i.e. smallest checkpoint)
+    --   2. Its slot number is equal to the current cursor
+    --   3. Its slot number is higher than the current cursor.
+    --
+    -- - In the case of (1), it's simple[NOTE^A], we have already seen that block and we can just skip it. The
+    -- cursor doesn't move as we haven't caught up with that checkpoint yet.
+    --
+    -- - In the case of (2), we have two possibilities:
+    --
+    --   1. The block header hash and the checkpoint header hash are identical
+    --      -> This means we've found a block that's on both chains. We can skip it as we already know
+    --      of it. We can move to the next checkpoint too.
+    --
+    --   2. The block header hash and the checkpoint header hash are different
+    --      -> This means we (the indexer) is on a fork. But we don't have enough information to know
+    --      where to rollback to. So we throw an exception.
+    --      Note that this truly is *exceptional* because Hydra heads cannot fork in principle. The
+    --      only way we end up here is if someone tries to connect an already synchronized index to a
+    --      new head which happen to have different chain histories. And that's a very valid reason to
+    --      crash.
+    --
+    -- - The case of (3) is in principle _impossible_ because a Hydra snapshots are monotically
+    -- increasing with no gaps. So we can't possibly hit that scenario without first hitting (2).
+    --
+    -- - When the list of checkpoints is empty, it means we have caught up with the chain and any new
+    -- block is relevant to the indexer.
+    --
+    --
+    -- NOTE^A: It is "simple" because we assume that there is not two different Hydra "chains" that
+    -- might have two equal blocks. However, in principle, we should verify that the discarded blocks
+    -- still form a chain up to the last known block we stored. Otherwise, there could be a scenario
+    -- where we have stored: b1, b2, b3 but receive b1', b2', b3. If are waiting for a snapshot number
+    -- at 3, then we will discard b1' and b2' even though they are actually different from what we
+    -- stored.
+    --
+    -- This can really only happen if we have concomittantly:
+    --   (a) Someone restarting the indexer on a *different* Hydra head.
+    --   (b) ALL of our selected checkpoint being identical on both heads.
+    --
+    -- Without (b), the condition 2.2 would already throw an exception. Given the scenario we're in,
+    -- we consider this quite unlikely.
+    handleBlock
+        :: (Tip, PartialBlock)
+        -> StateT [Point] m ()
+    handleBlock (tip, block) = do
+        get >>= \case
+            -- No checkpoints, all blocks are relevant.
+            [] -> do
+                lift $ atomically (putHighFrequencyMessage mailbox (tip, block))
+
+            requestedPoints@(cursor:_) -> do
+                   -- Block is before a known checkpoint, ignoring.
+                if | slot < getPointSlotNo cursor -> do
+                       return ()
+
+                   -- Block is at checkpoint
+                   | slot == getPointSlotNo cursor -> do
+                       if point == cursor then do
+                           -- Checkpoint matches, we skip the block and move the cursor
+                           modify' (drop 1)
+                       else
+                            lift $ throwIO $ IntersectionNotFound
+                               { requestedPoints = At . getPointSlotNo <$> requestedPoints
+                               , tip = At . getTipSlotNo $ tip
+                               }
+
+                   -- Block is after a known checkpoint, absurd
+                   | otherwise -> do
+                       error $ "impossible: received a block *after* a known checkpoint? \
+                               \There isn't supposed to be any gaps in Hydra snapshots \
+                               \however this suggests that there was one.\
+                               \We choked on: " <> show point <> ", while expecting a \
+                               \snapshot at: " <> show cursor <> "."
+      where
+        point = blockPoint block
+        slot = getPointSlotNo point
 
 connect
     :: ConnectionStatusToggle IO
@@ -96,7 +184,13 @@ newtype TransactionStoreException = TransactionNotInStore { transactionId :: Tra
 
 instance Exception TransactionStoreException
 
-newTransactionStore :: (Monad m, MonadSTM m, MonadThrow (STM m)) => m (TransactionStore m)
+newTransactionStore
+    :: forall m.
+        ( Monad m
+        , MonadSTM m
+        , MonadThrow (STM m)
+        )
+    => m (TransactionStore m)
 newTransactionStore = do
   store <- atomically $ newTVar mempty
   pure TransactionStore
@@ -107,7 +201,7 @@ newTransactionStore = do
             txMap <- readTVar store
             forM ids $ \id -> do
                 case Map.lookup id txMap of
-                  Nothing -> throwM $ TransactionNotInStore id
+                  Nothing -> throwIO $ TransactionNotInStore id
                   Just tx -> do
                       writeTVar store (Map.delete id txMap)
                       pure tx

--- a/src/Kupo/App/ChainSync/Hydra.hs
+++ b/src/Kupo/App/ChainSync/Hydra.hs
@@ -5,6 +5,9 @@
 module Kupo.App.ChainSync.Hydra
     ( connect
     , runChainSyncClient
+    , newTransactionStore
+    , TransactionStore (..)
+    , TransactionStoreException (..)
     ) where
 
 import Kupo.Prelude

--- a/src/Kupo/App/ChainSync/Ogmios.hs
+++ b/src/Kupo/App/ChainSync/Ogmios.hs
@@ -12,9 +12,6 @@ module Kupo.App.ChainSync.Ogmios
 
 import Kupo.Prelude
 
-import Control.Exception.Safe
-    ( MonadThrow
-    )
 import Kupo.App.Mailbox
     ( Mailbox
     , putHighFrequencyMessage
@@ -22,6 +19,9 @@ import Kupo.App.Mailbox
     )
 import Kupo.Control.MonadSTM
     ( MonadSTM (..)
+    )
+import Kupo.Control.MonadThrow
+    ( MonadThrow (..)
     )
 import Kupo.Data.Cardano
     ( Point

--- a/src/Kupo/App/Configuration.hs
+++ b/src/Kupo/App/Configuration.hs
@@ -215,6 +215,9 @@ data TraceConfiguration where
     ConfigurationOgmios
         :: { ogmiosHost :: String, ogmiosPort :: Int }
         -> TraceConfiguration
+    ConfigurationHydra
+        :: { hydraHost :: String, hydraPort :: Int }
+        -> TraceConfiguration
     ConfigurationCardanoNode
         :: { nodeSocket :: FilePath, nodeConfig :: FilePath }
         -> TraceConfiguration
@@ -240,6 +243,7 @@ instance HasSeverityAnnotation TraceConfiguration where
     getSeverityAnnotation = \case
         ConfigurationNetwork{} -> Info
         ConfigurationOgmios{} -> Info
+        ConfigurationHydra{} -> Info
         ConfigurationCardanoNode{} -> Info
         ConfigurationPatterns{} -> Info
         ConfigurationCheckpointsForIntersection{} -> Info

--- a/src/Kupo/App/Database.hs
+++ b/src/Kupo/App/Database.hs
@@ -830,7 +830,7 @@ mkDatabase tr mode longestRollback bracketConnection = Database
             _otherwise -> do
                 withTemporaryIndex tr conn "inputsByCreatedAt" "inputs(created_at)" $ do
                     withTemporaryIndex tr conn "inputsBySpentAt" "inputs(spent_at)" $ do
-                        deleteInputsIncrementally tr conn minSlotNo
+                        -- deleteInputsIncrementally tr conn minSlotNo
                         traceExecute tr conn rollbackQryUpdateInputs [ minSlotNo ]
                         traceExecute tr conn rollbackQryDeleteCheckpoints [ minSlotNo ]
         query_ conn selectMaxCheckpointQry >>= \case
@@ -845,11 +845,11 @@ mkDatabase tr mode longestRollback bracketConnection = Database
         retryWhenBusy tr (constantStrategy 0.1) 1 $ withTransaction conn mode (runReaderT r conn)
     }
 
-deleteInputsIncrementally :: Tracer IO TraceConnection -> Connection -> SQLData -> IO ()
-deleteInputsIncrementally tr conn minSlotNo = do
+_deleteInputsIncrementally :: Tracer IO TraceConnection -> Connection -> SQLData -> IO ()
+_deleteInputsIncrementally tr conn minSlotNo = do
     traceExecute tr conn rollbackQryDeleteInputs [ minSlotNo ]
     deleted <- changes conn
-    unless (deleted < pruneInputsMaxIncrement) $ deleteInputsIncrementally tr conn minSlotNo
+    unless (deleted < pruneInputsMaxIncrement) $ _deleteInputsIncrementally tr conn minSlotNo
 
 insertRow
     :: forall tableName.

--- a/src/Kupo/Data/Configuration.hs
+++ b/src/Kupo/Data/Configuration.hs
@@ -65,7 +65,7 @@ import qualified Data.Aeson as Json
 -- | Application-level configuration.
 data Configuration = Configuration
     { chainProducer :: ChainProducer
-        -- ^ Where the data comes from: cardano-node vs ogmios
+        -- ^ Where the data comes from: cardano-node, ogmios, or hydra
         --
         -- NOTE: There's no bang pattern on this field because we do not want it
         -- to be unnecessarily evaluated in some test scenarios (e.g. state-machine)
@@ -101,7 +101,8 @@ data Configuration = Configuration
 -- equivalent in the capabilities and information they offer; a cardano-node
 -- will have to be through a local connection (domain socket) whereas ogmios can
 -- happen _over the wire_ on a remote server but is slower overall. So both have
--- trade-offs.
+-- trade-offs. The 'hydra' chain producer is slightly different as it's "chain"
+-- is actually the UTxO and transactions happening on the Hydra head layer 2.
 data ChainProducer
     = CardanoNode
         { nodeSocket :: !FilePath

--- a/src/Kupo/Data/Configuration.hs
+++ b/src/Kupo/Data/Configuration.hs
@@ -111,6 +111,7 @@ data ChainProducer
         { ogmiosHost :: !String
         , ogmiosPort :: !Int
         }
+    | Hydra
     deriving (Generic, Eq, Show)
 
 -- | Database working directory. 'in-memory' runs the database in hot memory,

--- a/src/Kupo/Data/Configuration.hs
+++ b/src/Kupo/Data/Configuration.hs
@@ -112,6 +112,9 @@ data ChainProducer
         , ogmiosPort :: !Int
         }
     | Hydra
+        { hydraHost :: !String
+        , hydraPort :: !Int
+        }
     deriving (Generic, Eq, Show)
 
 -- | Database working directory. 'in-memory' runs the database in hot memory,

--- a/src/Kupo/Data/Hydra.hs
+++ b/src/Kupo/Data/Hydra.hs
@@ -1,23 +1,74 @@
+{-# LANGUAGE PatternSynonyms #-}
+
 module Kupo.Data.Hydra where
 
 import Kupo.Prelude
 
+import Cardano.Crypto.Hash
+    ( hashToBytes
+    , hashWith
+    )
 import Data.Aeson
     ( (.:)
     )
+import Kupo.Data.Cardano
+    ( BlockNo (..)
+    , SlotNo (..)
+    , Tip
+    , pattern BlockPoint
+    , pattern Tip
+    , unsafeHeaderHashFromBytes
+    )
+import Kupo.Data.PartialBlock
+    ( PartialBlock (..)
+    )
+
 import qualified Data.Aeson.Types as Json
+import qualified Data.ByteString.Builder as BS
+
+-- Types
 
 data HydraMessage
-  = SnapshotConfirmed
-  | SomethingElse
+    = SnapshotConfirmed { snapshot :: Snapshot }
+    | SomethingElse
 
+data Snapshot = Snapshot
+    { number :: Word64
+    }
+
+fromSnapshot :: Snapshot -> (Tip, PartialBlock)
+fromSnapshot Snapshot { number } = do
+    let
+        headerHash = number
+            & hashWith @Blake2b_256 (toStrict . BS.toLazyByteString . BS.word64BE)
+            & hashToBytes
+            & unsafeHeaderHashFromBytes
+
+        slotNo =
+            SlotNo number
+
+        blockNo =
+            BlockNo number
+     in
+        ( Tip slotNo headerHash blockNo
+        , PartialBlock
+            { blockPoint = BlockPoint slotNo headerHash
+            , blockBody  = []
+            }
+        )
 
 -- Decoders
 
 decodeHydraMessage :: Json.Value -> Json.Parser HydraMessage
 decodeHydraMessage =
-  Json.withObject "HydraMessage" $ \o -> do
-    tag <- o .: "tag"
-    case tag of
-      ("SnapshotConfirmed" :: Text) -> pure SnapshotConfirmed
-      _ -> pure SomethingElse
+    Json.withObject "HydraMessage" $ \o -> do
+        tag <- o .: "tag"
+        case tag of
+            ("SnapshotConfirmed" :: Text) -> SnapshotConfirmed <$> decodeSnapshotConfirmed o
+            _ -> pure SomethingElse
+
+decodeSnapshotConfirmed :: Json.Object -> Json.Parser Snapshot
+decodeSnapshotConfirmed o = do
+    snapshot <- o .: "snapshot"
+    number <- snapshot .: "snapshotNumber"
+    pure $ Snapshot { number }

--- a/src/Kupo/Data/Hydra.hs
+++ b/src/Kupo/Data/Hydra.hs
@@ -1,0 +1,23 @@
+module Kupo.Data.Hydra where
+
+import Kupo.Prelude
+
+import Data.Aeson
+    ( (.:)
+    )
+import qualified Data.Aeson.Types as Json
+
+data HydraMessage
+  = SnapshotConfirmed
+  | SomethingElse
+
+
+-- Decoders
+
+decodeHydraMessage :: Json.Value -> Json.Parser HydraMessage
+decodeHydraMessage =
+  Json.withObject "HydraMessage" $ \o -> do
+    tag <- o .: "tag"
+    case tag of
+      ("SnapshotConfirmed" :: Text) -> pure SnapshotConfirmed
+      _ -> pure SomethingElse

--- a/src/Kupo/Data/Hydra.hs
+++ b/src/Kupo/Data/Hydra.hs
@@ -29,15 +29,16 @@ import qualified Data.ByteString.Builder as BS
 -- Types
 
 data HydraMessage
-    = SnapshotConfirmed { snapshot :: Snapshot }
+    = HeadIsOpen
+    | SnapshotConfirmed { snapshot :: Snapshot }
     | SomethingElse
 
 data Snapshot = Snapshot
     { number :: Word64
     }
 
-fromSnapshot :: Snapshot -> (Tip, PartialBlock)
-fromSnapshot Snapshot { number } = do
+fromSnapshotNumber :: Word64 -> (Tip, PartialBlock)
+fromSnapshotNumber number = do
     let
         headerHash = number
             & hashWith @Blake2b_256 (toStrict . BS.toLazyByteString . BS.word64BE)
@@ -64,6 +65,7 @@ decodeHydraMessage =
     Json.withObject "HydraMessage" $ \o -> do
         tag <- o .: "tag"
         case tag of
+            ("HeadIsOpen" :: Text) -> pure HeadIsOpen
             ("SnapshotConfirmed" :: Text) -> SnapshotConfirmed <$> decodeSnapshotConfirmed o
             _ -> pure SomethingElse
 

--- a/src/Kupo/Data/Hydra.hs
+++ b/src/Kupo/Data/Hydra.hs
@@ -44,6 +44,7 @@ import Kupo.Data.Cardano
     , scriptFromBytes
     , scriptHashFromText
     , transactionIdFromText
+    , transactionIdToBytes
     , unsafeHeaderHashFromBytes
     , unsafeValueFromList
     , withReferences
@@ -63,7 +64,7 @@ import qualified Data.Aeson.Key as Key
 import qualified Data.Aeson.KeyMap as KeyMap
 import qualified Data.Aeson.Types as Json
 import qualified Data.ByteString as BS
-import qualified Data.ByteString.Builder as BS
+import qualified Data.ByteString.Builder as B
 import qualified Data.Map.Strict as Map
 import qualified Data.Text as Text
 
@@ -83,8 +84,9 @@ data Snapshot = Snapshot
 mkHydraBlock :: Word64 -> [PartialTransaction] -> (Tip, PartialBlock)
 mkHydraBlock number txs = do
     let
-        headerHash = number
-            & hashWith @Blake2b_256 (toStrict . BS.toLazyByteString . BS.word64BE)
+        headerHash = txs
+            & foldr (\PartialTransaction{id} -> (B.byteString (transactionIdToBytes id) <>)) mempty
+            & hashWith @Blake2b_256 (toStrict . B.toLazyByteString)
             & hashToBytes
             & unsafeHeaderHashFromBytes
 

--- a/src/Kupo/Data/Hydra.hs
+++ b/src/Kupo/Data/Hydra.hs
@@ -36,6 +36,10 @@ import Kupo.Data.Cardano
     , unsafeValueFromList
     , withReferences
     )
+import Kupo.Data.Ogmios
+    ( decodeAddress
+    , decodeTransactionId
+    )
 import Kupo.Data.PartialBlock
     ( PartialBlock (..)
     , PartialTransaction (PartialTransaction, datums, id, inputs, metadata, outputs, scripts)
@@ -47,10 +51,6 @@ import qualified Data.Aeson.Types as Json
 import qualified Data.ByteString.Builder as BS
 import qualified Data.Map.Strict as Map
 import qualified Data.Text as Text
-import Kupo.Data.Ogmios
-    ( decodeAddress
-    , decodeTransactionId
-    )
 
 -- Types
 
@@ -83,7 +83,7 @@ mkHydraBlock number txs = do
         ( Tip slotNo headerHash blockNo
         , PartialBlock
             { blockPoint = BlockPoint slotNo headerHash
-            , blockBody  = txs
+            , blockBody  = toList txs
             }
         )
 

--- a/src/Kupo/Data/Ogmios.hs
+++ b/src/Kupo/Data/Ogmios.hs
@@ -17,6 +17,7 @@ module Kupo.Data.Ogmios
     , decodeNextBlockResponse
     -- ** Cardano decoders
     , decodeTransactionId
+    , decodeAddress
     ) where
 
 import Kupo.Prelude

--- a/src/Kupo/Data/Ogmios.hs
+++ b/src/Kupo/Data/Ogmios.hs
@@ -304,9 +304,9 @@ decodeScript = Json.withObject "Script" $ \o -> do
             Right (Just s) ->
                 pure s
             Right Nothing ->
-                fail "decodeScript: decodePlutusV1: malformed script"
+                fail "decodeScript: malformed script"
             Left e ->
-                fail $ "decodeScript: decodePlutusV1: not base16: " <> show e
+                fail $ "decodeScript: not base16: " <> show e
 
 decodeNativeScript
     :: Json.Object

--- a/src/Kupo/Data/Ogmios.hs
+++ b/src/Kupo/Data/Ogmios.hs
@@ -15,6 +15,8 @@ module Kupo.Data.Ogmios
 
     , decodeFindIntersectionResponse
     , decodeNextBlockResponse
+    -- ** Cardano decoders
+    , decodeTransactionId
     ) where
 
 import Kupo.Prelude

--- a/src/Kupo/Options.hs
+++ b/src/Kupo/Options.hs
@@ -157,7 +157,7 @@ parserInfo = info (helper <*> parser) $ mempty
 
 chainProducerOption :: Parser ChainProducer
 chainProducerOption =
-    cardanoNodeOptions <|> ogmiosOptions
+    cardanoNodeOptions <|> ogmiosOptions <|> hydraOptions
   where
     cardanoNodeOptions = CardanoNode
         <$> nodeSocketOption
@@ -166,6 +166,10 @@ chainProducerOption =
     ogmiosOptions = Ogmios
         <$> ogmiosHostOption
         <*> ogmiosPortOption
+
+    hydraOptions = Hydra
+        <$> hydraHostOption
+        <*> hydraPortOption
 
 -- | --node-socket=FILEPATH
 nodeSocketOption :: Parser FilePath
@@ -231,6 +235,21 @@ ogmiosPortOption = option auto $ mempty
     <> long "ogmios-port"
     <> metavar "TCP/PORT"
     <> help "Ogmios' port."
+
+-- | [--hydra-host=IPv4]
+hydraHostOption :: Parser String
+hydraHostOption = option str $ mempty
+    <> long "hydra-host"
+    <> metavar "IPv4"
+    <> help "Hydra-node host address to connect to."
+    <> completer (bashCompleter "hostname")
+
+-- | [--hydra-port=TCP/PORT]
+hydraPortOption :: Parser Int
+hydraPortOption = option auto $ mempty
+    <> long "hydra-port"
+    <> metavar "TCP/PORT"
+    <> help "Hydra-node port to connect to."
 
 -- | [--since=POINT]
 sinceOption :: Parser Point

--- a/test/Test/Kupo/Data/HydraSpec.hs
+++ b/test/Test/Kupo/Data/HydraSpec.hs
@@ -1,0 +1,70 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this
+-- file, You can obtain one at http://mozilla.org/MPL/2.0/.
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Test.Kupo.Data.HydraSpec
+    ( spec
+    ) where
+
+import qualified Data.Set as Set
+import Kupo.App.ChainSync.Hydra
+    ( TransactionStore (..)
+    , TransactionStoreException (TransactionNotInStore)
+    , newTransactionStore
+    , pushTx
+    )
+import Kupo.Data.PartialBlock
+    ( PartialTransaction (..)
+    )
+import Kupo.Prelude
+import Test.Hspec
+    ( Spec
+    , context
+    , parallel
+    , shouldBe
+    , shouldThrow
+    )
+import Test.Hspec.QuickCheck
+    ( prop
+    )
+import Test.Kupo.AppSpec
+    ( genPartialTransactions
+    )
+import Test.Kupo.Data.Generators
+    ( genOutputReference
+    )
+import Test.QuickCheck
+    ( label
+    , listOf1
+    , shuffle
+    )
+import Test.QuickCheck.Monadic
+    ( monadicIO
+    , monitor
+    , pick
+    , run
+    )
+
+spec :: Spec
+spec = parallel $ context "TransactionStore" $ do
+
+    prop "can retrieve transactions in any order" $ monadicIO $ do
+      TransactionStore{pushTx, popTxById} <- run newTransactionStore
+      txs <- pick $ do
+           txIns <- listOf1 genOutputReference
+           evalStateT genPartialTransactions (Set.fromList txIns)
+      txsWithIds <- forM txs $ \tx@PartialTransaction{id} -> do
+            run $ pushTx tx
+            pure (tx, id)
+      monitor (label $ "Generated list length is " <> show (length txsWithIds))
+      shuffledTxs <- pick $ shuffle txsWithIds
+      pure $
+          forM_ shuffledTxs $ \(tx, txId) -> do
+              tx' <- popTxById txId
+              tx' `shouldBe` tx
+              popTxById txId `shouldThrow` \case
+                  TransactionNotInStore txId' -> txId' == txId
+
+
+

--- a/test/Test/Kupo/OptionsSpec.hs
+++ b/test/Test/Kupo/OptionsSpec.hs
@@ -88,6 +88,12 @@ spec = parallel $ do
         , ( [ "--ogmios-port", "1337" ]
           , shouldFail
           )
+        , ( [ "--hydra-host", "localhost" ]
+          , shouldFail
+          )
+        , ( [ "--hydra-port", "4001" ]
+          , shouldFail
+          )
         , ( defaultArgs
           , shouldParseAppConfiguration $ defaultConfiguration
             { chainProducer = CardanoNode
@@ -102,6 +108,15 @@ spec = parallel $ do
             { chainProducer = Ogmios
                 { ogmiosHost = "localhost"
                 , ogmiosPort = 1337
+                }
+            , workDir = InMemory
+            }
+          )
+        , ( defaultArgs''
+          , shouldParseAppConfiguration $ defaultConfiguration
+            { chainProducer = Hydra
+                { hydraHost = "localhost"
+                , hydraPort = 4001
                 }
             , workDir = InMemory
             }
@@ -339,6 +354,13 @@ defaultArgs' :: [String]
 defaultArgs' =
     [ "--ogmios-host", "localhost"
     , "--ogmios-port", "1337"
+    , "--in-memory"
+    ]
+
+defaultArgs'' :: [String]
+defaultArgs'' =
+    [ "--hydra-host", "localhost"
+    , "--hydra-port", "4001"
     , "--in-memory"
     ]
 

--- a/test/Test/KupoSpec.hs
+++ b/test/Test/KupoSpec.hs
@@ -210,7 +210,7 @@ spec :: Spec
 spec = skippableContext "End-to-end" $ do
 
     endToEnd "can connect" $ \(configure, runSpec, HttpClient{..}) -> do
-        (cfg, env) <- configure $ \defaultCfg -> defaultCfg
+        (_cfg, env) <- configure $ \defaultCfg -> defaultCfg
             { workDir = InMemory
             , since = Just GenesisPoint
             , patterns = fromList [MatchAny OnlyShelley]
@@ -296,6 +296,11 @@ spec = skippableContext "End-to-end" $ do
                         Ogmios
                             { ogmiosHost = "/dev/null"
                             , ogmiosPort
+                            }
+                    Hydra{hydraPort} ->
+                        Hydra
+                            { hydraHost = "/dev/null"
+                            , hydraPort
                             }
             }
         runSpec env 5 $ do

--- a/test/Test/KupoSpec.hs
+++ b/test/Test/KupoSpec.hs
@@ -216,7 +216,7 @@ spec = skippableContext "End-to-end" $ do
             , patterns = fromList [MatchAny OnlyShelley]
             }
         runSpec env 5 $ do
-            waitSlot (> 1)
+            waitSlot (>= 0)
             matches <- getAllMatches NoStatusFlag
             matches `shouldSatisfy` not . null
 

--- a/test/Test/KupoSpec.hs
+++ b/test/Test/KupoSpec.hs
@@ -574,11 +574,11 @@ skippableContext prefix skippableSpec = do
 
     let hydra = prefix <> " (hydra)"
     runIO ((,) <$> lookupEnv varHydraHost <*> lookupEnv varHydraPort) >>= \case
-        (Just _hydraHost, Just _hydraPort) -> do
+        (Just hydraHost, Just (Prelude.read -> hydraPort)) -> do
             manager <- runIO $ newManager $
                 defaultManagerSettings { managerResponseTimeout = responseTimeoutNone }
             let defaultCfg = Configuration
-                    { chainProducer = Hydra
+                    { chainProducer = Hydra {hydraHost, hydraPort}
                     , workDir = InMemory
                     , serverHost = "127.0.0.1"
                     , serverPort = 0

--- a/test/Test/KupoSpec.hs
+++ b/test/Test/KupoSpec.hs
@@ -191,6 +191,12 @@ varOgmiosHost = "OGMIOS_HOST"
 varOgmiosPort :: String
 varOgmiosPort = "OGMIOS_PORT"
 
+varHydraHost :: String
+varHydraHost = "HYDRA_HOST"
+
+varHydraPort :: String
+varHydraPort = "HYDRA_PORT"
+
 type EndToEndContext
     = ( (Configuration -> Configuration) -> IO (Configuration, Env Kupo)
       , Env Kupo -> DiffTime -> IO () -> IO ()
@@ -202,6 +208,18 @@ endToEnd = specify
 
 spec :: Spec
 spec = skippableContext "End-to-end" $ do
+
+    endToEnd "can connect" $ \(configure, runSpec, HttpClient{..}) -> do
+        (cfg, env) <- configure $ \defaultCfg -> defaultCfg
+            { workDir = InMemory
+            , since = Just GenesisPoint
+            , patterns = fromList [MatchAny OnlyShelley]
+            }
+        runSpec env 30 $ do
+            waitSlot (> 1)
+            matches <- getAllMatches NoStatusFlag
+            matches `shouldSatisfy` not . null
+
     endToEnd "in-memory" $ \(configure, runSpec, HttpClient{..}) -> do
         (cfg, env) <- configure $ \defaultCfg -> defaultCfg
             { workDir = InMemory
@@ -501,6 +519,9 @@ spec = skippableContext "End-to-end" $ do
 -- - If 'varOgmiosHost' AND 'varOgmiosPort' are set, the spec items will execute against an Ogmios
 -- server expected to be running and available through the context defined by these variables.
 --
+-- - If 'varHydraHost' AND 'varHydraPort' are set, the spec items will execute against a Hydra node
+-- with an open head running and available through the context defined by these variables.
+--
 -- If either set of variables is missing, then the spec items do not run for that item.
 skippableContext :: String -> SpecWith (Arg (EndToEndContext -> IO ())) -> Spec
 skippableContext prefix skippableSpec = do
@@ -545,6 +566,27 @@ skippableContext prefix skippableSpec = do
             context ogmios $ around (withTempDirectory manager ref defaultCfg) skippableSpec
         _skipOtherwise ->
             xcontext ogmios (pure ())
+
+    let hydra = prefix <> " (hydra)"
+    runIO ((,) <$> lookupEnv varHydraHost <*> lookupEnv varHydraPort) >>= \case
+        (Just _hydraHost, Just _hydraPort) -> do
+            manager <- runIO $ newManager $
+                defaultManagerSettings { managerResponseTimeout = responseTimeoutNone }
+            let defaultCfg = Configuration
+                    { chainProducer = Hydra
+                    , workDir = InMemory
+                    , serverHost = "127.0.0.1"
+                    , serverPort = 0
+                    , since = Nothing
+                    , patterns = fromList []
+                    , inputManagement = MarkSpentInputs
+                    , longestRollback = 43200
+                    , garbageCollectionInterval = 180
+                    , deferIndexes = InstallIndexesIfNotExist
+                    }
+            context hydra $ around (withTempDirectory manager ref defaultCfg) skippableSpec
+        _skipOtherwise ->
+            xcontext hydra (pure ())
   where
     withTempDirectory
         :: Manager

--- a/test/Test/KupoSpec.hs
+++ b/test/Test/KupoSpec.hs
@@ -215,7 +215,7 @@ spec = skippableContext "End-to-end" $ do
             , since = Just GenesisPoint
             , patterns = fromList [MatchAny OnlyShelley]
             }
-        runSpec env 30 $ do
+        runSpec env 5 $ do
             waitSlot (> 1)
             matches <- getAllMatches NoStatusFlag
             matches `shouldSatisfy` not . null


### PR DESCRIPTION
:dragon: Adds `--hydra-host` and `--hydra-port` command line options to connect and index the head state of a `hydra-node`

:dragon: Internally, `Hydra` is just another `ChainProducer` and `HeadIsOpen` and `SnapshotConfirmed` messages are mapped to rollforward of blocks.

TODO:
- [x] Finish Hydra decoders (missing datum, script and metadata)
- [ ] Handle intersection negotiation by skipping blocks 
- [ ] Many tests assume a busy network and fail because of this. Make it possible to run them against a busy `hydra-node` easily (e.g. re-using the benchmarks in https://github.com/input-output-hk/hydra)
- [ ] TBD: Clear index state when seeing a `HeadIsClosed` message? Use a rollbackward?