### PR TITLE
Add `block_no` to `Checkpoint`

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,5 +1,5 @@
 repository cardano-haskell-packages
-  url: https://input-output-hk.github.io/cardano-haskell-packages
+  url: https://chap.intersectmbo.org/
   secure: true
   root-keys:
     3e0cce471cf09815f930210f7827266fd09045445d65923e6d0238a6cd15126f

--- a/db/v2.13.0/001.sql
+++ b/db/v2.13.0/001.sql
@@ -1,0 +1,9 @@
+DELETE FROM inputs;
+
+DROP TABLE checkpoints;
+
+CREATE TABLE checkpoints (
+  header_hash BLOB NOT NULL,
+  slot_no INTEGER PRIMARY KEY NOT NULL,
+  block_no INTEGER NOT NULL
+);

--- a/kupo.cabal
+++ b/kupo.cabal
@@ -82,6 +82,7 @@ library
       Kupo.Data.Cardano.BinaryData
       Kupo.Data.Cardano.Block
       Kupo.Data.Cardano.BlockNo
+      Kupo.Data.Cardano.Checkpoint
       Kupo.Data.Cardano.Datum
       Kupo.Data.Cardano.DatumHash
       Kupo.Data.Cardano.HeaderHash

--- a/src/Kupo.hs
+++ b/src/Kupo.hs
@@ -302,17 +302,17 @@ kupoWith tr networkParameters withProducer withFetchBlock fetchTipClient =
                         toggleConnected statusToggle *> idle
                       else
                         withExceptionHandler (tracerKupo tr) statusToggle $ do
-                            (mostRecentCheckpoint, checkpoints) <- startOrResume
+                            (mostRecentPoint, points) <- startOrResume
                                 (tracerConfiguration tr)
                                 config
                                 db
                                 fetchTipClient
 
-                            initializeHealth health mostRecentCheckpoint
+                            initializeHealth health mostRecentPoint
 
                             producer
                                 (tracerChainSync tr)
-                                checkpoints
+                                points
                                 statusToggle
                     )
 

--- a/src/Kupo/App.hs
+++ b/src/Kupo/App.hs
@@ -113,7 +113,9 @@ import Kupo.Data.Cardano
     , SlotNo (..)
     , Tip
     , TransactionId
+    , checkpointPoint
     , distanceToTip
+    , getCheckpoint
     , getPoint
     , getPointSlotNo
     , getTipSlotNo
@@ -524,7 +526,7 @@ rollForwardAll tr inputManagement notifyTip Database{..} patterns blks = do
     let Match{consumed, produced, datums, scripts, policies} =
             foldMap (matchBlock codecs patterns . snd) blks
     isNonEmptyBlock <- runTransaction $ do
-        insertCheckpoints (foldr ((:) . getPoint . snd) [] blks)
+        insertCheckpoints (foldr ((:) . getCheckpoint . snd) [] blks)
         insertInputs produced
         insertPolicies policies
         nSpentInputs <- onSpentInputs lastKnownTip lastKnownSlot consumed
@@ -602,11 +604,11 @@ readOnlyConsumer
     -> m Void
 readOnlyConsumer health Database{..} = do
     forever $ do
-        mostRecentCheckpoint <- runTransaction listCheckpointsDesc <&> \case
+        mostRecentPoint <- runTransaction listCheckpointsDesc <&> \case
             []  -> Nothing
-            h:_ -> Just h
+            h:_ -> Just (checkpointPoint h)
         now <- getCurrentTime
-        recordCheckpoint health now (maybe 0 getPointSlotNo mostRecentCheckpoint) mostRecentCheckpoint
+        recordCheckpoint health now (maybe 0 getPointSlotNo mostRecentPoint) mostRecentPoint
         threadDelay 5
 
 -- | Periodically garbage collect the database from entries that aren't of

