### PR TITLE
cabal.project: fix sha256 for ogmios

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -64,7 +64,7 @@ source-repository-package
   type: git
   location: https://github.com/CardanoSolutions/ogmios
   tag: 01f7787216e7ceb8e39c8c6807f7ae53fc14ab9e
-  --sha256: 18wxmz3452lwnd169r408b54h5grjws3q25i30nkl425sl4k8p87
+  --sha256: 16mdvv3qws92fins673jb2qiw7b9vd0pwzwvq9zvi6zkhhhkfdfm
   subdir:
     server/modules/fast-bech32
 


### PR DESCRIPTION
Somehow this built due to cached path
but on another computer, it fails with mismatch,
probably due to `subdir` directive - seems like
it cannot be updated by simply using `nix-prefetch-git` and TOFU hash should be used in combination with haskell.nix.