### PR TITLE
Add conway era

### DIFF
--- a/src/Kupo/Data/Cardano/BinaryData.hs
+++ b/src/Kupo/Data/Cardano/BinaryData.hs
@@ -12,7 +12,7 @@ import qualified Data.Aeson as Json
 import qualified Data.Aeson.Encoding as Json
 
 type BinaryData =
-    Ledger.BinaryData (BabbageEra StandardCrypto)
+    Ledger.BinaryData (ConwayEra StandardCrypto)
 
 type BinaryDataHash =
     DatumHash
@@ -65,6 +65,13 @@ fromBabbageData
     :: Ledger.Data (BabbageEra StandardCrypto)
     -> BinaryData
 fromBabbageData =
-    Ledger.dataToBinaryData
+      Ledger.dataToBinaryData
+    . Ledger.upgradeData
 {-# INLINEABLE fromBabbageData #-}
 
+fromConwayData
+    :: Ledger.Data (ConwayEra StandardCrypto)
+    -> BinaryData
+fromConwayData =
+      Ledger.dataToBinaryData
+{-# INLINEABLE fromConwayData #-}

--- a/src/Kupo/Data/Cardano/Datum.hs
+++ b/src/Kupo/Data/Cardano/Datum.hs
@@ -17,20 +17,20 @@ data Datum
     | Inline !(Either DatumHash BinaryData)
     deriving (Generic, Show, Eq, Ord)
 
-toBabbageDatum
+toConwayDatum
     :: Datum
-    -> Ledger.Datum (BabbageEra StandardCrypto)
-toBabbageDatum = \case
+    -> Ledger.Datum (ConwayEra StandardCrypto)
+toConwayDatum = \case
     NoDatum -> Ledger.NoDatum
     Reference (Left ref) -> Ledger.DatumHash ref
     Reference (Right bin) -> Ledger.Datum bin
     Inline (Left ref) -> Ledger.DatumHash ref
     Inline (Right bin) -> Ledger.Datum bin
 
-fromBabbageDatum
-    :: Ledger.Datum (BabbageEra StandardCrypto)
+fromConwayDatum
+    :: Ledger.Datum (ConwayEra StandardCrypto)
     -> Datum
-fromBabbageDatum = \case
+fromConwayDatum = \case
     Ledger.NoDatum -> NoDatum
     Ledger.DatumHash ref -> Reference (Left ref)
     Ledger.Datum bin -> Inline (Right bin)

--- a/src/Kupo/Data/Cardano/Metadata.hs
+++ b/src/Kupo/Data/Cardano/Metadata.hs
@@ -41,7 +41,7 @@ import qualified Data.Text as T
 import qualified Data.Text.Read as T
 
 type Metadata =
-    AlonzoTxAuxData (BabbageEra StandardCrypto)
+    AlonzoTxAuxData (ConwayEra StandardCrypto)
 
 emptyMetadata :: Metadata
 emptyMetadata =
@@ -182,5 +182,10 @@ fromAlonzoMetadata =
 
 fromBabbageMetadata :: AlonzoTxAuxData (BabbageEra StandardCrypto) -> Metadata
 fromBabbageMetadata =
-    identity
+    Ledger.upgradeTxAuxData
 {-# INLINABLE fromBabbageMetadata #-}
+
+fromConwayMetadata :: AlonzoTxAuxData (ConwayEra StandardCrypto) -> Metadata
+fromConwayMetadata =
+    identity
+{-# INLINABLE fromConwayMetadata #-}

--- a/src/Kupo/Data/Cardano/NativeScript.hs
+++ b/src/Kupo/Data/Cardano/NativeScript.hs
@@ -19,4 +19,4 @@ import Cardano.Ledger.Keys
 
 import qualified Cardano.Ledger.Allegra.Scripts as Ledger.Allegra
 
-type NativeScript = Ledger.Allegra.Timelock (BabbageEra StandardCrypto)
+type NativeScript = Ledger.Allegra.Timelock (ConwayEra StandardCrypto)

--- a/src/Kupo/Data/Cardano/Output.hs
+++ b/src/Kupo/Data/Cardano/Output.hs
@@ -17,13 +17,12 @@ import Kupo.Data.Cardano.Address
     )
 import Kupo.Data.Cardano.Datum
     ( Datum
-    , fromBabbageDatum
-    , toBabbageDatum
+    , fromConwayDatum
+    , toConwayDatum
     )
 import Kupo.Data.Cardano.Script
     ( ComparableScript
     , Script
-    , fromComparableScript
     , hashScript
     , toComparableScript
     )
@@ -33,7 +32,6 @@ import Kupo.Data.Cardano.ScriptHash
 import Kupo.Data.Cardano.Value
     ( ComparableValue
     , Value
-    , fromComparableValue
     , toComparableValue
     )
 
@@ -43,6 +41,7 @@ import qualified Cardano.Ledger.Address as Ledger
 import qualified Cardano.Ledger.Alonzo.TxBody as Ledger.Alonzo
 import qualified Cardano.Ledger.Babbage.TxBody as Ledger.Babbage
 import qualified Cardano.Ledger.Coin as Ledger
+import qualified Cardano.Ledger.Conway as Ledger.Conway
 import qualified Cardano.Ledger.Core as Ledger.Core
 import qualified Cardano.Ledger.Mary.Value as Ledger
 import qualified Cardano.Ledger.Shelley.Tx as Ledger.Shelley
@@ -55,7 +54,7 @@ type Output =
     Output' StandardCrypto
 
 type Output' crypto =
-    Ledger.Babbage.BabbageTxOut (BabbageEra crypto)
+    Ledger.Babbage.BabbageTxOut (ConwayEra crypto)
 
 mkOutput
     :: Address
@@ -67,7 +66,7 @@ mkOutput address value datum script =
     Ledger.Babbage.BabbageTxOut
         address
         value
-        (toBabbageDatum datum)
+        (toConwayDatum datum)
         (maybeToStrictMaybe script)
 {-# INLINABLE mkOutput #-}
 
@@ -76,7 +75,7 @@ fromByronOutput
         ( Crypto crypto
         )
     => Ledger.Byron.TxOut
-    -> Ledger.Core.TxOut (BabbageEra crypto)
+    -> Output' crypto
 fromByronOutput (Ledger.Byron.TxOut address value) =
     Ledger.Babbage.BabbageTxOut
         (Ledger.AddrBootstrap (Ledger.BootstrapAddress address))
@@ -94,7 +93,7 @@ fromShelleyOutput
         )
     => (Ledger.Core.Value (era crypto) -> Ledger.MaryValue crypto)
     -> Ledger.Core.TxOut (era crypto)
-    -> Ledger.Core.TxOut (BabbageEra crypto)
+    -> Output' crypto
 fromShelleyOutput liftValue (Ledger.Shelley.ShelleyTxOut addr value) =
     Ledger.Babbage.BabbageTxOut addr (liftValue value) Ledger.Babbage.NoDatum SNothing
 {-# INLINABLE fromShelleyOutput #-}
@@ -104,7 +103,7 @@ fromAlonzoOutput
         ( Crypto crypto
         )
     => Ledger.Core.TxOut (AlonzoEra crypto)
-    -> Ledger.Core.TxOut (BabbageEra crypto)
+    -> Output' crypto
 fromAlonzoOutput (Ledger.Alonzo.AlonzoTxOut addr value datum) =
     case datum of
         SNothing ->
@@ -120,6 +119,15 @@ fromAlonzoOutput (Ledger.Alonzo.AlonzoTxOut addr value datum) =
                 value
                 (Ledger.Babbage.DatumHash datumHash)
                 SNothing
+
+fromBabbageOutput
+    :: forall crypto.
+        ( Crypto crypto
+        )
+    => Ledger.Core.TxOut (BabbageEra crypto)
+    -> Output' crypto
+fromBabbageOutput = Ledger.Core.upgradeTxOut
+{-# INLINABLE fromBabbageOutput #-}
 
 getAddress
     :: Output
@@ -139,7 +147,7 @@ getDatum
     :: Output
     -> Datum
 getDatum (Ledger.Babbage.BabbageTxOut _address _value datum _refScript) =
-    fromBabbageDatum datum
+    fromConwayDatum datum
 {-# INLINABLE getDatum #-}
 
 getScript
@@ -182,9 +190,3 @@ toComparableOutput out = ComparableOutput
     , comparableOutputDatum = getDatum out
     , comparableOutputScript = toComparableScript <$> getScript out
     }
-
-fromComparableOutput
-    :: ComparableOutput
-    -> Output
-fromComparableOutput (ComparableOutput addr val datum script) =
-    mkOutput addr (fromComparableValue val) datum (fromComparableScript <$> script)

--- a/src/Kupo/Data/Cardano/Output.hs
+++ b/src/Kupo/Data/Cardano/Output.hs
@@ -41,7 +41,6 @@ import qualified Cardano.Ledger.Address as Ledger
 import qualified Cardano.Ledger.Alonzo.TxBody as Ledger.Alonzo
 import qualified Cardano.Ledger.Babbage.TxBody as Ledger.Babbage
 import qualified Cardano.Ledger.Coin as Ledger
-import qualified Cardano.Ledger.Conway as Ledger.Conway
 import qualified Cardano.Ledger.Core as Ledger.Core
 import qualified Cardano.Ledger.Mary.Value as Ledger
 import qualified Cardano.Ledger.Shelley.Tx as Ledger.Shelley

--- a/src/Kupo/Data/Cardano/Script.hs
+++ b/src/Kupo/Data/Cardano/Script.hs
@@ -39,7 +39,7 @@ import qualified Data.ByteString as BS
 import qualified Data.Map as Map
 
 type Script =
-    Ledger.Alonzo.Script (BabbageEra StandardCrypto)
+    Ledger.Alonzo.Script (ConwayEra StandardCrypto)
 
 scriptFromAllegraAuxiliaryData
     :: forall era.
@@ -100,8 +100,15 @@ fromBabbageScript
     :: Ledger.Alonzo.Script (BabbageEra StandardCrypto)
     -> Script
 fromBabbageScript =
-    identity
+    Ledger.Core.upgradeScript
 {-# INLINABLE fromBabbageScript #-}
+
+fromConwayScript
+    :: Ledger.Alonzo.Script (ConwayEra StandardCrypto)
+    -> Script
+fromConwayScript =
+    identity
+{-# INLINABLE fromConwayScript #-}
 
 scriptToJson
     :: Script
@@ -169,7 +176,7 @@ hashScript
     :: Script
     -> ScriptHash
 hashScript =
-    Ledger.Core.hashScript @(BabbageEra StandardCrypto)
+    Ledger.Core.hashScript @(ConwayEra StandardCrypto)
 {-# INLINABLE hashScript #-}
 
 newtype ComparableScript = ComparableScript { unComparableScript :: Script }

--- a/src/Kupo/Data/Cardano/Transaction.hs
+++ b/src/Kupo/Data/Cardano/Transaction.hs
@@ -31,6 +31,8 @@ data Transaction' crypto
         !(Ledger.Alonzo.AlonzoTx (AlonzoEra crypto))
     | TransactionBabbage
         !(Ledger.Alonzo.AlonzoTx (BabbageEra crypto))
+    | TransactionConway
+        !(Ledger.Alonzo.AlonzoTx (ConwayEra crypto))
 
 instance HasTransactionId Transaction StandardCrypto where
     getTransactionId = \case
@@ -51,3 +53,6 @@ instance HasTransactionId Transaction StandardCrypto where
         TransactionBabbage tx ->
             let body = Ledger.Alonzo.body tx
              in Ledger.txid @(BabbageEra StandardCrypto) body
+        TransactionConway tx ->
+            let body = Ledger.Alonzo.body tx
+             in Ledger.txid @(ConwayEra StandardCrypto) body


### PR DESCRIPTION
Implements the missing conway era. Adds the bare minimum to have kupo running on sanchonet with cardano-node 8.5.0-pre.