--- a/src/Kupo/App/ChainSync/Node.hs
+++ b/src/Kupo/App/ChainSync/Node.hs
@@ -21,8 +21,9 @@ import Kupo.Control.MonadThrow
     )
 import Kupo.Data.Cardano
     ( IsBlock (..)
+    , Checkpoint (..)
     , Point
-    , Tip
+    , Tip,
     )
 import Kupo.Data.ChainSync
     ( DistanceFromTip
@@ -156,7 +157,9 @@ mkChainSyncClient var0 mailbox pts =
         ClientStNext
             { recvMsgRollForward = \block tip -> do
                 atomically (putHighFrequencyMessage mailbox (tip, block))
-                clientStIdle var (mkDistanceFromTip tip (getPoint block)) n
+                let
+                    Checkpoint { checkpointPoint } = getCheckpoint block
+                clientStIdle var (mkDistanceFromTip tip checkpointPoint) n
             , recvMsgRollBackward = \point tip -> do
                 atomically (putIntermittentMessage mailbox (tip, point))
                 clientStIdle var (mkDistanceFromTip tip point) n

--- a/src/Kupo/App/Configuration.hs
+++ b/src/Kupo/App/Configuration.hs
@@ -55,6 +55,7 @@ import Kupo.Control.MonadThrow
 import Kupo.Data.Cardano
     ( Point
     , SlotNo (..)
+    , checkpointPoint
     , getPointSlotNo
     , pointFromTip
     )
@@ -190,7 +191,7 @@ startOrResume
     -> FetchTipClient m
     -> m (Maybe Point, [Point])
 startOrResume tr configuration Database{..} fetchTip = do
-    checkpoints <- runTransaction listCheckpointsDesc
+    checkpoints <- runTransaction listCheckpointsDesc <&> map checkpointPoint
 
     let slots = unSlotNo . getPointSlotNo <$> checkpoints
     logWith tr $ ConfigurationCheckpointsForIntersection { slots }
@@ -200,18 +201,18 @@ startOrResume tr configuration Database{..} fetchTip = do
             logWith tr (ConfigurationInvalidOrMissingOption errNoStartingPoint)
             throwIO (NoStartingPointException errNoStartingPoint)
 
-        (Just (SincePoint point), mostRecentCheckpoint:_) -> do
-            if getPointSlotNo point > getPointSlotNo mostRecentCheckpoint then do
+        (Just (SincePoint point), mostRecentPoint:_) -> do
+            if getPointSlotNo point > getPointSlotNo mostRecentPoint then do
                 logWith tr (ConfigurationInvalidOrMissingOption errConflictingSinceOptions)
                 throwIO (ConflictingOptionsException errConflictingSinceOptions)
             else do
                 pure
-                    ( Just mostRecentCheckpoint
+                    ( Just mostRecentPoint
                     , sortOn (Down . getPointSlotNo) (point : checkpoints)
                     )
 
-        (Nothing, pts@(mostRecentCheckpoint:_)) -> do
-            pure (Just mostRecentCheckpoint, pts)
+        (Nothing, pts@(mostRecentPoint:_)) -> do
+            pure (Just mostRecentPoint, pts)
 
         (Just (SincePoint pt), []) ->
             pure (Nothing, [pt])
@@ -220,8 +221,8 @@ startOrResume tr configuration Database{..} fetchTip = do
             tip <- pointFromTip <$> fetchTip
             pure (Just tip, [tip])
 
-        (Just SinceTip, pts@(mostRecentCheckpoint:_)) -> do
-            pure (Just mostRecentCheckpoint, pts)
+        (Just SinceTip, pts@(mostRecentPoint:_)) -> do
+            pure (Just mostRecentPoint, pts)
   where
     Configuration{since} = configuration
 

--- a/src/Kupo/App/Database/SQLite.hs
+++ b/src/Kupo/App/Database/SQLite.hs
@@ -668,8 +668,10 @@ mkDatabase tr mode longestRollback bracketConnection = Database
              , matchMaybeBytes -> refScriptHash
              , SQLInteger (fromIntegral -> createdAtSlotNo)
              , SQLBlob createdAtHeaderHash
+             , SQLInteger (fromIntegral -> createdAtBlockNo)
              , matchMaybeWord64 -> spentAtSlotNo
              , matchMaybeBytes -> spentAtHeaderHash
+             , matchMaybeWord64 -> spentAtBlockNo
              , matchMaybeBytes -> spentBy
              , matchMaybeBytes -> spentWith
              , matchMaybeBytes -> datumBinaryData
@@ -714,10 +716,11 @@ mkDatabase tr mode longestRollback bracketConnection = Database
 
     , insertCheckpoints = \cps -> ReaderT $ \conn -> do
         mapM_
-            (\(DB.pointToRow -> DB.Checkpoint{..}) ->
+            (\(DB.checkpointToRow -> DB.Checkpoint{..}) ->
                 insertRow @"checkpoints" conn
                     [ SQLBlob checkpointHeaderHash
                     , SQLInteger (fromIntegral checkpointSlotNo)
+                    , SQLInteger (fromIntegral checkpointBlockNo)
                     ]
             )
             cps
@@ -730,16 +733,16 @@ mkDatabase tr mode longestRollback bracketConnection = Database
                 [ k `div` (2 ^ e) | (e :: Integer) <- [ n-1, n-2 .. 0 ] ]
               where
                 n = ceiling (log (fromIntegral @_ @Double k))
-        fmap (fmap DB.pointFromRow . nubOn DB.checkpointSlotNo . mconcat) $ forM points $ \pt ->
+        fmap (fmap DB.checkpointFromRow . nubOn DB.checkpointSlotNo . mconcat) $ forM points $ \pt ->
             Sqlite.fold conn listCheckpointsQry [SQLInteger pt] [] $
-                \xs (checkpointHeaderHash, checkpointSlotNo) ->
+                \xs (checkpointHeaderHash, checkpointSlotNo, checkpointBlockNo) ->
                     pure (DB.Checkpoint{..} : xs)
 
     , listAncestorsDesc = \(SlotNo slotNo) n -> ReaderT $ \conn -> do
         fmap reverse $
             Sqlite.fold conn listAncestorQry (SQLInteger <$> [fromIntegral slotNo, n]) [] $
-                \xs (checkpointHeaderHash, checkpointSlotNo) ->
-                    pure ((DB.pointFromRow DB.Checkpoint{..}) : xs)
+                \xs (checkpointHeaderHash, checkpointSlotNo, checkpointBlockNo) ->
+                    pure ((DB.checkpointFromRow DB.Checkpoint{..}) : xs)
 
     , insertBinaryData = \bin -> ReaderT $ \conn -> do
         mapM_
@@ -814,8 +817,8 @@ mkDatabase tr mode longestRollback bracketConnection = Database
                         traceExecute tr conn rollbackQryUpdateInputs [ minSlotNo ]
                         traceExecute tr conn rollbackQryDeleteCheckpoints [ minSlotNo ]
         query_ conn selectMaxCheckpointQry >>= \case
-            [[SQLInteger (fromIntegral -> checkpointSlotNo), SQLBlob checkpointHeaderHash]] ->
-                return $ Just (DB.pointFromRow DB.Checkpoint{..})
+            [[SQLInteger (fromIntegral -> pointSlotNo), SQLBlob pointHeaderHash]] ->
+                return $ Just (DB.pointFromRow DB.Point{..})
             [[SQLNull, SQLNull]] ->
                 return Nothing
             xs ->
@@ -930,8 +933,8 @@ foldInputsQry pattern_ slotRange statusFlag referenceFlag sortDirection =
     Query $ "SELECT \
       \inputs.ext_output_reference, inputs.address, inputs.value, \
       \inputs.datum_info, inputs.script_hash, \
-      \inputs.created_at, createdAt.header_hash, \
-      \inputs.spent_at, spentAt.header_hash, \
+      \inputs.created_at, createdAt.header_hash, createdAt.block_no, \
+      \inputs.spent_at, spentAt.header_hash, spentAt.block_no, \
       \inputs.spent_by, inputs.spent_with"
     <> case referenceFlag of
          AsReference -> ", NULL as datum, NULL as script"
@@ -1306,6 +1309,7 @@ migrations =
         , $(embedFile "db/v2.1.0/003.sql")
         , $(embedFile "db/v2.2.0/001.sql")
         , $(embedFile "db/v2.10.0/001.sql")
+        , $(embedFile "db/v2.13.0/001.sql")
         ]
     ]
   where

--- a/src/Kupo/App/Database/Types.hs
+++ b/src/Kupo/App/Database/Types.hs
@@ -35,6 +35,7 @@ import Kupo.Control.MonadTime
     )
 import Kupo.Data.Cardano
     ( BinaryData
+    , Checkpoint
     , DatumHash
     , InputIndex
     , Point
@@ -122,16 +123,16 @@ data Database (m :: Type -> Type) = Database
         -> DBTransaction m ()
 
     , insertCheckpoints
-        :: [Point]
+        :: [Checkpoint]
         -> DBTransaction m ()
 
     , listCheckpointsDesc
-        :: DBTransaction m [Point]
+        :: DBTransaction m [Checkpoint]
 
     , listAncestorsDesc
         :: SlotNo
         -> Int64 -- Number of ancestors to retrieve
-        -> DBTransaction m [Point]
+        -> DBTransaction m [Checkpoint]
 
     , insertPatterns
         :: Set Pattern

--- a/src/Kupo/App/Health.hs
+++ b/src/Kupo/App/Health.hs
@@ -64,10 +64,10 @@ recordCheckpoint
     -> SlotNo
     -> Maybe Point
     -> m ()
-recordCheckpoint health (Just -> mostRecentClockTick) (Just -> mostRecentNodeTip) mostRecentCheckpoint =
+recordCheckpoint health (Just -> mostRecentClockTick) (Just -> mostRecentNodeTip) mostRecentPoint =
     atomically $ modifyTVar' health $ \h -> h
         { mostRecentNodeTip
-        , mostRecentCheckpoint
+        , mostRecentPoint
         , mostRecentClockTick
         }
 
@@ -79,8 +79,8 @@ initializeHealth
     => TVar m Health
     -> Maybe Point
     -> m ()
-initializeHealth health mostRecentCheckpoint' =
+initializeHealth health mostRecentPoint' =
     atomically $ modifyTVar' health $ \h -> h
-        { mostRecentCheckpoint =
-            max (mostRecentCheckpoint h) mostRecentCheckpoint'
+        { mostRecentPoint =
+            max (mostRecentPoint h) mostRecentPoint'
         }

--- a/src/Kupo/App/Http.hs
+++ b/src/Kupo/App/Http.hs
@@ -56,15 +56,18 @@ import Kupo.Control.MonadTime
     ( DiffTime
     )
 import Kupo.Data.Cardano
-    ( DatumHash
+    ( Checkpoint (checkpointPoint)
+    , DatumHash
     , IsBlock (..)
     , Point
     , ScriptHash
     , SlotNo (..)
     , binaryDataToJson
+    , checkpointToJson
     , datumHashFromText
     , distanceToSlot
     , foldBlock
+    , getCheckpointSlotNo
     , getPoint
     , getPointHeaderHash
     , getPointSlotNo
@@ -74,7 +77,6 @@ import Kupo.Data.Cardano
     , headerHashToText
     , metadataToJson'
     , pattern GenesisPoint
-    , pointToJson
     , scriptHashFromText
     , scriptToJson
     , slotNoFromText
@@ -453,7 +455,7 @@ cacheOr
 cacheOr readHealth req send handler = do
     health <- readHealth
     let mostRecentHeaderHash =
-            (encodeUtf8 . headerHashToText) <$> (mostRecentCheckpoint health >>= getPointHeaderHash)
+            (encodeUtf8 . headerHashToText) <$> (mostRecentPoint health >>= getPointHeaderHash)
     case L.lookup "if-none-match" (requestHeaders req) of
         Just etag | Just etag == mostRecentHeaderHash ->
             send $ responseLBS status304 (addCacheHeaders Default.headers health) ""
@@ -521,7 +523,7 @@ handleGetHealth reqHeaders forcedStatus resolveNetworkParameters health = do
         Health{..} = health
         d = distanceToSlot
             <$> mostRecentNodeTip
-            <*> (getPointSlotNo <$> mostRecentCheckpoint)
+            <*> (getPointSlotNo <$> mostRecentPoint)
 
     cTextPlain = "text/plain"
     cApplicationJson = "application/json"
@@ -539,9 +541,9 @@ handleGetCheckpoints
     -> Database IO
     -> Response
 handleGetCheckpoints headers Database{..} = do
-    responseStreamJson headers pointToJson $ \yield done -> do
-        points <- runTransaction listCheckpointsDesc
-        mapM_ yield points
+    responseStreamJson headers checkpointToJson $ \yield done -> do
+        checkpoints <- runTransaction listCheckpointsDesc
+        mapM_ yield checkpoints
         done
 
 handleGetCheckpointBySlot
@@ -561,12 +563,12 @@ handleGetCheckpointBySlot headers mSlotNo query Database{..} =
   where
     handleGetCheckpointBySlot' slotNo mode = do
         let successor = next slotNo
-        points <- runTransaction (listAncestorsDesc successor 1)
-        pure $ responseJsonEncoding status200 headers $ case (points, mode) of
-            ([point], GetCheckpointStrict) | getPointSlotNo point == slotNo ->
-                pointToJson point
-            ([point], GetCheckpointClosestAncestor) ->
-                pointToJson point
+        checkpoints <- runTransaction (listAncestorsDesc successor 1)
+        pure $ responseJsonEncoding status200 headers $ case (checkpoints, mode) of
+            ([checkpoint], GetCheckpointStrict) | getCheckpointSlotNo checkpoint == slotNo ->
+                checkpointToJson checkpoint
+            ([checkpoint], GetCheckpointClosestAncestor) ->
+                checkpointToJson checkpoint
             _pointNotFound ->
                 Json.null_
 
@@ -608,12 +610,12 @@ handleGetMatches resHeaders reqHeaders patternQuery queryParams Database{..} = h
         let assertPointExists :: Point -> DBTransaction IO ()
             assertPointExists requested = do
                 let nextSlot = next (getPointSlotNo requested)
-                points <- listAncestorsDesc nextSlot 1
-                case points of
-                    [found] | found == requested ->
+                checkpoints <- listAncestorsDesc nextSlot 1
+                case checkpoints of
+                    [found] | checkpointPoint found == requested ->
                         pure ()
                     [found] ->
-                        throwIO ErrPointMismatch{requested, found}
+                        throwIO ErrPointMismatch{requested, found = checkpointPoint found}
                     _pointNotFound ->
                         throwIO ErrPointNotFound{requested}
         runTransaction $ do
@@ -746,7 +748,7 @@ handleGetMetadata baseHeaders slotArg queryParams Database{..} fetchBlock =
             pure $ responseStreamJson baseHeaders metadataToJson' $ \_yield done -> done
         Just slotNo -> do
             ancestor <- runTransaction (listAncestorsDesc slotNo 1) <&> \case
-                [ancestor]  -> ancestor
+                [ancestor]  -> checkpointPoint ancestor
                 _noAncestor -> GenesisPoint
             case filterMatchesBy queryParams of
                 Just NoFilter ->
@@ -855,7 +857,7 @@ handlePutPatterns headers readHealth forceRollback patternsVar mPointOrSlot quer
             let successor = next $ getPointSlotNo pt
             pts <- runTransaction $ listAncestorsDesc successor 1
             return $ case pts of
-                [pt'] | pt == pt' ->
+                [pt'] | pt == checkpointPoint pt' ->
                     Just pt
                 -- NOTE: It may be possible for clients to rollback to a point
                 -- prior to any point we know, in which case, we keep things
@@ -870,7 +872,7 @@ handlePutPatterns headers readHealth forceRollback patternsVar mPointOrSlot quer
             pts <- runTransaction $ listAncestorsDesc successor 1
             return $ case pts of
                 [pt] ->
-                    Just pt
+                    Just (checkpointPoint pt)
                 _unexpectedPoint ->
                     Nothing
 
@@ -921,7 +923,7 @@ addCacheHeaders
     -> Health
     -> [Http.Header]
 addCacheHeaders defaultHeaders =
-    toHeaders . mostRecentCheckpoint
+    toHeaders . mostRecentPoint
   where
     toHeaders :: Maybe Point -> [Http.Header]
     toHeaders pt =

--- a/src/Kupo/Data/Cardano.hs
+++ b/src/Kupo/Data/Cardano.hs
@@ -10,12 +10,14 @@
 
 module Kupo.Data.Cardano
     ( IsBlock (..)
+    , getPoint
     , module Kupo.Data.Cardano.Address
     , module Kupo.Data.Cardano.AssetId
     , module Kupo.Data.Cardano.AssetName
     , module Kupo.Data.Cardano.BinaryData
     , module Kupo.Data.Cardano.Block
     , module Kupo.Data.Cardano.BlockNo
+    , module Kupo.Data.Cardano.Checkpoint
     , module Kupo.Data.Cardano.Datum
     , module Kupo.Data.Cardano.DatumHash
     , module Kupo.Data.Cardano.HeaderHash
@@ -64,9 +66,11 @@ import Ouroboros.Consensus.Ledger.SupportsMempool
     )
 import Ouroboros.Consensus.Shelley.Ledger.Block
     ( ShelleyBlock (..)
+    , getHeader
     )
 import Ouroboros.Network.Block
-    ( blockPoint
+    ( blockNo
+    , blockPoint
     )
 
 import Kupo.Data.Cardano.Address
@@ -75,6 +79,7 @@ import Kupo.Data.Cardano.AssetName
 import Kupo.Data.Cardano.BinaryData
 import Kupo.Data.Cardano.Block
 import Kupo.Data.Cardano.BlockNo
+import Kupo.Data.Cardano.Checkpoint
 import Kupo.Data.Cardano.Datum
 import Kupo.Data.Cardano.DatumHash
 import Kupo.Data.Cardano.HeaderHash
@@ -109,9 +114,9 @@ import qualified Data.Set as Set
 class HasTransactionId (BlockBody block) => IsBlock (block :: Type) where
     type BlockBody block :: Type
 
-    getPoint
+    getCheckpoint
         :: block
-        -> Point
+        -> Checkpoint
 
     foldBlock
         :: (TransactionIndex -> BlockBody block -> result -> result)
@@ -145,11 +150,18 @@ class HasTransactionId (BlockBody block) => IsBlock (block :: Type) where
         -> InputIndex
         -> Maybe BinaryData
 
+getPoint :: forall block. IsBlock block => block -> Point
+getPoint blk = do
+    let
+        checkpoint :: Checkpoint
+        checkpoint = getCheckpoint blk
+    checkpointPoint checkpoint
+
 -- Block
 
 instance IsBlock Void where
     type BlockBody Void = Void
-    getPoint = absurd
+    getCheckpoint = absurd
     foldBlock _ _ = absurd
     spentInputs = absurd
     mapMaybeOutputs _ = absurd
@@ -161,11 +173,12 @@ instance IsBlock Void where
 instance IsBlock Block where
     type BlockBody Block = Transaction
 
-    getPoint
+    getCheckpoint
         :: Block
-        -> Point
-    getPoint =
-        blockPoint
+        -> Checkpoint
+    getCheckpoint block = Checkpoint
+        (blockPoint block)
+        (blockNo (getHeader block))
 
     foldBlock
         :: (TransactionIndex -> Transaction -> result -> result)

--- a/src/Kupo/Data/Cardano/BlockNo.hs
+++ b/src/Kupo/Data/Cardano/BlockNo.hs
@@ -1,6 +1,14 @@
 module Kupo.Data.Cardano.BlockNo
     ( BlockNo (..)
+    , blockNoToJson
     ) where
+import qualified Data.Aeson.Encoding as Json
 import Cardano.Slotting.Block
     ( BlockNo (..)
     )
+import Kupo.Prelude
+
+blockNoToJson :: BlockNo -> Json.Encoding
+blockNoToJson =
+    Json.integer . toInteger . unBlockNo
+{-# INLINABLE blockNoToJson #-}

--- a/src/Kupo/Data/Cardano/Checkpoint.hs
+++ b/src/Kupo/Data/Cardano/Checkpoint.hs
@@ -1,0 +1,61 @@
+module Kupo.Data.Cardano.Checkpoint
+    ( Checkpoint (..)
+    , checkpointToJson
+    , getCheckpointHeaderHash
+    , getCheckpointSlotNo
+    , unsafeGetCheckpointHeaderHash
+    ) where
+
+import Kupo.Prelude
+
+import Kupo.Data.Cardano.Block
+    ( Block
+    )
+import Kupo.Data.Cardano.BlockNo
+    ( BlockNo
+    , blockNoToJson
+    )
+import Kupo.Data.Cardano.HeaderHash
+    ( headerHashToJson
+    )
+import Ouroboros.Network.Block
+    ( HeaderHash
+    )
+import Kupo.Data.Cardano.Point
+    ( Point
+    , getPointSlotNo
+    , getPointHeaderHash
+    , unsafeGetPointHeaderHash
+    )
+import Kupo.Data.Cardano.SlotNo
+    ( slotNoToJson, SlotNo
+    )
+
+import qualified Data.Aeson.Encoding as Json
+
+data Checkpoint = Checkpoint
+    { checkpointPoint :: !Point
+    , checkpointBlockNo :: !BlockNo
+    } deriving (Show, Eq)
+
+checkpointToJson :: Checkpoint -> Json.Encoding
+checkpointToJson pt = Json.pairs $ mconcat
+    [ Json.pair "slot_no"
+        (slotNoToJson (getCheckpointSlotNo pt))
+    , Json.pair "header_hash"
+        (headerHashToJson (unsafeGetCheckpointHeaderHash pt))
+    , Json.pair "block_no"
+        (blockNoToJson (checkpointBlockNo pt))
+    ]
+{-# INLINABLE checkpointToJson #-}
+
+getCheckpointSlotNo :: Checkpoint -> SlotNo
+getCheckpointSlotNo checkpoint = getPointSlotNo (checkpointPoint checkpoint)
+
+getCheckpointHeaderHash :: Checkpoint -> Maybe (HeaderHash Block)
+getCheckpointHeaderHash checkpoint = getPointHeaderHash (checkpointPoint checkpoint)
+
+unsafeGetCheckpointHeaderHash :: Checkpoint -> HeaderHash Block
+unsafeGetCheckpointHeaderHash =
+    fromMaybe (error "Point is 'Origin'") . getCheckpointHeaderHash
+{-# INLINABLE unsafeGetCheckpointHeaderHash #-}

--- a/src/Kupo/Data/Database.hs
+++ b/src/Kupo/Data/Database.hs
@@ -11,13 +11,16 @@
 module Kupo.Data.Database
     ( -- * Point / Checkpoint
       Checkpoint (..)
-    , pointToRow
-    , pointFromRow
+    , checkpointToRow
+    , checkpointFromRow
 
       -- * Result / Input
     , Input (..)
     , resultToRow
     , resultFromRow
+
+    , Point (..)
+    , pointFromRow
 
       -- * Policy
     , Policy (..)
@@ -112,29 +115,34 @@ import qualified Kupo.Data.Pattern as App
 data Checkpoint = Checkpoint
     { checkpointHeaderHash :: !ByteString
     , checkpointSlotNo :: !Word64
+    , checkpointBlockNo :: !Word64
     } deriving (Show)
 
-pointFromRow
+checkpointFromRow
     :: Checkpoint
-    -> App.Point
-pointFromRow row = App.BlockPoint
-    (App.SlotNo (checkpointSlotNo row))
-    (fromShortRawHash (Proxy @App.Block) $ toShort $ checkpointHeaderHash row)
-{-# INLINABLE pointFromRow #-}
+    -> App.Checkpoint
+checkpointFromRow row = do
+    let
+        point = App.BlockPoint
+            (App.SlotNo (checkpointSlotNo row))
+            (fromShortRawHash (Proxy @App.Block) $ toShort $ checkpointHeaderHash row)
+    App.Checkpoint point (App.BlockNo (checkpointBlockNo row))
+{-# INLINABLE checkpointFromRow #-}
 
-pointToRow
+checkpointToRow
     :: HasCallStack
-    => App.Point
+    => App.Checkpoint
     -> Checkpoint
-pointToRow = \case
+checkpointToRow (App.Checkpoint point blockNo) = case point of
     App.GenesisPoint -> error "pointToRow: genesis point."
     App.BlockPoint slotNo headerHash -> Checkpoint
         { checkpointHeaderHash = toRawHash proxy headerHash
         , checkpointSlotNo = App.unSlotNo slotNo
+        , checkpointBlockNo = App.unBlockNo blockNo
         }
   where
     proxy = Proxy @App.Block
-{-# INLINABLE pointToRow #-}
+{-# INLINABLE checkpointToRow #-}
 
 --
 -- Result
@@ -148,8 +156,10 @@ data Input = Input
     , datumInfo :: !(Maybe ByteString)
     , refScript :: !(Maybe ScriptReference)
     , refScriptHash :: !(Maybe ByteString)
+    , createdAtBlockNo :: !Word64
     , createdAtSlotNo :: !Word64
     , createdAtHeaderHash :: !ByteString
+    , spentAtBlockNo :: !(Maybe Word64)
     , spentAtSlotNo :: !(Maybe Word64)
     , spentAtHeaderHash :: !(Maybe ByteString)
     , spentBy :: !(Maybe ByteString)
@@ -171,9 +181,9 @@ resultFromRow row = App.Result
     , App.scriptReference =
         scriptReferenceFromRow (refScriptHash row) (refScript row)
     , App.createdAt =
-        pointFromRow (Checkpoint (createdAtHeaderHash row) (createdAtSlotNo row))
+        checkpointFromRow (Checkpoint (createdAtHeaderHash row) (createdAtSlotNo row) (createdAtBlockNo row))
     , App.spentAt =
-        pointFromRow <$> (Checkpoint <$> spentAtHeaderHash row <*> spentAtSlotNo row)
+        checkpointFromRow <$> (Checkpoint <$> spentAtHeaderHash row <*> spentAtSlotNo row <*> spentAtBlockNo row)
     , App.spentBy =
         outputReferenceFromRow <$> spentBy row
     , App.spentWith =
@@ -201,19 +211,36 @@ resultToRow x =
     (refScriptHash, refScript) =
         scriptReferenceToRow (App.scriptReference x)
 
-    (createdAtSlotNo, createdAtHeaderHash) =
-        let row = pointToRow (App.createdAt x)
-         in (checkpointSlotNo row, checkpointHeaderHash row)
+    (createdAtSlotNo, createdAtHeaderHash, createdAtBlockNo) =
+        let row = checkpointToRow (App.createdAt x)
+         in (checkpointSlotNo row, checkpointHeaderHash row, checkpointBlockNo row)
 
-    (spentAtSlotNo, spentAtHeaderHash) =
-        let row = pointToRow <$> (App.spentAt x)
-         in (checkpointSlotNo <$> row, checkpointHeaderHash <$> row)
+    (spentAtSlotNo, spentAtHeaderHash, spentAtBlockNo) =
+        let row = checkpointToRow <$> (App.spentAt x)
+         in (checkpointSlotNo <$> row, checkpointHeaderHash <$> row, checkpointBlockNo <$> row)
 
     spentBy =
         outputReferenceToRow <$> App.spentBy x
 
     spentWith =
         redeemerToRow <$> App.spentWith x
+
+--
+-- Point
+--
+
+data Point = Point
+    { pointHeaderHash :: !ByteString
+    , pointSlotNo :: !Word64
+    } deriving (Show)
+
+pointFromRow
+    :: Point
+    -> App.Point
+pointFromRow row = App.BlockPoint
+    (App.SlotNo (pointSlotNo row))
+    (fromShortRawHash (Proxy @App.Block) $ toShort $ pointHeaderHash row)
+{-# INLINABLE pointFromRow #-}
 
 --
 -- Policy

--- a/src/Kupo/Data/Health.hs
+++ b/src/Kupo/Data/Health.hs
@@ -86,7 +86,7 @@ import qualified Data.Scientific as Scientific
 data Health = Health
     { connectionStatus :: !ConnectionStatus
         -- ^ Condition of the connection with the underlying node.
-    , mostRecentCheckpoint :: !(Maybe Point)
+    , mostRecentPoint :: !(Maybe Point)
         -- ^ Absolute slot number of the most recent database checkpoint.
     , mostRecentNodeTip :: !(Maybe SlotNo)
         -- ^ Absolute slot number of the tip of the node
@@ -111,7 +111,7 @@ instance ToJSON SerialisableHealth where
             (toEncoding connectionStatus)
         , Json.pair
             "most_recent_checkpoint"
-            (maybe Json.null_ (slotNoToJson . getPointSlotNo) mostRecentCheckpoint)
+            (maybe Json.null_ (slotNoToJson . getPointSlotNo) mostRecentPoint)
         , Json.pair
             "most_recent_node_tip"
             (maybe Json.null_ slotNoToJson mostRecentNodeTip)
@@ -123,7 +123,7 @@ instance ToJSON SerialisableHealth where
             (maybe Json.null_ toEncoding
                 (liftA2 (mkNetworkSynchronization now)
                     optNetworkParameters
-                    (getPointSlotNo <$> mostRecentCheckpoint)
+                    (getPointSlotNo <$> mostRecentPoint)
                 )
             )
          , Json.pair
@@ -152,7 +152,7 @@ nominalDiffTimeToInteger =
 emptyHealth :: Health
 emptyHealth = Health
     { connectionStatus = Disconnected
-    , mostRecentCheckpoint = Nothing
+    , mostRecentPoint = Nothing
     , mostRecentNodeTip = Nothing
     , mostRecentClockTick = Nothing
     , configuration = Nothing
@@ -266,7 +266,7 @@ mkPrometheusMetrics now optNetworkParameters Health{..} =
     networkSynchronization = liftA2
         (mkNetworkSynchronization now)
         optNetworkParameters
-        (getPointSlotNo <$> mostRecentCheckpoint)
+        (getPointSlotNo <$> mostRecentPoint)
 
     prometheusMetrics :: [(Text, MetricSample)]
     prometheusMetrics = mconcat
@@ -279,7 +279,7 @@ mkPrometheusMetrics now optNetworkParameters Health{..} =
 
         , [ ( "most_recent_checkpoint"
             , mkCounter $ fromEnum $ unSlotNo $ getPointSlotNo s
-            ) | Just s <- [mostRecentCheckpoint]
+            ) | Just s <- [mostRecentPoint]
           ]
 
         , [ ( "most_recent_node_tip"

--- a/src/Kupo/Data/Hydra.hs
+++ b/src/Kupo/Data/Hydra.hs
@@ -118,6 +118,7 @@ mkHydraBlock number txs = do
         , PartialBlock
             { blockPoint = BlockPoint slotNo headerHash
             , blockBody  = toList txs
+            , blockNo    = blockNo
             }
         )
 

--- a/src/Kupo/Data/Ogmios.hs
+++ b/src/Kupo/Data/Ogmios.hs
@@ -2,6 +2,7 @@
 --  License, v. 2.0. If a copy of the MPL was not distributed with this
 --  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+{-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE PatternSynonyms #-}
 
 module Kupo.Data.Ogmios
@@ -196,11 +197,13 @@ decodeBlock
     -> Json.Parser PartialBlock
 decodeBlock = Json.withObject "Block" $ \o -> do
     id <- o .: "id" >>= decodeOneEraHash
+    height <- o.: "height"
     slot <- o .:? "slot" >>= \case
         Just slot -> pure slot
-        Nothing -> o .: "height"
+        Nothing -> pure height
     txs <- o .:? "transactions" .!= []
-    PartialBlock (BlockPoint (SlotNo slot) id) <$> traverse decodePartialTransaction txs
+    traverse decodePartialTransaction txs <&> \pTxs -> do
+        PartialBlock (BlockPoint (SlotNo slot) id) pTxs (BlockNo height)
 
 decodePartialTransaction
     :: Json.Value

--- a/src/Kupo/Data/PartialBlock.hs
+++ b/src/Kupo/Data/PartialBlock.hs
@@ -11,6 +11,8 @@ import Kupo.Prelude
 
 import Kupo.Data.Cardano
     ( BinaryData
+    , BlockNo
+    , Checkpoint (..)
     , DatumHash
     , HasTransactionId (..)
     , Input
@@ -24,7 +26,7 @@ import Kupo.Data.Cardano
     , Script
     , ScriptHash
     , TransactionId
-    , emptyMetadata
+    , emptyMetadata,
     )
 
 import qualified Data.Map.Strict as Map
@@ -35,6 +37,7 @@ import qualified Data.Set as Set
 data PartialBlock = PartialBlock
     { blockPoint :: !Point
     , blockBody :: ![PartialTransaction]
+    , blockNo :: !BlockNo
     } deriving (Eq, Show)
 
 -- | A partial transaction, analogous to 'PartialBlock', trimmed down to the
@@ -55,8 +58,10 @@ instance HasTransactionId PartialTransaction where
 instance IsBlock PartialBlock where
     type BlockBody PartialBlock = PartialTransaction
 
-    getPoint =
-        blockPoint
+    getCheckpoint blk =
+        Checkpoint
+            (blockPoint blk)
+            (blockNo blk)
 
     spentInputs =
         Set.fromList . inputs

--- a/src/Kupo/Data/Pattern.hs
+++ b/src/Kupo/Data/Pattern.hs
@@ -39,6 +39,7 @@ import Kupo.Data.Cardano
     ( Address
     , AssetId
     , BinaryData
+    , Checkpoint
     , Datum (..)
     , DatumHash
     , ExtendedOutputReference
@@ -47,7 +48,6 @@ import Kupo.Data.Cardano
     , Metadata
     , Output
     , OutputReference
-    , Point
     , PolicyId
     , Script
     , ScriptHash
@@ -62,14 +62,16 @@ import Kupo.Data.Cardano
     , assetNameFromText
     , assetNameToText
     , binaryDataToJson
+    , blockNoToJson
+    , checkpointBlockNo
     , datumHashToJson
     , foldrValue
     , getAddress
+    , getCheckpointSlotNo
     , getDatum
     , getDelegationPartBytes
     , getOutputIndex
     , getPaymentPartBytes
-    , getPointSlotNo
     , getScript
     , getTransactionId
     , getValue
@@ -94,7 +96,7 @@ import Kupo.Data.Cardano
     , transactionIdToJson
     , transactionIdToText
     , transactionIndexToJson
-    , unsafeGetPointHeaderHash
+    , unsafeGetCheckpointHeaderHash
     , valueToJson
     )
 import Kupo.Data.Http.QuantityEncoding
@@ -438,8 +440,8 @@ data Result = Result
     , value :: !Value
     , datum :: !Datum
     , scriptReference :: !ScriptReference
-    , createdAt :: !Point
-    , spentAt :: !(Maybe Point)
+    , createdAt :: !Checkpoint
+    , spentAt :: !(Maybe Checkpoint)
     , spentBy :: !(Maybe OutputReference)
     , spentWith :: !(Maybe BinaryData)
     } deriving (Show, Eq)
@@ -477,20 +479,24 @@ resultToJson referenceFlag quantityEncoding Result{..} = Json.pairs $ mconcat
     , Json.pair "created_at"
         (Json.pairs $ mconcat
             [ Json.pair "slot_no"
-                (slotNoToJson (getPointSlotNo createdAt))
+                (slotNoToJson (getCheckpointSlotNo createdAt))
             , Json.pair "header_hash"
-                (headerHashToJson (unsafeGetPointHeaderHash createdAt))
+                (headerHashToJson (unsafeGetCheckpointHeaderHash createdAt))
+            , Json.pair "block_no"
+                (blockNoToJson (checkpointBlockNo createdAt))
             ]
         )
     , Json.pair "spent_at"
         (case spentAt of
             Nothing -> Json.null_
-            Just point ->
+            Just checkpoint ->
                 Json.pairs $ mconcat
                     [ Json.pair "slot_no"
-                        (slotNoToJson (getPointSlotNo point))
+                        (slotNoToJson (getCheckpointSlotNo checkpoint))
                     , Json.pair "header_hash"
-                        (headerHashToJson (unsafeGetPointHeaderHash point))
+                        (headerHashToJson (unsafeGetCheckpointHeaderHash checkpoint))
+                    , Json.pair "block_no"
+                        (blockNoToJson (checkpointBlockNo checkpoint))
                     , Json.pair "transaction_id"
                         (maybe Json.null_ (transactionIdToJson . getTransactionId) spentBy)
                     , Json.pair "input_index"
@@ -568,10 +574,10 @@ matchBlock
     -> block
     -> Match result bin script policy
 matchBlock Codecs{..} patterns blk =
-    let pt = getPoint blk in foldBlock (fn pt) mempty blk
+    let pt = getCheckpoint blk in foldBlock (fn pt) mempty blk
   where
     fn
-        :: Point
+        :: Checkpoint
         -> TransactionIndex
         -> BlockBody block
         -> Match result bin script policy
@@ -583,7 +589,7 @@ matchBlock Codecs{..} patterns blk =
                 (fromMaybe mempty st, 0)
                 (spentInputs @block tx)
             )
-            (getTransactionId tx, getPointSlotNo pt)
+            (getTransactionId tx, getCheckpointSlotNo pt)
             consumed
 
         , produced =
@@ -614,7 +620,7 @@ matchBlock Codecs{..} patterns blk =
                 patterns
 
     match
-        :: Point
+        :: Checkpoint
         -> TransactionIndex
         -> Pattern
         -> OutputReference

--- a/test/Test/Kupo/App/Http/Client.hs
+++ b/test/Test/Kupo/App/Http/Client.hs
@@ -30,6 +30,8 @@ import Kupo.Control.MonadDelay
 import Kupo.Data.Cardano
     ( Address
     , BinaryData
+    , BlockNo (..)
+    , Checkpoint (..)
     , Datum (..)
     , DatumHash
     , ExtendedOutputReference
@@ -46,7 +48,7 @@ import Kupo.Data.Cardano
     , binaryDataFromBytes
     , datumHashFromBytes
     , datumHashToText
-    , getPointSlotNo
+    , getCheckpointSlotNo
     , metadataFromText
     , metadataHashFromText
     , mkOutputReference
@@ -127,9 +129,9 @@ data HttpClient (m :: Type -> Type) = HttpClient
     , lookupMetadataBySlotNo
         :: SlotNo -> Maybe TransactionId -> m [(MetadataHash, Metadata)]
     , listCheckpoints
-        :: m [Point]
+        :: m [Checkpoint]
     , getCheckpointBySlot
-        :: GetCheckpointMode -> SlotNo -> m (Maybe Point)
+        :: GetCheckpointMode -> SlotNo -> m (Maybe Checkpoint)
     , getAllMatches
         :: StatusFlag
         -> ReferenceFlag
@@ -211,24 +213,24 @@ newHttpClientWith manager (serverHost, serverPort) log =
                 log "waitSlot: no checkpoint"
                 threadDelay 0.05
                 _waitSlot predicate
-            (maximum . fmap getPointSlotNo -> sl) -> do
+            (maximum . fmap getCheckpointSlotNo -> sl) -> do
                 log $ "waitSlot (" <> slotNoToText sl <> "): " <> show (predicate sl)
                 unless (predicate sl) $ do
                     threadDelay 0.05
                     _waitSlot predicate
 
-    _listCheckpoints :: IO [Point]
+    _listCheckpoints :: IO [Checkpoint]
     _listCheckpoints = do
         req <- parseRequest (baseUrl <> "/checkpoints")
         res <- httpLbs req manager
         let body = responseBody res
-        case eitherDecodeJson (Json.listParser decodePoint) body of
+        case eitherDecodeJson (Json.listParser decodeCheckpoint) body of
             Left e ->
                 fail (show body <> " ----> " <> show e)
             Right xs ->
                 pure xs
 
-    _getCheckpointBySlot :: GetCheckpointMode -> SlotNo -> IO (Maybe Point)
+    _getCheckpointBySlot :: GetCheckpointMode -> SlotNo -> IO (Maybe Checkpoint)
     _getCheckpointBySlot mode (SlotNo slot) = do
         let qry = case mode of
                 GetCheckpointStrict -> "?strict"
@@ -236,7 +238,7 @@ newHttpClientWith manager (serverHost, serverPort) log =
         req <- parseRequest (baseUrl <> "/checkpoints/" <> show slot <> qry)
         res <- httpLbs req manager
         let body = responseBody res
-        pure $ either (const Nothing) Just (eitherDecodeJson decodePoint body)
+        pure $ either (const Nothing) Just (eitherDecodeJson decodeCheckpoint body)
 
     _getAllMatches :: StatusFlag -> ReferenceFlag -> IO [Result]
     _getAllMatches st ref = do
@@ -387,6 +389,16 @@ newHttpClientWith manager (serverHost, serverPort) log =
 -- Decoders
 --
 
+decodeCheckpoint :: Json.Value -> Json.Parser Checkpoint
+decodeCheckpoint =
+    Json.withObject "Checkpoint" $ \o -> do
+        point <- decodePoint (Json.Object o)
+        blockNo <- o .: "block_no"
+        pure $ Checkpoint
+            { checkpointPoint = point
+            , checkpointBlockNo = BlockNo blockNo
+            }
+
 decodeHealth :: Json.Value -> Json.Parser Health
 decodeHealth = Json.withObject "Health" $ \o -> do
     connectionStatus <- o .: "connection_status" >>= decodeConnectionStatus
@@ -398,7 +410,7 @@ decodeHealth = Json.withObject "Health" $ \o -> do
         , mostRecentNodeTip = Just (SlotNo mostRecentNodeTip)
         -- NOTE: We only have the point's slot number here. No test should rely on that.
         , mostRecentClockTick = Nothing
-        , mostRecentCheckpoint = Nothing
+        , mostRecentPoint = Nothing
         }
   where
     decodeConnectionStatus = Json.withText "ConnectionStatus" $ \case
@@ -591,8 +603,8 @@ decodeResult = Json.withObject "Result" $ \o -> Result
     <*> (decodeValue =<< (o .: "value"))
     <*> join (liftA3 decodeDatum (o .:? "datum_type") (o .:? "datum_hash") (o .:? "datum"))
     <*> join (liftA2 decodeScriptReference (o .:? "script_hash") (o .:? "script"))
-    <*> (decodePoint =<< (o .: "created_at"))
-    <*> (traverse decodePoint =<< (o .:? "spent_at"))
+    <*> (decodeCheckpoint =<< (o .: "created_at"))
+    <*> (traverse decodeCheckpoint =<< (o .:? "spent_at"))
     <*> (traverse decodeInputReference =<< (o .:? "spent_at"))
     <*> (do
             spentAt <- o .:? "spent_at"

--- a/test/Test/Kupo/App/HttpSpec.hs
+++ b/test/Test/Kupo/App/HttpSpec.hs
@@ -52,7 +52,8 @@ import Kupo.Control.MonadSTM
     ( MonadSTM (..)
     )
 import Kupo.Data.Cardano
-    ( SlotNo (..)
+    ( Checkpoint (..)
+    , SlotNo (..)
     , getPointSlotNo
     , pattern BlockPoint
     , unsafeHeaderHashFromBytes
@@ -105,9 +106,9 @@ import Test.Hspec.QuickCheck
     )
 import Test.Kupo.Data.Generators
     ( genBinaryData
+    , genCheckpoint
     , genHeaderHash
     , genMetadata
-    , genNonGenesisPoint
     , genOutputReference
     , genPattern
     , genPolicyId
@@ -115,6 +116,7 @@ import Test.Kupo.Data.Generators
     , genScript
     , genTransactionId
     , generateWith
+    , mkCheckpointFromPoint
     )
 import Test.Kupo.Data.Pattern.Fixture
     ( patterns
@@ -527,7 +529,7 @@ newStubbedApplication defaultPatterns = do
                 reply Nothing
             else do
                 reply $ Just $ generateWith 42 $ do
-                    blockPoint <- genNonGenesisPoint
+                    Checkpoint { checkpointBlockNo, checkpointPoint } <- genCheckpoint
                     blockBody <- vectorOf 10 $ do
                         id <- genTransactionId
                         metadata <- oneof [pure Nothing, Just <$> genMetadata]
@@ -540,7 +542,11 @@ newStubbedApplication defaultPatterns = do
                             , spendRedeemers = mempty
                             , metadata
                             }
-                    pure $ PartialBlock { blockPoint, blockBody }
+                    pure $ PartialBlock
+                        { blockPoint = checkpointPoint
+                        , blockBody
+                        , blockNo = checkpointBlockNo
+                        }
         )
         patternsVar
         healthStub
@@ -549,7 +555,7 @@ healthStub :: IO Health
 healthStub =
     pure $ Health
         { connectionStatus = Connected
-        , mostRecentCheckpoint = Just $ BlockPoint 42 (generateWith 42 genHeaderHash)
+        , mostRecentPoint = Just $ BlockPoint 42 (generateWith 42 genHeaderHash)
         , mostRecentNodeTip = Just 42
         , mostRecentClockTick = Nothing
         , configuration = Just InstallIndexesIfNotExist
@@ -586,16 +592,16 @@ databaseStub = Database
     , insertCheckpoints =
         \_ -> return ()
     , listCheckpointsDesc = lift $ do
-        generate (listOf1 genNonGenesisPoint)
+        generate (listOf1 genCheckpoint)
     , listAncestorsDesc = \sl n -> lift $ do
         case n of
             1 -> do
                 let headerHash = unsafeHeaderHashFromBytes $ unsafeDecodeBase16
                         "0000000000000000000000000000000000000000000000000000000000000000"
-                let point = BlockPoint (prev sl) headerHash
-                pure [point]
+                let checkpoint = mkCheckpointFromPoint $ BlockPoint (prev sl) headerHash
+                pure [checkpoint]
             _otherwise -> do
-                generate (listOf1 genNonGenesisPoint)
+                generate (listOf1 genCheckpoint)
     , insertPatterns =
         \_ -> return ()
     , deletePattern =

--- a/test/Test/Kupo/AppSpec.hs
+++ b/test/Test/Kupo/AppSpec.hs
@@ -66,9 +66,11 @@ import Kupo.Control.MonadThrow
 import Kupo.Control.MonadTime
     ( DiffTime
     )
+import qualified Kupo.Data.Cardano as Data
 import Kupo.Data.Cardano
     ( BinaryData
     , BlockNo (..)
+    , Checkpoint (checkpointPoint)
     , DatumHash
     , Input
     , Metadata
@@ -174,6 +176,8 @@ import Test.Kupo.Data.Generators
     , genScriptHash
     , genTransactionId
     , generateWith
+    , mkBlockNoFromSlotNo
+    , mkCheckpointFromPoint
     )
 import Test.QuickCheck
     ( Gen
@@ -373,7 +377,7 @@ instance Show (Event r) where
 
 data Response (r :: Type -> Type)
     = Unit !()
-    | Checkpoint !(Maybe Point)
+    | Checkpoint !(Maybe Data.Checkpoint)
     | Utxo !(Set OutputReference)
     | DatumByHash !(Maybe BinaryData)
     | ScriptByHash !(Maybe Script)
@@ -385,8 +389,8 @@ instance Show (Response r) where
     show = \case
         Unit () ->
             "()"
-        Checkpoint pt ->
-            toString $ "(Checkpoint " <> maybe "NULL" showPoint pt <> ")"
+        Checkpoint cp ->
+            toString $ "(Checkpoint " <> maybe "NULL" showCheckpoint cp <> ")"
         Utxo outRefs ->
             toString $ "(Utxo " <> T.intercalate "," (showOutputReference <$> Set.toList outRefs) <> ")"
         DatumByHash bin ->
@@ -735,7 +739,7 @@ genContinuingBlock utxo txs previousTip = do
     blockPoint <- BlockPoint (next (getPointSlotNo previousTip)) <$> genHeaderHash
     (txs', utxo') <- runStateT (genTransactionSublist txs) utxo
     blockBody <- (txs' <>) <$> evalStateT genPartialTransactions utxo'
-    pure PartialBlock { blockPoint, blockBody }
+    pure PartialBlock { blockPoint, blockBody, blockNo = mkBlockNoFromSlotNo (getPointSlotNo blockPoint) }
 
 -- | Generate a list of transactions using and modifying a given utxo. The
 -- generation stops when there's no more utxos or, arbitrarily (1 chance out of
@@ -873,21 +877,21 @@ semantics
     -> IO (Response Concrete)
 semantics pause HttpClient{..} chan = \case
     DoRollForward tip block -> do
-        cp <- getMostRecentCheckpoint
+        cp <- getMostRecentPoint
         atomically $ writeTChan chan (Right $ RollForward tip block)
         fmap Unit $ waitUntilM $ do
-            cp' <- getMostRecentCheckpoint
+            cp' <- getMostRecentPoint
             pure (cp' > cp)
     DoRollBackward tip point -> do
-        cp <- getMostRecentCheckpoint
+        cp <- getMostRecentPoint
         atomically $ writeTChan chan (Right $ RollBackward tip point)
         fmap Unit $ waitUntilM $ do
-            cp' <- getMostRecentCheckpoint
+            cp' <- getMostRecentPoint
             pure (cp' < cp)
     LoseConnection ->
         Unit <$> atomically (writeTChan chan (Left ConnectionClosed))
     GetMostRecentCheckpoint -> do
-        Checkpoint . Just <$> getMostRecentCheckpoint
+        Checkpoint <$> getMostRecentCheckpoint
     GetPreviousCheckpoint sl -> do
         Checkpoint <$> getCheckpointBySlot GetCheckpointClosestAncestor sl
     GetUtxo -> do
@@ -901,10 +905,14 @@ semantics pause HttpClient{..} chan = \case
     Pause -> do
         Unit <$> threadDelay pause
   where
+    getMostRecentCheckpoint :: IO (Maybe Data.Checkpoint)
     getMostRecentCheckpoint =
         listCheckpoints <&> \case
-            [] -> GenesisPoint
-            h:_ -> h
+            [] -> Nothing
+            h:_ -> Just h
+
+    getMostRecentPoint :: IO Point
+    getMostRecentPoint = maybe GenesisPoint checkpointPoint <$> getMostRecentCheckpoint
 
 -- | Here we mock the server behavior using our model; this is used within the
 -- generator itself, to advance the state-machine. Because the model is our
@@ -922,15 +930,18 @@ mock model = \case
         pure (Unit ())
     GetMostRecentCheckpoint ->
         pure $ Checkpoint $ case currentChain model of
-            []  -> Just GenesisPoint
-            h:_ -> Just (blockPoint h)
+            []  -> Nothing
+            h:_ -> do
+                let
+                    point = blockPoint h
+                Just $ mkCheckpointFromPoint point
     GetPreviousCheckpoint sl ->
         let
             search = \case
                 [] -> Nothing
                 (blockPoint -> h):rest ->
                     if getPointSlotNo h <= sl
-                    then Just h
+                    then Just $ mkCheckpointFromPoint h
                     else search rest
          in
             pure $ Checkpoint $ search (currentChain model)
@@ -982,7 +993,7 @@ newMockProducer HttpClient{..} chan callback = do
                         pure (Left e)
                 either
                     (\e -> do
-                        atomically . writeTVar lastKnownTipVar =<< getMostRecentCheckpoint
+                        atomically . writeTVar lastKnownTipVar =<< getMostRecentPoint
                         throwIO e
                     )
                     return
@@ -993,10 +1004,10 @@ newMockProducer HttpClient{..} chan callback = do
     forcedRollbackCallback _point _handler =
         fail "Mock producer cannot force rollback."
 
-    getMostRecentCheckpoint =
+    getMostRecentPoint =
         listCheckpoints <&> \case
             [] -> GenesisPoint
-            h:_ -> h
+            h:_ -> checkpointPoint h
 
 -- | Mock a request to the node which returns the block immediately following the given point.
 newMockFetchBlock
@@ -1029,6 +1040,9 @@ newMockFetchBlock chan callback =
 showPoint :: Point -> Text
 showPoint =
     showSlotNo . getPointSlotNo
+
+showCheckpoint :: Data.Checkpoint -> Text
+showCheckpoint (Data.Checkpoint { checkpointPoint }) = showPoint checkpointPoint
 
 showTip :: Tip -> Text
 showTip =

--- a/test/Test/Kupo/Data/DatabaseSpec.hs
+++ b/test/Test/Kupo/Data/DatabaseSpec.hs
@@ -69,14 +69,14 @@ import Kupo.Control.MonadTime
     )
 import Kupo.Data.Cardano
     ( Address
+    , Checkpoint
     , Output
-    , Point
     , PolicyId
     , SlotNo (..)
     , foldrValue
     , getAddress
+    , getCheckpointSlotNo
     , getOutputIndex
-    , getPointSlotNo
     , getValue
     , policyIdToBytes
     , slotNoToText
@@ -91,6 +91,8 @@ import Kupo.Data.Database
     ( SortDirection (..)
     , addressFromRow
     , addressToRow
+    , checkpointFromRow
+    , checkpointToRow
     , datumFromRow
     , datumToRow
     , extendedOutputReferenceFromRow
@@ -99,8 +101,6 @@ import Kupo.Data.Database
     , patternFromRow
     , patternToRow
     , patternToSql
-    , pointFromRow
-    , pointToRow
     , resultFromRow
     , resultToRow
     , scriptReferenceFromRow
@@ -140,13 +140,13 @@ import Test.Kupo.Data.Generators
     ( chooseVector
     , genAddress
     , genBytes
+    , genCheckpoint
+    , genCheckpointBetween
+    , genCheckpointsBetween
     , genDatum
     , genExtendedOutputReference
-    , genNonGenesisPoint
-    , genNonGenesisPointBetween
     , genOutputReference
     , genPattern
-    , genPointsBetween
     , genPolicyId
     , genQueryablePattern
     , genResult
@@ -202,7 +202,7 @@ spec = parallel $ do
         prop "Result" $
             roundtripFromToRow genResult resultToRow resultFromRow
         prop "Checkpoint" $
-            roundtripFromToRow genNonGenesisPoint pointToRow pointFromRow
+            roundtripFromToRow genCheckpoint checkpointToRow checkpointFromRow
         prop "Pattern" $
             roundtripFromToRow genPattern patternToRow patternFromRow
         prop "OutputReference" $
@@ -231,27 +231,27 @@ spec = parallel $ do
             forAllCheckpoints k $ \pts -> monadicIO $ do
                 cps <- withInMemoryDatabase k $ \Database{..} -> do
                     runTransaction $ insertCheckpoints pts
-                    runTransaction $ fmap getPointSlotNo <$> listCheckpointsDesc
+                    runTransaction $ fmap getCheckpointSlotNo <$> listCheckpointsDesc
                 monitor $ counterexample (show cps)
                 assert $ all (uncurry (>)) (zip cps (drop 1 cps))
-                assert $ Prelude.head cps == maximum (getPointSlotNo <$> pts)
+                assert $ Prelude.head cps == maximum (getCheckpointSlotNo <$> pts)
 
         prop "get ancestor of any checkpoint" $
             forAllCheckpoints k $ \pts -> monadicIO $ do
                 oneByOne <- withInMemoryDatabase k $ \Database{..} -> do
                     runTransaction $ insertCheckpoints pts
                     fmap mconcat $ runTransaction $ forM pts $ \pt -> do
-                        listAncestorsDesc (getPointSlotNo pt) 1
+                        listAncestorsDesc (getCheckpointSlotNo pt) 1
 
                 allAtOnce <- withInMemoryDatabase k $ \Database{..} -> do
                     runTransaction $ insertCheckpoints pts
                     fmap reverse $ runTransaction $ do
-                        let slotNo = maximum (getPointSlotNo <$> pts)
+                        let slotNo = maximum (getCheckpointSlotNo <$> pts)
                         listAncestorsDesc slotNo (fromIntegral $ length pts)
 
                 monitor $ counterexample $ toString $ unlines
-                    [ "one-by-one:  " <> show (getPointSlotNo <$> oneByOne)
-                    , "all-at-once: " <> show (getPointSlotNo <$> allAtOnce)
+                    [ "one-by-one:  " <> show (getCheckpointSlotNo <$> oneByOne)
+                    , "all-at-once: " <> show (getCheckpointSlotNo <$> allAtOnce)
                     ]
 
                 assert (Prelude.init pts == oneByOne)
@@ -259,7 +259,7 @@ spec = parallel $ do
 
     context "matches" $ do
         prop "return matches in order" $ do
-            let slot = getPointSlotNo . createdAt
+            let slot = getCheckpointSlotNo . createdAt
             let txIx = snd . outputReference
             let outIx = getOutputIndex . fst . outputReference
 
@@ -282,7 +282,7 @@ spec = parallel $ do
                         property (slot current > slot successor)
 
             let genConflictingResults =
-                    scale (10*) $ listOf1 $ genResultWith (genNonGenesisPointBetween (1, 100))
+                    scale (10*) $ listOf1 $ genResultWith (genCheckpointBetween (1, 100))
 
             let shrinkResults =
                     shrinkList (const [])
@@ -1589,9 +1589,9 @@ withInMemoryDatabase' runInIO deferIndexes k action = do
 forAllCheckpoints
     :: Testable prop
     => Word64
-    -> ([Point] -> prop)
+    -> ([Checkpoint] -> prop)
     -> Property
 forAllCheckpoints k =
     forAllShow
-        (genPointsBetween (0, SlotNo (10 * k)))
-        (show . fmap getPointSlotNo)
+        (genCheckpointsBetween (0, SlotNo (10 * k)))
+        (show . fmap getCheckpointSlotNo)

--- a/test/Test/Kupo/Data/Generators.hs
+++ b/test/Test/Kupo/Data/Generators.hs
@@ -20,6 +20,8 @@ import Kupo.Data.Cardano
     , AssetId
     , BinaryData
     , Block
+    , BlockNo (..)
+    , Checkpoint (..)
     , Datum (..)
     , DatumHash
     , ExtendedOutputReference
@@ -40,6 +42,7 @@ import Kupo.Data.Cardano
     , TransactionIndex
     , Value
     , assetNameMaxLength
+    , getPointSlotNo
     , hashMetadata
     , mkMetadata
     , mkOutput
@@ -221,6 +224,20 @@ genNonGenesisPoint :: Gen Point
 genNonGenesisPoint = do
     BlockPoint <$> genSlotNo <*> genHeaderHash
 
+mkBlockNoFromSlotNo :: SlotNo -> BlockNo
+mkBlockNoFromSlotNo (SlotNo slotNo) = BlockNo slotNo
+
+-- Use for non genesis points.
+-- For genesis point creates a nonsensical block number `0`
+mkCheckpointFromPoint :: Point -> Checkpoint
+mkCheckpointFromPoint pt = do
+    let
+        slotNo = getPointSlotNo pt
+    Checkpoint pt (mkBlockNoFromSlotNo slotNo)
+
+genCheckpoint :: Gen Checkpoint
+genCheckpoint = mkCheckpointFromPoint <$> genNonGenesisPoint
+
 genNonGenesisPointBetween :: (SlotNo, SlotNo) -> Gen Point
 genNonGenesisPointBetween (SlotNo minSlot, SlotNo maxSlot) =
     BlockPoint <$> fmap SlotNo (choose (minSlot, maxSlot)) <*> genHeaderHash
@@ -236,6 +253,15 @@ genPointsBetween (inf, sup)
             ]
         pt <- BlockPoint slotNo <$> genHeaderHash
         (pt :) <$> genPointsBetween (slotNo, sup)
+
+genCheckpointsBetween :: (SlotNo, SlotNo) -> Gen [Checkpoint]
+genCheckpointsBetween (inf, sup) =
+    map mkCheckpointFromPoint <$> genPointsBetween (inf, sup)
+
+genCheckpointBetween :: (SlotNo, SlotNo) -> Gen Checkpoint
+genCheckpointBetween (inf, sup) = do
+    pt <- genNonGenesisPointBetween (inf, sup)
+    pure $ mkCheckpointFromPoint pt
 
 genOutputIndex :: Gen OutputIndex
 genOutputIndex =
@@ -274,21 +300,20 @@ genQueryablePattern =
         _ -> True
     )
 
-genResult :: Gen Result
-genResult =
-    genResultWith genNonGenesisPoint
-
-genResultWith :: Gen Point -> Gen Result
-genResultWith genPoint = Result
+genResultWith :: Gen Checkpoint -> Gen Result
+genResultWith genCheckpoint' = Result
     <$> genExtendedOutputReference
     <*> genAddress
     <*> genOutputValue
     <*> genDatum
     <*> genScriptReference
-    <*> genPoint
-    <*> frequency [(1, pure Nothing), (5, Just <$> genPoint)]
+    <*> genCheckpoint'
+    <*> frequency [(1, pure Nothing), (5, Just <$> genCheckpoint')]
     <*> frequency [(1, pure Nothing), (5, Just <$> genOutputReference)]
     <*> frequency [(1, pure Nothing), (5, Just <$> genBinaryData)]
+
+genResult :: Gen Result
+genResult = genResultWith genCheckpoint
 
 genOutput :: Gen Output
 genOutput = mkOutput

--- a/test/Test/Kupo/Fixture.hs
+++ b/test/Test/Kupo/Fixture.hs
@@ -34,9 +34,11 @@ import Kupo.Data.Cardano
     , unsafeScriptHashFromBytes
     , unsafeTransactionIdFromBytes
     )
+import qualified Kupo.Data.Database as DB
 import Kupo.Data.Database
-    ( Checkpoint (..)
-    , pointFromRow
+    ( pointFromRow
+    , pointHeaderHash
+    , pointSlotNo
     )
 
 eraBoundaries :: [(String, Point)]
@@ -51,93 +53,93 @@ eraBoundaries =
 
 -- | Last point of the Byron era
 lastByronPoint :: Point
-lastByronPoint = pointFromRow $ Checkpoint
-    { checkpointSlotNo =
+lastByronPoint = pointFromRow $ DB.Point
+    { pointSlotNo =
         84242
-    , checkpointHeaderHash = unsafeDecodeBase16
+    , pointHeaderHash = unsafeDecodeBase16
         "45899e8002b27df291e09188bfe3aeb5397ac03546a7d0ead93aa2500860f1af"
     }
 
 -- | Last point of the Shelley era
 lastShelleyPoint :: Point
-lastShelleyPoint = pointFromRow $ Checkpoint
-    { checkpointSlotNo =
+lastShelleyPoint = pointFromRow $ DB.Point
+    { pointSlotNo =
         518360
-    , checkpointHeaderHash = unsafeDecodeBase16
+    , pointHeaderHash = unsafeDecodeBase16
         "f9d8b6c77fedd60c3caf5de0ce63a0aeb9d1753269c9c07503d9aa09d5144481"
     }
 
 -- | Last point of the Allegra era
 lastAllegraPoint :: Point
-lastAllegraPoint = pointFromRow $ Checkpoint
-    { checkpointSlotNo =
+lastAllegraPoint = pointFromRow $ DB.Point
+    { pointSlotNo =
         950340
-    , checkpointHeaderHash = unsafeDecodeBase16
+    , pointHeaderHash = unsafeDecodeBase16
         "74c03af754bcde9cd242c5a168689edcab1756a3f7ae4d5dca1a31d86839c7b1"
     }
 
 -- | Last point of the Mary era
 lastMaryPoint :: Point
-lastMaryPoint = pointFromRow $ Checkpoint
-    { checkpointSlotNo =
+lastMaryPoint = pointFromRow $ DB.Point
+    { pointSlotNo =
         1382348
-    , checkpointHeaderHash = unsafeDecodeBase16
+    , pointHeaderHash = unsafeDecodeBase16
         "af5fddc7d16a349e1a2af8ba89f4f5d3273955a13095b3709ef6e3db576a0b33"
     }
 
 -- | Last point of the Alonzo era
 lastAlonzoPoint :: Point
-lastAlonzoPoint = pointFromRow $ Checkpoint
-    { checkpointSlotNo =
+lastAlonzoPoint = pointFromRow $ DB.Point
+    { pointSlotNo =
         3542390
-    , checkpointHeaderHash = unsafeDecodeBase16
+    , pointHeaderHash = unsafeDecodeBase16
         "f93e682d5b91a94d8660e748aef229c19cb285bfb9830db48941d6a78183d81f"
     }
 
 -- | Some point that actually doesn't exist on chain. Useful to test failures to find
 -- intersection.
 someNonExistingPoint :: Point
-someNonExistingPoint = pointFromRow $ Checkpoint
-    { checkpointSlotNo =
+someNonExistingPoint = pointFromRow $ DB.Point
+    { pointSlotNo =
         14141414
-    , checkpointHeaderHash = unsafeDecodeBase16
+    , pointHeaderHash = unsafeDecodeBase16
         "0000000000000000000000000000000000000000000000000000000000000000"
     }
 
 -- | A point that exists on-chain. There's nothing special about it other than, it exists.
 somePoint :: Point
-somePoint = pointFromRow $ Checkpoint
-    { checkpointSlotNo =
+somePoint = pointFromRow $ DB.Point
+    { pointSlotNo =
         11017324
-    , checkpointHeaderHash = unsafeDecodeBase16
+    , pointHeaderHash = unsafeDecodeBase16
         "195908564a66d713bd2b71a9b1f290be6853cb31085fe7371276a35a2f8f7e62"
     }
 
 -- | The direct ancestor of 'somePoint'.
 somePointAncestor :: Point
-somePointAncestor = pointFromRow $ Checkpoint
-    { checkpointSlotNo =
+somePointAncestor = pointFromRow $ DB.Point
+    { pointSlotNo =
         11017254
-    , checkpointHeaderHash = unsafeDecodeBase16
+    , pointHeaderHash = unsafeDecodeBase16
         "97349562d7dc20b95e81e3bc5d4c5aab6cb8fdfd6fc846fcea4bcb364dca7045"
     }
 
 -- | The direct successor of 'somePoint'.
 somePointSuccessor :: Point
-somePointSuccessor = pointFromRow $ Checkpoint
-    { checkpointSlotNo =
+somePointSuccessor = pointFromRow $ DB.Point
+    { pointSlotNo =
         11017333
-    , checkpointHeaderHash = unsafeDecodeBase16
+    , pointHeaderHash = unsafeDecodeBase16
         "28f9e744c21c5ebdcfe53e2f1dc2e996066fbc93faf8203c404b2bbd87a28306"
     }
 
 -- | Another point that exists on-chain that is different from 'somePoint' and is located MANY blocks
 -- after 'somePoint'.
 someOtherPoint :: Point
-someOtherPoint = pointFromRow $ Checkpoint
-    { checkpointSlotNo =
+someOtherPoint = pointFromRow $ DB.Point
+    { pointSlotNo =
         36492716
-    , checkpointHeaderHash = unsafeDecodeBase16
+    , pointHeaderHash = unsafeDecodeBase16
         "d51095ef5405d83e7a1c82b98d12b357ba6b95f070f684bb38ab47ef90b21688"
     }
 
@@ -172,10 +174,10 @@ someDatumInOutputHash = fromJust $ hashDatum $ Inline $ Right someDatumInOutput
 -- - 'somescriptInMetadata'
 -- - 'someScriptInOutput'
 somePointNearScripts :: Point
-somePointNearScripts = pointFromRow $ Checkpoint
-    { checkpointSlotNo =
+somePointNearScripts = pointFromRow $ DB.Point
+    { pointSlotNo =
         12123866
-    , checkpointHeaderHash = unsafeDecodeBase16
+    , pointHeaderHash = unsafeDecodeBase16
         "61220259a295f31c1b3d1e7ac0afab51801e96848f9e63c13c2094dff4618533"
     }
 
@@ -447,9 +449,9 @@ somePhase2FailedTransactionIdWithReturn = unsafeTransactionIdFromBytes $ unsafeD
 
 -- | An ancestor point near 'somePhase2FailedTransactionIdWithReturn'.
 somePointNearPhase2Failure :: Point
-somePointNearPhase2Failure = pointFromRow $ Checkpoint
-    { checkpointSlotNo =
+somePointNearPhase2Failure = pointFromRow $ DB.Point
+    { pointSlotNo =
         12912834
-    , checkpointHeaderHash = unsafeDecodeBase16
+    , pointHeaderHash = unsafeDecodeBase16
         "0f1df0ab66fb5fa4b12409ad4abde5d7509e134442ad0d5356160650a42540d6"
     }

--- a/test/Test/KupoSpec.hs
+++ b/test/Test/KupoSpec.hs
@@ -61,6 +61,8 @@ import Kupo.Control.MonadTime
 import Kupo.Data.Cardano
     ( Datum (..)
     , ScriptReference (..)
+    , checkpointPoint
+    , getCheckpointSlotNo
     , getPointSlotNo
     , hasPolicyId
     , mkOutputReference
@@ -224,7 +226,7 @@ spec = skippableContext "End-to-end" $ do
                 , deferIndexes = SkipNonEssentialIndexes
                 }
             runSpec env 5 $ do
-                cp <- maximum . (<> [0]) . fmap getPointSlotNo <$> listCheckpoints
+                cp <- maximum . (<> [0]) . fmap getCheckpointSlotNo <$> listCheckpoints
                 waitSlot (> (cp + 1_000))
                 healthCheck (serverHost cfg) (serverPort cfg)
 
@@ -300,16 +302,18 @@ spec = skippableContext "End-to-end" $ do
             }
         let slot = getPointSlotNo
         runSpec env 5 $ do
+            let
+                getPointBySlot mode slotNo = getCheckpointBySlot mode slotNo <&> fmap checkpointPoint
             waitSlot (> (getPointSlotNo somePointSuccessor))
-            getCheckpointBySlot GetCheckpointStrict (slot somePoint)
+            getPointBySlot GetCheckpointStrict (slot somePoint)
                 `shouldReturn` Just somePoint
-            getCheckpointBySlot GetCheckpointStrict (prev (slot somePoint))
+            getPointBySlot GetCheckpointStrict (prev (slot somePoint))
                 `shouldReturn` Nothing
-            getCheckpointBySlot GetCheckpointStrict (slot somePointSuccessor)
+            getPointBySlot GetCheckpointStrict (slot somePointSuccessor)
                 `shouldReturn` Just somePointSuccessor
-            getCheckpointBySlot GetCheckpointStrict  (prev (slot somePointSuccessor))
+            getPointBySlot GetCheckpointStrict  (prev (slot somePointSuccessor))
                 `shouldReturn` Nothing
-            getCheckpointBySlot GetCheckpointClosestAncestor (prev (slot somePointSuccessor))
+            getPointBySlot GetCheckpointClosestAncestor (prev (slot somePointSuccessor))
                 `shouldReturn` Just somePoint
 
     endToEnd "Retrieve datums associated with datum hashes" $ \(configure, runSpec, HttpClient{..}) -> do
@@ -371,9 +375,9 @@ spec = skippableContext "End-to-end" $ do
         runSpec env 10 $ do
             let maxSlot = getPointSlotNo lastByronPoint + 10_000
             waitSlot (>= maxSlot)
-            slot <- maximum . fmap getPointSlotNo <$> listCheckpoints
+            slot <- maximum . fmap getCheckpointSlotNo <$> listCheckpoints
             res <- putPatternSince (MatchDelegation someOtherStakeKey) (Left (maxSlot - 20_000))
-            slot' <- maximum . fmap getPointSlotNo <$> listCheckpoints
+            slot' <- maximum . fmap getCheckpointSlotNo <$> listCheckpoints
             res `shouldBe` False
             listPatterns `shouldReturn` [MatchAny OnlyShelley]
             slot' `shouldSatisfy` (>= slot)
@@ -386,11 +390,11 @@ spec = skippableContext "End-to-end" $ do
         runSpec env 5 $ do
             let maxSlot = getPointSlotNo lastByronPoint + 10_000
             waitSlot (>= maxSlot)
-            slot <- maximum . fmap getPointSlotNo <$> listCheckpoints
+            slot <- maximum . fmap getCheckpointSlotNo <$> listCheckpoints
             res <- putPatternSince
                 (MatchDelegation someOtherStakeKey)
                 (Right someNonExistingPoint)
-            slot' <- maximum . fmap getPointSlotNo <$> listCheckpoints
+            slot' <- maximum . fmap getCheckpointSlotNo <$> listCheckpoints
             res `shouldBe` False
             listPatterns `shouldReturn` [MatchAny OnlyShelley]
             slot' `shouldSatisfy` (>= slot)
@@ -454,8 +458,8 @@ spec = skippableContext "End-to-end" $ do
         runSpec env 5 $ do
             waitSlot httpClient (> (getPointSlotNo lastAlonzoPoint))
             withReplica cfg $ \replicaHttpClient -> do
-                mostRecentCheckpoint <- Prelude.head <$> listCheckpoints httpClient
-                waitSlot replicaHttpClient (>= (getPointSlotNo mostRecentCheckpoint))
+                mostRecentPoint <- Prelude.head <$> listCheckpoints httpClient
+                waitSlot replicaHttpClient (>= (getCheckpointSlotNo mostRecentPoint))
                 Health{connectionStatus, configuration} <- getHealth replicaHttpClient
                 connectionStatus `shouldBe` Connected
                 configuration `shouldBe` Nothing
@@ -472,11 +476,11 @@ spec = skippableContext "End-to-end" $ do
         runSpec env 30 $ do
             waitSlot (>= maxSlot)
             points <- listCheckpoints
-            forM_ points $ \point -> getPointSlotNo point `shouldSatisfy` (<= maxSlot)
+            forM_ points $ \point -> getCheckpointSlotNo point `shouldSatisfy` (<= maxSlot)
             -- Ensures that even if we let time pass, we're not synchronizing beyond --until
             threadDelay 1
             points' <- listCheckpoints
-            forM_ points' $ \point -> getPointSlotNo point `shouldSatisfy` (<= maxSlot)
+            forM_ points' $ \point -> getCheckpointSlotNo point `shouldSatisfy` (<= maxSlot)
 
 -- | Create an 'EndToEndContext' around each child specification item within that 'Spec' tree. The
 -- spec items are 'skippable' and only executed if the appropriate environment variables are present.


### PR DESCRIPTION
Some context:
* This is a draft opened to support related discussion: https://github.com/CardanoSolutions/kupo/discussions/213
* This PR was manually coded (no AI).
* Tests were executed against cardano-node using SQLite. PostgreSQL and Ogmios will be next if the overall change is approved.

Main changes:
* I introduced `Checkpoint` which is a ~`Checkpoint Point BlockNo`. I introduced that type on both Database and App levels.
* I added `block_no` to the `checkpoints` table.
* `Checkpoint` is used during insertions and during checkpoint and match related retrievals.
* `Point` is used in rollback handling and in queries.