### PR TITLE
Allow building with recent GHC, cardano-node, aeson

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -60,15 +60,18 @@ source-repository-package
   type: git
   location: https://github.com/CardanoSolutions/ogmios
   tag: 01f7787216e7ceb8e39c8c6807f7ae53fc14ab9e
+  --sha256: 18wxmz3452lwnd169r408b54h5grjws3q25i30nkl425sl4k8p87
   subdir:
     server/modules/fast-bech32
 
 source-repository-package
   type: git
   location: https://github.com/CardanoSolutions/direct-sqlite
+  --sha256: 1r1g6nf65d9n436ppcjky3gkywpnx4y0a3v88ddngchmf8za3qky
   tag: 82c5ab46715ecd51901256144f1411b480e2cb8b
 
 source-repository-package
   type: git
   location: https://github.com/CardanoSolutions/text-ansi
+  --sha256: 16ki7wsf7wivxn65acv4hxwfrzmphq4zp61lpxwzqkgrg8shi8bv
   tag: e204822d2f343b2d393170a2ec46ee935571345c

--- a/cabal.project
+++ b/cabal.project
@@ -46,9 +46,8 @@ package direct-sqlite
   flags: +nomutex
 
 constraints:
-  , any.base == 4.18.1.0
-  , any.cardano-node == 8.6.0
-  , any.cardano-ledger-conway == 1.10.1.0
+    any.cardano-node == 8.7.2
+  , any.cardano-ledger-conway == 1.11.0.0
   , direct-sqlite == 2.3.29
   , any.text source
   , any.formatting >= 7.2

--- a/kupo.cabal
+++ b/kupo.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.0.
+-- This file has been generated from package.yaml by hpack version 0.35.2.
 --
 -- see: https://github.com/sol/hpack
 
@@ -159,7 +159,8 @@ library
       ViewPatterns
   ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wpartial-fields -Wredundant-constraints -fno-warn-unticked-promoted-constructors -fno-warn-partial-fields
   build-depends:
-      aeson
+      aeson >=2.2
+    , attoparsec-aeson >=2.2
     , base >=4.7 && <5
     , base16
     , base58-bytestring

--- a/modules/websockets-json/package.yaml
+++ b/modules/websockets-json/package.yaml
@@ -24,7 +24,8 @@ library:
   source-dirs: src
   ghc-options: *ghc-options-lib
   dependencies:
-    - aeson
+    - aeson >= 2.2
+    - attoparsec-aeson >= 2.2
     - bytestring
     - connection
     - exceptions

--- a/modules/websockets-json/websockets-json.cabal
+++ b/modules/websockets-json/websockets-json.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.0.
+-- This file has been generated from package.yaml by hpack version 0.35.2.
 --
 -- see: https://github.com/sol/hpack
 
@@ -72,7 +72,8 @@ library
       ViewPatterns
   ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wpartial-fields -Wredundant-constraints -fno-warn-unticked-promoted-constructors -fno-warn-partial-fields
   build-depends:
-      aeson
+      aeson >=2.2
+    , attoparsec-aeson >=2.2
     , base >=4.7 && <5
     , bytestring
     , connection

--- a/package.yaml
+++ b/package.yaml
@@ -39,7 +39,8 @@ library:
     - -Werror
     - -O2
   dependencies:
-    - aeson
+    - aeson >= 2.2
+    - attoparsec-aeson >= 2.2
     - base16
     - base58-bytestring
     - base64

--- a/src/Kupo/Data/Cardano/Value.hs
+++ b/src/Kupo/Data/Cardano/Value.hs
@@ -13,6 +13,7 @@ import Kupo.Data.Cardano.PolicyId
     , unsafePolicyIdFromBytes
     )
 
+import qualified Cardano.Ledger.Coin as Ledger
 import qualified Cardano.Ledger.Hashes as Ledger
 import qualified Cardano.Ledger.Mary.Value as Ledger
 import qualified Data.Aeson as Json
@@ -51,7 +52,7 @@ unsafeValueFromList
     -> Value
 unsafeValueFromList ada assets =
     Ledger.valueFromList
-        ada
+        (Ledger.Coin ada)
         [ ( unsafePolicyIdFromBytes pid, unsafeAssetNameFromBytes name, q)
         | (pid, name, q) <- assets
         ]
@@ -59,7 +60,7 @@ unsafeValueFromList ada assets =
 valueToJson :: Value -> Json.Encoding
 valueToJson (Ledger.MaryValue coins (Ledger.MultiAsset assets)) =
     Json.pairs $
-        Json.pair "coins"  (Json.integer coins)
+        Json.pair "coins"  (Json.integer (Ledger.unCoin coins))
       <>
         Json.pair "assets" (assetsToJson assets)
   where
@@ -103,8 +104,8 @@ data ComparableValue = ComparableValue
 
 fromComparableValue :: ComparableValue -> Value
 fromComparableValue (ComparableValue ada assets) =
-    Ledger.MaryValue ada (Ledger.MultiAsset assets)
+    Ledger.MaryValue (Ledger.Coin ada) (Ledger.MultiAsset assets)
 
 toComparableValue :: Value -> ComparableValue
-toComparableValue (Ledger.MaryValue ada (Ledger.MultiAsset assets)) =
+toComparableValue (Ledger.MaryValue (Ledger.Coin ada) (Ledger.MultiAsset assets)) =
     ComparableValue ada assets


### PR DESCRIPTION
* Adding back `--sha256` hashes to make it buildable with haskell.nix again
* Some deps aligned with ogmios
  * `cardano-node`
  * `cardano-ledger-conway`
  * dropped `base` constraint
 * Fixed build with `aeson 2.2`, package got split into `attoparsec-aeson` so we need to require that as well. If you don't like the lower bound, I can probably make the dependency conditional (not sure if possible with hpack).
 * `Ledger.Coin` instead of `Integer`