### PR TITLE
Update cardano-node dependencies

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -10,8 +10,8 @@ repository cardano-haskell-packages
     d4a35cd3121aa00d18544bb0ac01c3e1691d618f462c46129271bccf39f7e8ee
 
 index-state:
-  , hackage.haskell.org 2025-09-11T07:59:00Z
-  , cardano-haskell-packages 2025-09-11T08:36:14Z
+  , hackage.haskell.org 2026-05-05T07:59:00Z
+  , cardano-haskell-packages 2026-05-05T04:28:05Z
 
 packages:
   ./
@@ -45,21 +45,26 @@ package formatting
 package direct-sqlite
   flags: +nomutex
 
+package blockio
+  flags: +serialblockio
+
 constraints:
-  , any.cardano-node == 10.5.1
+  , any.cardano-node == 11.0.1
 
-  , any.cardano-ledger-core == 1.17.0.0
-  , any.cardano-ledger-shelley == 1.16.0.0
-  , any.cardano-ledger-conway == 1.19.0.0
+  , any.cardano-ledger-core == 1.20.0.0
+  , any.cardano-ledger-shelley == 1.18.1.0
+  , any.cardano-ledger-conway == 1.22.0.0
 
-  , any.ouroboros-consensus == 0.27.0.0
-  , any.ouroboros-consensus-cardano == 0.25.1.0
-  , any.ouroboros-network == 0.21.3.0
+  , any.ouroboros-consensus == 3.0.1.0
+  , any.ouroboros-network == 1.1.0.0
+  , any.cardano-diffusion ==1.0.0.0
 
-  , any.io-classes == 1.5.0.0
+  , any.io-classes == 1.8.0.1
   , any.io-classes-mtl == 0.1.2.0
   , any.formatting == 7.2.0
   , any.text source
+
+  , any.validation < 1.2
 
   , direct-sqlite == 2.3.29.1
   , sqlite-simple == 0.4.19.0.1

--- a/kupo.cabal
+++ b/kupo.cabal
@@ -1,4 +1,4 @@
-cabal-version: 1.12
+cabal-version: 3.0
 
 -- This file has been generated from package.yaml by hpack version 0.38.2.
 --
@@ -214,13 +214,9 @@ library
     , modern-uri
     , network-mux
     , optparse-applicative
-    , ouroboros-consensus
-    , ouroboros-consensus-cardano
-    , ouroboros-consensus-diffusion
-    , ouroboros-network
-    , ouroboros-network-api
-    , ouroboros-network-framework
-    , ouroboros-network-protocols
+    , ouroboros-consensus:{ouroboros-consensus,cardano,diffusion}
+    , ouroboros-network:{api,framework,protocols}
+    , cardano-diffusion
     , prometheus
     , relude
     , resource-pool
@@ -387,7 +383,7 @@ test-suite unit
     , http-client
     , http-media
     , http-types
-    , io-classes
+    , io-classes:{io-classes,si-timers}
     , io-sim
     , kupo
     , lens-aeson
@@ -395,7 +391,6 @@ test-suite unit
     , process
     , quickcheck-state-machine
     , relude
-    , si-timers
     , sqlite-simple
     , stm
     , temporary

--- a/package.yaml
+++ b/package.yaml
@@ -93,13 +93,9 @@ library:
     - modern-uri
     - network-mux
     - optparse-applicative
-    - ouroboros-consensus
-    - ouroboros-consensus-cardano
-    - ouroboros-consensus-diffusion
-    - ouroboros-network
-    - ouroboros-network-api
-    - ouroboros-network-framework
-    - ouroboros-network-protocols
+    - ouroboros-consensus:{ouroboros-consensus,cardano,diffusion}
+    - ouroboros-network:{api,framework,protocols}
+    - cardano-diffusion
     - prometheus
     - relude
     - resource-pool
@@ -137,7 +133,7 @@ tests:
     - http-client
     - http-media
     - http-types
-    - io-classes
+    - io-classes:{io-classes,si-timers}
     - io-sim
     - kupo
     - lens-aeson
@@ -146,7 +142,6 @@ tests:
     - QuickCheck
     - quickcheck-state-machine
     - relude
-    - si-timers
     - sqlite-simple
     - stm
     - temporary

