### PR TITLE
Fix test: inherit environment to run cardano-cli process

### DIFF
--- a/test/Test/KupoSpec.hs
+++ b/test/Test/KupoSpec.hs
@@ -189,6 +189,9 @@ import System.IO
     ( hClose
     , hGetLine
     )
+import System.Environment
+    ( getEnvironment
+    )
 
 import qualified Data.Aeson as Json
 import qualified Data.Text as T
@@ -792,7 +795,8 @@ currentNetworkTip = do
         Nothing ->
             fail $ varCardanoNodeSocket <> " not set but necessary for this test."
         Just socket -> do
-            let env = Just [("CARDANO_NODE_SOCKET_PATH", socket)]
+            baseEnv <- getEnvironment
+            let env = Just (("CARDANO_NODE_SOCKET_PATH", socket):baseEnv)
             let args =
                     [ "query", "tip"
                     , "--testnet-magic", "1"


### PR DESCRIPTION
Some environment variables (e.g. LD_LIBRARY_PATH) are needed on certain platforms for cardano-cli to run. For example, when the libsecp256k1, libsodium etc. are installed with Homebrew and therefore are not in the standard place (/lib or /usr/lib).

This change _adds_ the environment variable required by the test to the existing environment, rather than replacing the existing environment completely.