### PR TITLE
Upgrade to hydra-0.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 #### Added
 
+* Compatibility with hydra-node 0.16.0.
+
 - A new mode `--read-only` which can be used to boot-up an HTTP server with only read access to the underlying database. This option comes as an alternative to the other options for chain producers (e.g. `--node-socket` and `--node-config`). The replica can only reply successfully to GET queries with the exception of queries under `/metadata`. The latter must go through the master server.
 
 - Automatic restart and setup indexes when `--defer-db-indexes` is provided and the tip of the chain is reached.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
-### [2.8.0] - 2024-02-09
+
+### [2.8.1] - UNRELEASED
 
 #### Added
 
 * Compatibility with hydra-node 0.16.0.
+
+### [2.8.0] - 2024-02-09
+
+#### Added
 
 - A new mode `--read-only` which can be used to boot-up an HTTP server with only read access to the underlying database. This option comes as an alternative to the other options for chain producers (e.g. `--node-socket` and `--node-config`). The replica can only reply successfully to GET queries with the exception of queries under `/metadata`. The latter must go through the master server.
 

--- a/kupo.cabal
+++ b/kupo.cabal
@@ -173,6 +173,7 @@ library
     , cardano-crypto-wrapper
     , cardano-ledger-allegra
     , cardano-ledger-alonzo
+    , cardano-ledger-api
     , cardano-ledger-babbage
     , cardano-ledger-binary
     , cardano-ledger-byron

--- a/test/Test/KupoSpec.hs
+++ b/test/Test/KupoSpec.hs
@@ -215,8 +215,6 @@ endToEnd = specify
 
 spec :: Spec
 spec = skippableContext "End-to-end" $ do
-    tip <- runIO currentNetworkTip
-
     endToEnd "can connect" $ \(configure, runSpec, HttpClient{..}) -> do
         (_cfg, env) <- configure $ \defaultCfg -> defaultCfg
             { workDir = InMemory
@@ -527,9 +525,8 @@ spec = skippableContext "End-to-end" $ do
                 connectionStatus `shouldBe` Connected
                 configuration `shouldBe` Nothing
 
-    -- NOTE: Run last, as they rely on the tip to have moved forward. We fetch the current tip at the
-    -- beginning of the test suite, so it's less time to wait if we run those tests last.
     endToEnd "Dynamically add pattern and restart to a past point when at the tip" $ \(configure, runSpec, HttpClient{..}) -> do
+        tip <- currentNetworkTip
         (_, env) <- configure $ \defaultCfg -> defaultCfg
             { since = Just tip
             , patterns = fromList [MatchAny IncludingBootstrap]
@@ -540,6 +537,7 @@ spec = skippableContext "End-to-end" $ do
             res `shouldBe` True
 
     endToEnd "Auto-magically restart when reaching the tip (--defer-db-indexes enabled)" $ \(configure, runSpec, HttpClient{..}) -> do
+        tip <- currentNetworkTip
         (_, env) <- configure $ \defaultCfg -> defaultCfg
             { since = Just tip
             , patterns = fromList [MatchAny IncludingBootstrap]

--- a/test/Test/KupoSpec.hs
+++ b/test/Test/KupoSpec.hs
@@ -222,7 +222,7 @@ spec = skippableContext "End-to-end" $ do
             , patterns = fromList [MatchAny OnlyShelley]
             }
         runSpec env 5 $ do
-            waitSlot (>= 0)
+            waitSlot (> 0)
             matches <- getAllMatches NoStatusFlag
             matches `shouldSatisfy` not . null
 


### PR DESCRIPTION
  Hydra 0.16 drops JSON encoding of transactions in favour of a CBOR representation only. This updates the hydra submodule to provide a golden test file in the new format.
  
  Co-Authored by Daniel Firth <daniel.firth@iohk.io>