--- a/src/Kupo/Control/MonadOuroboros.hs
+++ b/src/Kupo/Control/MonadOuroboros.hs
@@ -34,6 +34,7 @@ import Kupo.Control.MonadThrow
     )
 import Network.Mux
     ( StartOnDemandOrEagerly (..)
+    , nullTracers
     )
 import Ouroboros.Consensus.Byron.Ledger.Config
     ( CodecConfig (..)
@@ -74,7 +75,7 @@ import Ouroboros.Network.Mux
     , OuroborosApplication (..)
     , RunMiniProtocol (..)
     )
-import Ouroboros.Network.NodeToClient
+import Cardano.Network.NodeToClient
     ( NetworkConnectTracers (..)
     , NodeToClientVersion (..)
     , NodeToClientVersionData (..)
@@ -119,7 +120,7 @@ instance MonadOuroboros IO where
             connectTo (mkLocalSnocket iocp) tracers versions socket >>= either throwIO return
       where
         tracers = NetworkConnectTracers
-            { nctMuxTracer = nullTracer
+            { nctMuxTracers = nullTracers
             , nctHandshakeTracer = nullTracer
             }
 
@@ -167,7 +168,7 @@ codecs epochSlots nodeToClientV =
     supportedVersions =
         supportedNodeToClientVersions (Proxy @(BlockT IO))
     cfg =
-        CardanoCodecConfig byron shelley allegra mary alonzo babbage conway
+        CardanoCodecConfig byron shelley allegra mary alonzo babbage conway dijkstra
       where
         byron    = ByronCodecConfig epochSlots
         shelley  = ShelleyCodecConfig
@@ -176,3 +177,4 @@ codecs epochSlots nodeToClientV =
         alonzo   = ShelleyCodecConfig
         babbage  = ShelleyCodecConfig
         conway   = ShelleyCodecConfig
+        dijkstra = ShelleyCodecConfig

--- a/src/Kupo/Data/Cardano.hs
+++ b/src/Kupo/Data/Cardano.hs
@@ -99,7 +99,6 @@ import Kupo.Data.Cardano.Value
 
 import qualified Cardano.Chain.UTxO as Ledger.Byron
 import qualified Cardano.Ledger.Alonzo.Core as Ledger
-import qualified Cardano.Ledger.Alonzo.Tx as Ledger
 import qualified Cardano.Ledger.Alonzo.TxWits as Ledger
 import qualified Cardano.Ledger.Babbage.Core as Ledger
 import qualified Cardano.Ledger.Block as Ledger
@@ -184,17 +183,18 @@ instance IsBlock Block where
              in
                 foldrWithIndex ignoreProtocolTxs result (extractTxs blk)
         BlockShelley (ShelleyBlock (Ledger.Block _ txs) _) ->
-            foldrWithIndex (\ix -> fn ix . TransactionShelley) result (Ledger.fromTxSeq txs)
+            foldrWithIndex (\ix -> fn ix . TransactionShelley) result (txs ^. Ledger.txSeqBlockBodyL)
         BlockAllegra (ShelleyBlock (Ledger.Block _ txs) _) ->
-            foldrWithIndex (\ix -> fn ix . TransactionAllegra) result (Ledger.fromTxSeq txs)
+            foldrWithIndex (\ix -> fn ix . TransactionAllegra) result (txs ^. Ledger.txSeqBlockBodyL)
         BlockMary (ShelleyBlock (Ledger.Block _ txs) _) ->
-            foldrWithIndex (\ix -> fn ix . TransactionMary) result (Ledger.fromTxSeq txs)
+            foldrWithIndex (\ix -> fn ix . TransactionMary) result (txs ^. Ledger.txSeqBlockBodyL)
         BlockAlonzo (ShelleyBlock (Ledger.Block _ txs) _) ->
-            foldrWithIndex (\ix -> fn ix . TransactionAlonzo) result (Ledger.fromTxSeq txs)
+            foldrWithIndex (\ix -> fn ix . TransactionAlonzo) result (txs ^. Ledger.txSeqBlockBodyL)
         BlockBabbage (ShelleyBlock (Ledger.Block _ txs) _) ->
-            foldrWithIndex (\ix -> fn ix . TransactionBabbage) result (Ledger.fromTxSeq txs)
+            foldrWithIndex (\ix -> fn ix . TransactionBabbage) result (txs ^. Ledger.txSeqBlockBodyL)
         BlockConway (ShelleyBlock (Ledger.Block _ txs) _) ->
-            foldrWithIndex (\ix -> fn ix . TransactionConway) result (Ledger.fromTxSeq txs)
+            foldrWithIndex (\ix -> fn ix . TransactionConway) result (txs ^. Ledger.txSeqBlockBodyL)
+        BlockDijkstra (_) -> result -- TODO: actually support dijkstra
 
     spentInputs
         :: Transaction

--- a/src/Kupo/Data/Cardano/Metadata.hs
+++ b/src/Kupo/Data/Cardano/Metadata.hs
@@ -27,7 +27,6 @@ import Ouroboros.Consensus.Util
     )
 
 import qualified Cardano.Ledger.Allegra.Scripts as Ledger.Allegra
-import qualified Cardano.Ledger.Alonzo.TxAuxData as Ledger.Alonzo
 import qualified Cardano.Ledger.Core as Ledger
 import qualified Cardano.Ledger.Shelley.TxAuxData as Ledger
 import qualified Data.Aeson as Json
@@ -175,13 +174,13 @@ fromMaryMetadata (AllegraTxAuxData labels timelocks) =
 {-# INLINABLE fromMaryMetadata #-}
 
 fromAlonzoMetadata :: AlonzoTxAuxData AlonzoEra -> Metadata
-fromAlonzoMetadata =
-    Ledger.Alonzo.translateAlonzoTxAuxData
+fromAlonzoMetadata (AlonzoTxAuxData metadata nativeScripts plutusScripts) =
+    AlonzoTxAuxData metadata (Ledger.Allegra.translateTimelock <$> nativeScripts) plutusScripts
 {-# INLINABLE fromAlonzoMetadata #-}
 
 fromBabbageMetadata :: AlonzoTxAuxData BabbageEra -> Metadata
-fromBabbageMetadata =
-    Ledger.upgradeTxAuxData
+fromBabbageMetadata (AlonzoTxAuxData metadata nativeScripts plutusScripts) =
+    AlonzoTxAuxData metadata (Ledger.Allegra.translateTimelock <$> nativeScripts) plutusScripts
 {-# INLINABLE fromBabbageMetadata #-}
 
 fromConwayMetadata :: AlonzoTxAuxData ConwayEra -> Metadata

--- a/src/Kupo/Data/Cardano/Point.hs
+++ b/src/Kupo/Data/Cardano/Point.hs
@@ -45,7 +45,7 @@ import qualified Ouroboros.Network.Block as Ouroboros
 
 type Point = Ouroboros.Point Block
 
-instance ToJSON Point where
+instance {-# OVERLAPPING #-} ToJSON Point where
     toJSON = error "ToJSON Point called instead of 'toEncoding'."
     toEncoding = pointToJson
 

--- a/src/Kupo/Data/Cardano/Script.hs
+++ b/src/Kupo/Data/Cardano/Script.hs
@@ -43,6 +43,7 @@ scriptFromAllegraAuxiliaryData
     :: forall era.
         ( Ledger.Core.Era era
         , Ledger.Core.Script era ~ Ledger.Allegra.Timelock era
+        , Ledger.Core.NativeScript era ~ Ledger.Allegra.Timelock era
         )
     => (Ledger.Core.Script era -> Script)
     -> Ledger.Allegra.AllegraTxAuxData era
@@ -66,7 +67,7 @@ scriptFromAlonzoAuxiliaryData
     -> Map ScriptHash Script
 scriptFromAlonzoAuxiliaryData liftScript (Ledger.Alonzo.AlonzoTxAuxData _ scripts _) m0 =
     foldr
-        (\((liftScript . Ledger.Alonzo.TimelockScript) -> s) -> Map.insert (hashScript s) s)
+        (\((liftScript . Ledger.Alonzo.NativeScript) -> s) -> Map.insert (hashScript s) s)
         m0
         scripts
 {-# INLINABLE scriptFromAlonzoAuxiliaryData #-}
@@ -75,14 +76,14 @@ fromAllegraScript
     :: Ledger.Allegra.Timelock AllegraEra
     -> Script
 fromAllegraScript =
-    Ledger.Alonzo.TimelockScript . Ledger.Allegra.translateTimelock
+    Ledger.Alonzo.NativeScript . Ledger.Allegra.translateTimelock
 {-# INLINABLE fromAllegraScript #-}
 
 fromMaryScript
     :: Ledger.Allegra.Timelock MaryEra
     -> Script
 fromMaryScript =
-    Ledger.Alonzo.TimelockScript . Ledger.Allegra.translateTimelock
+    Ledger.Alonzo.NativeScript . Ledger.Allegra.translateTimelock
 {-# INLINABLE fromMaryScript  #-}
 
 fromAlonzoScript
@@ -112,13 +113,14 @@ scriptToJson
 scriptToJson script = encodeObject
     [ ("script", encodeBytes (Ledger.Core.originalBytes script))
     , ("language", case script of
-        Ledger.Alonzo.TimelockScript _ ->
+        Ledger.Alonzo.NativeScript _ ->
             Json.text "native"
         Ledger.Alonzo.PlutusScript ps ->
             case Ledger.Alonzo.plutusScriptLanguage ps of
                 Ledger.PlutusV1 -> Json.text "plutus:v1"
                 Ledger.PlutusV2 -> Json.text "plutus:v2"
                 Ledger.PlutusV3 -> Json.text "plutus:v3"
+                Ledger.PlutusV4 -> Json.text "plutus:v4"
       )
     ]
 
@@ -128,13 +130,14 @@ scriptToBytes
 scriptToBytes =
     let withTag n s = BS.singleton n <> Ledger.Core.originalBytes s
      in \case
-        Ledger.Alonzo.TimelockScript script ->
+        Ledger.Alonzo.NativeScript script ->
             withTag 0 script
         Ledger.Alonzo.PlutusScript script ->
             case Ledger.Alonzo.plutusScriptLanguage script of
                 Ledger.PlutusV1 -> withTag 1 script
                 Ledger.PlutusV2 -> withTag 2 script
                 Ledger.PlutusV3 -> withTag 3 script
+                Ledger.PlutusV4 -> withTag 4 script
 
 unsafeScriptFromBytes
     :: HasCallStack
@@ -150,9 +153,9 @@ scriptFromBytes
 scriptFromBytes (toLazy -> bytes) =
     eitherToMaybe $ do
         (script, tag) <- left (DecoderErrorDeserialiseFailure "Script") $
-            Cbor.deserialiseFromBytes Cbor.decodeWord8 bytes
+            Cbor.deserialiseFromBytes Cbor.decodeWord bytes
         case tag of
-            0 -> Ledger.Alonzo.TimelockScript <$> decodeCborAnn @BabbageEra "Timelock" decCBOR script
+            0 -> Ledger.Alonzo.NativeScript <$> decodeCborAnn @BabbageEra "Timelock" decCBOR script
             1 -> plutusScript Ledger.PlutusV1 script
             2 -> plutusScript Ledger.PlutusV2 script
             3 -> plutusScript Ledger.PlutusV3 script
@@ -165,7 +168,7 @@ scriptFromBytes (toLazy -> bytes) =
 
             script = maybeToRight
                 (Ledger.DecoderErrorCustom "Incompatible language and era" $ show (lang, uplc))
-                (Ledger.Alonzo.mkBinaryPlutusScript @ConwayEra lang uplc)
+                (Ledger.Alonzo.mkBinaryPlutusScript lang uplc)
          in
             Ledger.Alonzo.PlutusScript <$> script
 
@@ -173,7 +176,7 @@ fromNativeScript
     :: NativeScript
     -> Script
 fromNativeScript =
-    Ledger.Alonzo.TimelockScript
+    Ledger.Alonzo.NativeScript
 {-# INLINABLE fromNativeScript #-}
 
 hashScript

--- a/src/Kupo/Data/Cardano/Transaction.hs
+++ b/src/Kupo/Data/Cardano/Transaction.hs
@@ -8,9 +8,7 @@ import Kupo.Data.Cardano.TransactionId
     )
 
 import qualified Cardano.Chain.UTxO as Ledger.Byron
-import qualified Cardano.Ledger.Alonzo.Tx as Ledger.Alonzo
 import qualified Cardano.Ledger.Core as Ledger
-import qualified Cardano.Ledger.Shelley.Tx as Ledger.Shelley
 
 
 -- Transaction
@@ -20,37 +18,31 @@ data Transaction
         !Ledger.Byron.Tx
         !Ledger.Byron.TxId
     | TransactionShelley
-        !(Ledger.Shelley.ShelleyTx ShelleyEra)
+        !(Ledger.Tx Ledger.TopTx ShelleyEra)
     | TransactionAllegra
-        !(Ledger.Shelley.ShelleyTx AllegraEra)
+        !(Ledger.Tx Ledger.TopTx AllegraEra)
     | TransactionMary
-        !(Ledger.Shelley.ShelleyTx MaryEra)
+        !(Ledger.Tx Ledger.TopTx MaryEra)
     | TransactionAlonzo
-        !(Ledger.Alonzo.AlonzoTx AlonzoEra)
+        !(Ledger.Tx Ledger.TopTx AlonzoEra)
     | TransactionBabbage
-        !(Ledger.Alonzo.AlonzoTx BabbageEra)
+        !(Ledger.Tx Ledger.TopTx BabbageEra)
     | TransactionConway
-        !(Ledger.Alonzo.AlonzoTx ConwayEra)
+        !(Ledger.Tx Ledger.TopTx ConwayEra)
 
 instance HasTransactionId Transaction where
     getTransactionId = \case
         TransactionByron _ i ->
             transactionIdFromByron i
         TransactionShelley tx ->
-            let body = Ledger.Shelley.body tx
-             in Ledger.txIdTxBody @ShelleyEra body
+            Ledger.txIdTxBody @ShelleyEra (tx ^. Ledger.bodyTxL)
         TransactionAllegra tx ->
-            let body = Ledger.Shelley.body tx
-             in Ledger.txIdTxBody @AllegraEra body
+            Ledger.txIdTxBody @AllegraEra (tx ^. Ledger.bodyTxL)
         TransactionMary tx ->
-            let body = Ledger.Shelley.body tx
-             in Ledger.txIdTxBody @MaryEra body
+            Ledger.txIdTxBody @MaryEra (tx ^. Ledger.bodyTxL)
         TransactionAlonzo tx ->
-            let body = Ledger.Alonzo.body tx
-             in Ledger.txIdTxBody @AlonzoEra body
+            Ledger.txIdTxBody @AlonzoEra (tx ^. Ledger.bodyTxL)
         TransactionBabbage tx ->
-            let body = Ledger.Alonzo.body tx
-             in Ledger.txIdTxBody @BabbageEra body
+            Ledger.txIdTxBody @BabbageEra (tx ^. Ledger.bodyTxL)
         TransactionConway tx ->
-            let body = Ledger.Alonzo.body tx
-             in Ledger.txIdTxBody @ConwayEra body
+            Ledger.txIdTxBody @ConwayEra (tx ^. Ledger.bodyTxL)

--- a/src/Kupo/Data/Cardano/Transaction.hs
+++ b/src/Kupo/Data/Cardano/Transaction.hs
@@ -29,6 +29,7 @@ data Transaction
         !(Ledger.Tx Ledger.TopTx BabbageEra)
     | TransactionConway
         !(Ledger.Tx Ledger.TopTx ConwayEra)
+    -- TODO: TransactionDijkstra
 
 instance HasTransactionId Transaction where
     getTransactionId = \case

--- a/src/Kupo/Data/Hydra.hs
+++ b/src/Kupo/Data/Hydra.hs
@@ -26,6 +26,12 @@ import Cardano.Ledger.Api
     , scriptTxWitsL
     , witsTxL
     )
+import Cardano.Ledger.Binary
+    ( Annotator
+    )
+import Cardano.Ledger.Core
+    ( TopTx
+    )
 import Cardano.Ledger.Hashes
     ( unsafeMakeSafeHash
     )
@@ -181,7 +187,7 @@ decodePartialTransaction = Json.withObject "PartialTransaction" $ \o -> do
 
     bytes <- decodeBase16' hexText
 
-    tx <- case decodeCborAnn @ConwayEra "PartialTransaction" decCBOR (fromStrict bytes) of
+    tx <- case decodeCborAnn @BabbageEra "PartialTransaction" (decCBOR @(Annotator (Ledger.Tx TopTx BabbageEra))) (fromStrict bytes) of
       Left e -> fail $ show e
       Right tx -> pure tx
 

--- a/src/Kupo/Prelude.hs
+++ b/src/Kupo/Prelude.hs
@@ -92,7 +92,7 @@ import Cardano.Crypto.Hash
     , Hash (..)
     , HashAlgorithm (..)
     , hashFromBytes
-    , sizeHash
+    , hashSize
     )
 import Cardano.Ledger.Allegra
     ( AllegraEra
@@ -419,7 +419,7 @@ unsafeHashFromBytes bytes
 
 digestSize :: forall alg. HashAlgorithm alg => Int
 digestSize =
-    fromIntegral (sizeHash (Proxy @alg))
+    fromIntegral (hashSize (Proxy @alg))
 {-# INLINABLE digestSize #-}
 
 hashToJson :: HashAlgorithm alg => Hash alg a -> Json.Encoding


### PR DESCRIPTION
Update to cardano-node 11.0.1 and associated libraries.

Fixes #202 (Kupo starts up when run against a new node), but does not actually add Dijkstra support (that seems to be a significant breaking change)