### PR TITLE
Fix redeemer fetching pass

### DIFF
--- a/src/Kupo/Data/Pattern.hs
+++ b/src/Kupo/Data/Pattern.hs
@@ -577,14 +577,18 @@ matchBlock Codecs{..} patterns blk =
         -> Match result bin script policy
         -> Match result bin script policy
     fn pt ix tx Match{consumed, produced, datums, scripts, policies} = Match
-        { consumed = Map.alter
-            (\st -> Just $ fst $ foldr
-                (\ref (refs, i) -> ((MatchOutputReference ref, i, spendRedeemer @block tx i):refs, i + 1))
-                (fromMaybe mempty st, 0)
-                (spentInputs @block tx)
-            )
-            (getTransactionId tx, getPointSlotNo pt)
-            consumed
+        { consumed =
+            let
+                inputs = spentInputs @block tx
+            in
+                Map.alter
+                    (\st -> Just $ fst $ foldr
+                        (\ref (refs, i) -> ((MatchOutputReference ref, i, spendRedeemer @block tx i):refs, i - 1))
+                        (fromMaybe mempty st, fromIntegral (length inputs) - 1)
+                        inputs
+                    )
+                    (getTransactionId tx, getPointSlotNo pt)
+                    consumed
 
         , produced =
             newProduced


### PR DESCRIPTION
This fixes redeemer retrieval - we fold here from the right (last element) and not the first. 

We could also keep `0` and incrementing approach if we move to `foldl'` - I believe the order generated from this folding doesn't really matter for the `consumed`. 