### PR TITLE
websockets-json: connection -> crypton-connection

### DIFF
--- a/modules/websockets-json/websockets-json.cabal
+++ b/modules/websockets-json/websockets-json.cabal
@@ -76,7 +76,7 @@ library
     , attoparsec-aeson
     , base >=4.7 && <5
     , bytestring
-    , connection
+    , crypton-connection
     , exceptions
     , io-classes
     , websockets


### PR DESCRIPTION
Switch to maintained package which resolves a conflict since `wuss` now also uses `crypton-connection`.