### PR TITLE
Disable all the c++ nonsense in haskell land.

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -32,6 +32,16 @@ package websockets-json
 package cryptonite
   flags: -support_rdrand
 
+-- Depending on C++ for just so slightly faster utf8 parsing is a bit annoying
+-- especially as it brings in all kinds of complications for GHC.
+package text
+  flags: -simdutf
+
+-- formatting (>= 7.2) allows us do drop double-conversion (which again is one
+-- of the offending c++ dependencies)
+package formatting
+  flags: +no-double-conversion
+
 package direct-sqlite
   flags: +nomutex
 
@@ -40,6 +50,11 @@ constraints:
   , any.cardano-node == 8.6.0
   , any.cardano-ledger-conway == 1.10.1.0
   , direct-sqlite == 2.3.29
+  , any.text source
+  , any.formatting >= 7.2
+
+allow-newer:
+  *:formatting
 
 source-repository-package
   type: git


### PR DESCRIPTION
text-simdutf disable c++ in text. This also needs "text source" to
ensure we are not relying on the one shipped with GHC.

formatting+no-double-conversion drops the c++ double-conversion
dependency. This flag however needs 7.2+ and as such we need to relax
upper bounds on other packages for this.